### PR TITLE
Add developer documentation subdomain support

### DIFF
--- a/docs/developer-documentation-site.md
+++ b/docs/developer-documentation-site.md
@@ -1,0 +1,63 @@
+# Öffentliche Entwicklerdokumentation
+
+Die technische Dokumentation wird auf zwei Ebenen gepflegt:
+
+- `developer.stadtplaner.oklabflensburg.de` bietet einen kuratierten, navigierbaren Einstieg für Entwickler und Betreiber.
+- `docs/` im Repository bleibt die vollständige implementierungsnahe technische Source of Truth.
+
+## Warum eine eigene Subdomain?
+
+Die öffentliche Hilfe unter `stadtplaner.oklabflensburg.de/dokumentation` richtet sich an Nutzer des GIS. Technische Inhalte zu PostGIS, OSM-Synchronisation, Groq, CI, Performance und Deployment würden diese Navigation unnötig überladen. Die Subdomain trennt Zielgruppen, verwendet aber weiterhin dieselbe Nuxt-Anwendung und dasselbe Designsystem.
+
+## Routing
+
+Die Anwendung kennt weiterhin die internen Routen unter `/dokumentation/entwickler`. Eine globale Nuxt-Middleware ordnet die produktive Entwickler-Subdomain diesen Seiten zu. Auf der Hauptdomain wird ein Aufruf des Entwicklerpfads dauerhaft auf die kanonische Entwickler-Subdomain weitergeleitet.
+
+Lokale Entwicklung bleibt unter `/dokumentation/entwickler` möglich, weil die Host-Weiterleitung nur für die produktiven Hostnamen greift.
+
+## DNS und Reverse Proxy
+
+DNS und TLS werden außerhalb des Repositorys verwaltet. Für `developer.stadtplaner.oklabflensburg.de` muss ein DNS-Eintrag auf denselben Webserver zeigen. Der Reverse Proxy kann denselben Nuxt-Upstream wie die Hauptseite verwenden und muss den ursprünglichen `Host`-Header weiterreichen, damit die Nuxt-Middleware die Subdomain erkennt.
+
+Beispielhaft:
+
+```nginx
+server {
+    server_name developer.stadtplaner.oklabflensburg.de;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+```
+
+Dieses Beispiel ersetzt keine bestehende produktive TLS-, Security-Header- oder Proxy-Konfiguration.
+
+## Inhalt
+
+Die Entwicklerseite enthält kuratierte Einstiege zu:
+
+- Architektur
+- API und Backend
+- OpenStreetMap und GIS
+- kommunaler Statistik
+- intelligenter Suche und Assistant
+- CI und Tests
+- Deployment und Betrieb
+
+Spezialdokumente wie SQL-Explain-Dateien, Performance-Audits und tiefgehende Sync-/Recovery-Dokumente bleiben im Repository und werden von der Entwicklerseite aus verlinkt.
+
+## SEO
+
+Entwicklerseiten verwenden `https://developer.stadtplaner.oklabflensburg.de` als kanonische Origin. Die Hauptdomain soll für dieselben technischen Inhalte keine konkurrierenden Canonical-URLs erzeugen.
+
+## Sicherheit
+
+Die Entwicklerdokumentation ist öffentlich, enthält aber keine Secrets. Architektur, Frameworks und öffentliche API-Verträge dürfen beschrieben werden. Nicht veröffentlicht werden echte API-Keys, Datenbankpasswörter, Tokens, private Nutzer-/Eigentümerdaten oder vertrauliche Produktionskonfigurationen.
+
+## Betrieb
+
+Die zentrale Betriebsreferenz ist `docs/deployment.md`. DNS, TLS und die produktive Reverse-Proxy-Konfiguration sind serverseitige Voraussetzungen und können durch einen Repository-Commit allein nicht aktiviert werden.

--- a/frontend/app/components/docs/DeveloperDocsLayout.vue
+++ b/frontend/app/components/docs/DeveloperDocsLayout.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="min-h-screen bg-white">
+    <a href="#developer-docs-content" class="sr-only z-[100] rounded bg-white px-4 py-3 font-bold text-[#154d73] focus:not-sr-only focus:fixed focus:left-4 focus:top-20">Zum Entwicklerinhalt springen</a>
+
+    <div class="border-b border-slate-200 bg-slate-50/80">
+      <div class="mx-auto max-w-[1536px] px-4 py-6 sm:px-6 lg:px-8">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p class="text-xs font-bold uppercase tracking-[0.16em] text-[#4f86a8]">Open City Planner</p>
+            <h1 class="mt-1 text-2xl font-black text-slate-950">Entwicklerdokumentation</h1>
+            <p class="mt-1 max-w-3xl text-sm text-slate-600">Architektur, APIs, GIS, Datenimporte, intelligente Suche, Tests und Betrieb.</p>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <NuxtLink to="/dokumentation" class="inline-flex min-h-10 items-center rounded-lg border border-slate-300 bg-white px-3 text-sm font-bold text-slate-700 hover:bg-slate-50">Benutzerhandbuch</NuxtLink>
+            <a :href="projectConfig.github.url" class="inline-flex min-h-10 items-center rounded-lg bg-[#154d73] px-3 text-sm font-bold text-white hover:bg-[#103d5c]">GitHub Repository</a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mx-auto max-w-[1536px] px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mb-6 xl:hidden">
+        <button class="inline-flex min-h-11 items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 text-sm font-bold text-slate-800 hover:bg-slate-50" type="button" :aria-expanded="mobileNavigationOpen" aria-controls="developer-docs-mobile-navigation" @click="mobileNavigationOpen = !mobileNavigationOpen">
+          <Menu class="size-4" aria-hidden="true" /> Inhalte
+        </button>
+      </div>
+
+      <div v-if="mobileNavigationOpen" id="developer-docs-mobile-navigation" class="mb-6 rounded-xl border border-slate-200 bg-slate-50 p-4 xl:hidden">
+        <DeveloperDocsSidebar :active-slug="page.slug" @navigate="mobileNavigationOpen = false" />
+      </div>
+
+      <div class="grid gap-10 xl:grid-cols-[250px_minmax(0,1fr)_220px]">
+        <aside class="hidden xl:block">
+          <div class="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto pr-2">
+            <DeveloperDocsSidebar :active-slug="page.slug" />
+          </div>
+        </aside>
+
+        <article id="developer-docs-content" class="min-w-0 max-w-4xl">
+          <PageHeader :title="page.title" :description="page.description" :breadcrumbs="breadcrumbs" class="mb-10">
+            <template #badge><StatusBadge tone="info">Für Entwickler</StatusBadge></template>
+          </PageHeader>
+          <DocsContent :page="page" />
+
+          <nav class="mt-10 grid gap-3 border-t border-slate-200 pt-8 sm:grid-cols-2" aria-label="Weitere Entwicklerseiten">
+            <NuxtLink v-if="previous" :to="developerDocumentationPath(previous)" class="rounded-xl border border-slate-200 p-4 hover:border-[#4f86a8] hover:bg-slate-50">
+              <span class="text-xs font-bold uppercase tracking-wider text-slate-500">Zurück</span>
+              <span class="mt-1 flex items-center gap-2 font-bold text-[#154d73]"><ArrowLeft class="size-4" />{{ previous.navTitle }}</span>
+            </NuxtLink>
+            <span v-else />
+            <NuxtLink v-if="next" :to="developerDocumentationPath(next)" class="rounded-xl border border-slate-200 p-4 text-right hover:border-[#4f86a8] hover:bg-slate-50">
+              <span class="text-xs font-bold uppercase tracking-wider text-slate-500">Weiter</span>
+              <span class="mt-1 flex items-center justify-end gap-2 font-bold text-[#154d73]">{{ next.navTitle }}<ArrowRight class="size-4" /></span>
+            </NuxtLink>
+          </nav>
+        </article>
+
+        <aside class="hidden lg:block">
+          <div class="sticky top-24"><DocsTableOfContents :sections="page.sections" /></div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ArrowLeft, ArrowRight, Menu } from 'lucide-vue-next'
+import type { DocumentationPage } from '~/types/documentation'
+import { developerDocumentationPages } from '~/config/developerDocumentation'
+import { projectConfig } from '~/config/project'
+
+const props = defineProps<{ page: DocumentationPage }>()
+const mobileNavigationOpen = ref(false)
+const pageIndex = computed(() => developerDocumentationPages.findIndex(candidate => candidate.slug === props.page.slug))
+const previous = computed(() => pageIndex.value > 0 ? developerDocumentationPages[pageIndex.value - 1] : undefined)
+const next = computed(() => pageIndex.value >= 0 && pageIndex.value < developerDocumentationPages.length - 1 ? developerDocumentationPages[pageIndex.value + 1] : undefined)
+const breadcrumbs = computed(() => [
+  { label: 'Startseite', to: '/' },
+  { label: 'Dokumentation', to: '/dokumentation' },
+  ...(props.page.slug ? [{ label: 'Entwickler', to: '/dokumentation/entwickler' }, { label: props.page.title }] : [{ label: 'Entwickler' }])
+])
+
+function developerDocumentationPath(page: DocumentationPage) {
+  return page.slug ? `/dokumentation/entwickler/${page.slug}` : '/dokumentation/entwickler'
+}
+
+watch(() => props.page.slug, () => { mobileNavigationOpen.value = false })
+</script>

--- a/frontend/app/components/docs/DeveloperDocsSidebar.vue
+++ b/frontend/app/components/docs/DeveloperDocsSidebar.vue
@@ -1,0 +1,40 @@
+<template>
+  <nav aria-label="Entwicklerdokumentation" class="space-y-6">
+    <div v-for="group in groups" :key="group.label">
+      <h2 class="mb-2 text-xs font-black uppercase tracking-[0.14em] text-slate-500">{{ group.label }}</h2>
+      <ul class="space-y-1">
+        <li v-for="item in group.pages" :key="item.slug">
+          <NuxtLink
+            :to="pathFor(item.slug)"
+            class="block rounded-lg px-3 py-2 text-sm font-semibold transition-colors"
+            :class="item.slug === activeSlug ? 'bg-[#e8f1f6] text-[#154d73]' : 'text-slate-700 hover:bg-slate-100 hover:text-slate-950'"
+            @click="$emit('navigate')"
+          >
+            {{ item.navTitle }}
+          </NuxtLink>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { developerDocumentationPages } from '~/config/developerDocumentation'
+
+const props = defineProps<{ activeSlug: string }>()
+defineEmits<{ navigate: [] }>()
+
+const groups = computed(() => {
+  const values = new Map<string, typeof developerDocumentationPages>()
+  for (const page of developerDocumentationPages) {
+    const pages = values.get(page.group) || []
+    pages.push(page)
+    values.set(page.group, pages)
+  }
+  return Array.from(values, ([label, pages]) => ({ label, pages }))
+})
+
+function pathFor(slug: string) {
+  return slug ? `/dokumentation/entwickler/${slug}` : '/dokumentation/entwickler'
+}
+</script>

--- a/frontend/app/composables/useDeveloperDocumentationSeo.ts
+++ b/frontend/app/composables/useDeveloperDocumentationSeo.ts
@@ -1,0 +1,24 @@
+import type { DocumentationPage } from '~/types/documentation'
+import { projectConfig } from '~/config/project'
+import { buildBreadcrumbStructuredData, buildWebPageStructuredData } from '~/utils/seo'
+
+export function useDeveloperDocumentationSeo(page: DocumentationPage) {
+  const path = page.slug ? `/${page.slug}` : '/'
+  const breadcrumbs = [
+    { name: 'Entwicklerdokumentation', path: '/' },
+    ...(page.slug ? [{ name: page.title, path }] : [])
+  ]
+
+  usePageSeo({
+    title: `${page.title} · Entwicklerdokumentation`,
+    description: page.description,
+    path,
+    type: 'article',
+    robots: 'index,follow',
+    siteUrl: projectConfig.documentation.developerUrl,
+    structuredData: [
+      buildBreadcrumbStructuredData(projectConfig.documentation.developerUrl, breadcrumbs),
+      buildWebPageStructuredData(projectConfig.documentation.developerUrl, path, page.title, page.description)
+    ]
+  })
+}

--- a/frontend/app/composables/usePageSeo.ts
+++ b/frontend/app/composables/usePageSeo.ts
@@ -6,6 +6,7 @@ export interface PageSeoOptions {
   title: string
   description: string
   path?: string
+  siteUrl?: string
   image?: string | null
   imageAlt?: string | null
   type?: 'website' | 'article'
@@ -18,7 +19,7 @@ export interface PageSeoOptions {
 export function usePageSeo(options: PageSeoOptions) {
   const config = useRuntimeConfig()
   const siteName = config.public.siteName
-  const siteUrl = config.public.siteUrl
+  const siteUrl = options.siteUrl || config.public.siteUrl
   const title = options.title === siteName ? siteName : `${options.title} – ${siteName}`
   const canonical = buildAbsoluteUrl(siteUrl, options.path || '/')
   const image = options.image === null

--- a/frontend/app/config/developerDocumentation.ts
+++ b/frontend/app/config/developerDocumentation.ts
@@ -1,0 +1,192 @@
+import type { DocumentationPage } from '~/types/documentation'
+import { projectConfig } from '~/config/project'
+
+const repo = projectConfig.github.url
+const doc = (path: string) => `${repo}/blob/main/${path}`
+
+export const developerDocumentationPages: DocumentationPage[] = [
+  {
+    slug: '',
+    title: 'Entwicklerdokumentation',
+    navTitle: 'Übersicht',
+    description: 'Technischer Einstieg in Architektur, APIs, GIS-Daten, Suche, Tests und Betrieb des Open City Planner.',
+    group: 'Entwicklung',
+    keywords: ['Entwickler', 'Architektur', 'Open Source', 'Nuxt', 'FastAPI', 'PostGIS'],
+    audience: 'public',
+    sections: [
+      {
+        id: 'architektur',
+        title: 'Technischer Überblick',
+        blocks: [
+          { type: 'paragraph', text: 'Der Open City Planner besteht aus einem Nuxt-Frontend, einem FastAPI-Backend und PostgreSQL/PostGIS als fachlicher Datenbank. Redis kann öffentliche Lesezugriffe cachen. OpenStreetMap-, Statistik- und Stadtplaner-Daten werden über klar getrennte Services und öffentliche API-Verträge zusammengeführt.' },
+          { type: 'links', items: [
+            { label: 'Architektur', to: '/dokumentation/entwickler/architektur', description: 'Frontend, Backend, Datenbank und Datenflüsse.' },
+            { label: 'API', to: '/dokumentation/entwickler/api', description: 'Öffentliche Ressourcen und OpenAPI.' },
+            { label: 'OpenStreetMap', to: '/dokumentation/entwickler/osm', description: 'Import, Mapping, Gebäude, POIs und Synchronisation.' },
+            { label: 'Kommunale Statistik', to: '/dokumentation/entwickler/statistik', description: 'Import, Gebietsbezug und Zeitreihen.' },
+            { label: 'Intelligente Suche', to: '/dokumentation/entwickler/assistant', description: 'SearchPlan, Assistant, Groq und read-only Tools.' },
+            { label: 'CI und Tests', to: '/dokumentation/entwickler/ci', description: 'Qualitätschecks und E2E-Tests.' },
+            { label: 'Deployment und Betrieb', to: '/dokumentation/entwickler/deployment', description: 'Produktionsbetrieb und zentrale Betriebsreferenz.' }
+          ] }
+        ]
+      },
+      {
+        id: 'source-of-truth',
+        title: 'Technische Source of Truth',
+        blocks: [
+          { type: 'paragraph', text: 'Diese Website bietet einen kuratierten technischen Einstieg. Implementierungsnahe Spezialfälle, Performance-Analysen, SQL-Explain-Artefakte und ausführliche Betriebsanleitungen bleiben im Repository unter docs/ die vollständige technische Referenz.' },
+          { type: 'links', items: [
+            { label: 'Repository', to: repo, description: 'Quellcode des Open City Planner.', provider: 'github' },
+            { label: 'Technische Dokumente', to: `${repo}/tree/main/docs`, description: 'Vollständige Referenz unter docs/.', provider: 'github' },
+            { label: 'Beitragen', to: projectConfig.github.contributingUrl, description: 'Contribution-Workflow und lokale Qualitätschecks.', provider: 'github' }
+          ] }
+        ]
+      }
+    ]
+  },
+  {
+    slug: 'architektur',
+    title: 'Architektur',
+    navTitle: 'Architektur',
+    description: 'Aufbau des Open City Planner und Trennung von Frontend, Backend, Language Plane und GIS Data Plane.',
+    group: 'Entwicklung',
+    keywords: ['Architektur', 'Nuxt', 'FastAPI', 'PostGIS', 'Redis', 'MapLibre'],
+    audience: 'public',
+    sections: [
+      { id: 'komponenten', title: 'Kernkomponenten', blocks: [
+        { type: 'table', headers: ['Komponente', 'Aufgabe'], rows: [
+          ['Nuxt-Frontend', 'Karte, Filter, Analyse, Dokumentation und Assistant-Oberfläche'],
+          ['FastAPI-Backend', 'Öffentliche API, Authentifizierung, Fachservices, Imports und Assistant-Orchestrierung'],
+          ['PostgreSQL/PostGIS', 'Fachliche Hauptdatenbank und räumliche Abfragen'],
+          ['MapLibre', 'Interaktive GIS-Darstellung im Browser'],
+          ['Redis', 'Optionaler Read-Cache; nicht fachliche Source of Truth']
+        ] },
+        { type: 'links', items: [
+          { label: 'Frontend Design', to: doc('docs/frontend-design.md'), provider: 'github' },
+          { label: 'Map Layer Order', to: doc('docs/map-layer-order.md'), provider: 'github' },
+          { label: 'Map Performance', to: doc('docs/map-performance.md'), provider: 'github' }
+        ] }
+      ] },
+      { id: 'datenfluss', title: 'Daten- und Sprachschicht', blocks: [
+        { type: 'paragraph', text: 'GIS-Ergebnisse werden in PostGIS und den vorhandenen Stadtplaner-Services erzeugt. Das Sprachmodell ist keine Datenquelle und erhält keinen freien SQL-Zugriff. Große GeoJSON-Ergebnisse sollen direkt vom Backend an die Karte gelangen und nicht durch das Sprachmodell geleitet werden.' }
+      ] }
+    ]
+  },
+  {
+    slug: 'api',
+    title: 'API und Backend',
+    navTitle: 'API',
+    description: 'FastAPI, OpenAPI und die wichtigsten öffentlichen Ressourcen des Stadtplaners.',
+    group: 'Entwicklung',
+    keywords: ['API', 'FastAPI', 'OpenAPI', 'ReDoc', 'REST'],
+    audience: 'public',
+    sections: [
+      { id: 'ressourcen', title: 'Öffentliche Ressourcen', blocks: [
+        { type: 'list', items: ['Analysegebiete und GeoJSON', 'Analytics und Gebietsvergleiche', 'Kommunale Statistik und Zeitreihen', 'Öffentliche Stadtplaner-Flächen', 'OpenStreetMap-Features und Details', 'Read-only Assistant und intelligente Suche'] },
+        { type: 'paragraph', text: 'Die aktuelle OpenAPI des laufenden Backends ist die maßgebliche Endpoint-Referenz. Entwicklerdokumentation sollte deshalb fachliche Ressourcen erklären, aber keine zweite vollständige manuell gepflegte Endpoint-Liste erzeugen.' }
+      ] },
+      { id: 'sicherheit', title: 'Sicherheitsgrenzen', blocks: [
+        { type: 'paragraph', text: 'Öffentliche Assistant-Funktionen sind read-only. Admin-, Auth-, User- und schreibende Fachoperationen gehören nicht zur Tool-Allowlist des Sprachassistenten.' }
+      ] }
+    ]
+  },
+  {
+    slug: 'osm',
+    title: 'OpenStreetMap und GIS-Daten',
+    navTitle: 'OpenStreetMap',
+    description: 'Lokale OSM-Daten, Gebäude, POIs, kanonische Kategorien und Synchronisation.',
+    group: 'Daten',
+    keywords: ['OSM', 'OpenStreetMap', 'Gebäude', 'Building', 'POI', 'Sync', 'PostGIS'],
+    audience: 'public',
+    sections: [
+      { id: 'modell', title: 'Lokale OSM-Daten', blocks: [
+        { type: 'paragraph', text: 'OpenStreetMap-Daten werden lokal für die GIS-Abfragen des Stadtplaners verwendet. Fachliche Geschäftsfilter und OSM-Feature-Kategorien wie Gebäude sind getrennte Taxonomien und dürfen nicht miteinander vermischt werden.' },
+        { type: 'links', items: [
+          { label: 'OSM-Datenmodell und Mapping', to: doc('docs/osm-data.md'), provider: 'github' },
+          { label: 'Stündliche OSM-Synchronisation', to: doc('docs/osm-hourly-sync.md'), provider: 'github' }
+        ] }
+      ] },
+      { id: 'geometrie', title: 'Räumliche Abfragen', blocks: [
+        { type: 'paragraph', text: 'PostGIS bleibt die Suchmaschine für Geometrien, Gebietszuordnung, BBOX-Vorfilter, Entfernungen und exakte räumliche Einschränkungen. Ein Sprachmodell interpretiert die Anfrage, berechnet aber keine GIS-Geometrien.' }
+      ] }
+    ]
+  },
+  {
+    slug: 'statistik',
+    title: 'Kommunale Statistik',
+    navTitle: 'Statistik',
+    description: 'Technischer Überblick über Statistikimport, Kennzahlen, Zeitreihen und Gebietsvererbung.',
+    group: 'Daten',
+    keywords: ['Statistik', 'Bevölkerung', 'metric_key', 'Zeitreihe', 'Import'],
+    audience: 'public',
+    sections: [
+      { id: 'datenmodell', title: 'Statistikmodell', blocks: [
+        { type: 'paragraph', text: 'Kommunale Statistik wird getrennt von den aus Stadtplaner- und OSM-Daten berechneten Analytics geführt. Die API stellt Gebietsstatistiken und Kennzahl-Zeitreihen bereit und trägt Quelle, Periode und gegebenenfalls die Vererbung eines Werts vom übergeordneten Gebiet.' },
+        { type: 'links', items: [{ label: 'Vollständige Statistik-Referenz', to: doc('docs/flensburg-statistics.md'), provider: 'github' }] }
+      ] }
+    ]
+  },
+  {
+    slug: 'assistant',
+    title: 'Intelligente Suche und Assistant',
+    navTitle: 'Suche & Assistant',
+    description: 'SearchPlan, deterministischer Fast Path, Groq, Tool Registry und kontrollierte Knowledge-Abfragen.',
+    group: 'Entwicklung',
+    keywords: ['Assistant', 'Groq', 'LLM', 'SearchPlan', 'Tool Registry', 'Knowledge'],
+    audience: 'public',
+    sections: [
+      { id: 'pipeline', title: 'Verarbeitung', blocks: [
+        { type: 'steps', items: [
+          { title: 'Eindeutige Kommandos', text: 'Ein kleiner deterministischer Fast Path verarbeitet triviale und sichere Karten- oder Filterbefehle ohne Modellaufruf.' },
+          { title: 'Sprachinterpretation', text: 'Komplexere Formulierungen können über den konfigurierten LLM-Provider in einen validierten Plan übersetzt werden.' },
+          { title: 'Read-only Tools', text: 'Nur explizit freigegebene, Pydantic-validierte Werkzeuge dürfen vorhandene Stadtplaner-Services aufrufen.' },
+          { title: 'Fachliche Antwort', text: 'Zahlen und GIS-Ergebnisse stammen aus PostGIS und den Fachservices; Knowledge liefert kontrollierte Erklärungen.' }
+        ] },
+        { type: 'links', items: [
+          { label: 'Intelligente Suche', to: doc('docs/intelligent-search.md'), provider: 'github' },
+          { label: 'Stadtplaner Assistant', to: doc('docs/stadtplaner-assistant.md'), provider: 'github' }
+        ] }
+      ] },
+      { id: 'groq', title: 'Groq', blocks: [
+        { type: 'paragraph', text: 'Groq ist eine austauschbare Sprach- und Orchestrierungsschicht. API-Schlüssel bleiben ausschließlich im Backend. Das Modell erhält keinen direkten Datenbankzugang und keine vollständige OpenAPI als frei ausführbare Tool-Liste.' }
+      ] }
+    ]
+  },
+  {
+    slug: 'ci',
+    title: 'CI und Tests',
+    navTitle: 'CI & Tests',
+    description: 'Backend-, Frontend-, Migrations- und Browser-Tests in GitHub Actions.',
+    group: 'Qualität',
+    keywords: ['CI', 'Tests', 'GitHub Actions', 'pytest', 'Vitest', 'Playwright'],
+    audience: 'public',
+    sections: [
+      { id: 'checks', title: 'Qualitätssicherung', blocks: [
+        { type: 'paragraph', text: 'GitHub Actions prüft Backend, Frontend, Migrationen und zentrale Nutzerwege. Die vollständigen und jeweils aktuellen Jobnamen, lokalen Befehle und Branch-Protection-Empfehlungen stehen in der technischen CI-Referenz.' },
+        { type: 'links', items: [{ label: 'CI-Referenz', to: doc('docs/ci.md'), provider: 'github' }] }
+      ] }
+    ]
+  },
+  {
+    slug: 'deployment',
+    title: 'Deployment und Betrieb',
+    navTitle: 'Deployment',
+    description: 'Produktionsbetrieb von Frontend, Backend, PostGIS, Redis, Imports, Assistant und systemd-Workern.',
+    group: 'Betrieb',
+    keywords: ['Deployment', 'Produktion', 'systemd', 'Nginx', 'PostGIS', 'Redis', 'Backup'],
+    audience: 'public',
+    sections: [
+      { id: 'prinzip', title: 'Betriebsprinzip', blocks: [
+        { type: 'paragraph', text: 'Die Entwicklerseite bietet den Betriebsüberblick. Konkrete Installations-, Update-, Backup-, Worker- und Diagnosebefehle werden zentral in docs/deployment.md gepflegt, damit README und öffentliche Hilfeseiten nicht zu Betriebshandbüchern anwachsen.' },
+        { type: 'links', items: [{ label: 'Deployment-Referenz', to: doc('docs/deployment.md'), provider: 'github' }] }
+      ] },
+      { id: 'checkliste', title: 'Vor einem produktiven Update', blocks: [
+        { type: 'list', items: ['Aktuellen Branch und CI-Status prüfen.', 'Vor Schemaänderungen ein Datenbank-Backup sicherstellen.', 'Alembic-Migrationen und Frontend-Build ausführen.', 'Services und Timer nach dem Update prüfen.', 'Read-only Smoke Tests für API, Karte, Statistik und Assistant durchführen.', 'Logs nach dem Restart kontrollieren.'] }
+      ] }
+    ]
+  }
+]
+
+export function findDeveloperDocumentationPage(slug: string | undefined) {
+  return developerDocumentationPages.find(page => page.slug === (slug || ''))
+}

--- a/frontend/app/config/project.ts
+++ b/frontend/app/config/project.ts
@@ -6,6 +6,9 @@ export const projectConfig = {
     issuesUrl: 'https://github.com/oklabflensburg/open-city-planner/issues',
     contributingUrl: 'https://github.com/oklabflensburg/open-city-planner/blob/main/CONTRIBUTING.md'
   },
+  documentation: {
+    developerUrl: 'https://developer.stadtplaner.oklabflensburg.de'
+  },
   social: {
     mastodon: {
       label: 'Mastodon',

--- a/frontend/app/middleware/developer-docs.global.ts
+++ b/frontend/app/middleware/developer-docs.global.ts
@@ -1,0 +1,23 @@
+import { projectConfig } from '~/config/project'
+
+export default defineNuxtRouteMiddleware((to) => {
+  const requestUrl = useRequestURL()
+  const developerUrl = new URL(projectConfig.documentation.developerUrl)
+  const developerHost = developerUrl.hostname
+  const host = requestUrl.hostname
+  const developerPrefix = '/dokumentation/entwickler'
+
+  if (host === developerHost) {
+    if (to.path.startsWith(developerPrefix)) return
+    const suffix = to.path === '/' ? '' : to.path
+    return navigateTo(`${developerPrefix}${suffix}`, { redirectCode: 302 })
+  }
+
+  if (host === 'stadtplaner.oklabflensburg.de' && to.path.startsWith(developerPrefix)) {
+    const suffix = to.path.slice(developerPrefix.length)
+    return navigateTo(`${projectConfig.documentation.developerUrl}${suffix || '/'}`, {
+      external: true,
+      redirectCode: 301
+    })
+  }
+})

--- a/frontend/app/pages/dokumentation/entwickler/[slug].vue
+++ b/frontend/app/pages/dokumentation/entwickler/[slug].vue
@@ -12,5 +12,5 @@ const page = computed(() => findDeveloperDocumentationPage(slug.value))
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Entwicklerdokumentation nicht gefunden.' })
 }
-useDocumentationSeo(page.value)
+useDeveloperDocumentationSeo(page.value)
 </script>

--- a/frontend/app/pages/dokumentation/entwickler/[slug].vue
+++ b/frontend/app/pages/dokumentation/entwickler/[slug].vue
@@ -1,0 +1,16 @@
+<template>
+  <DeveloperDocsLayout v-if="page" :page="page" />
+</template>
+
+<script setup lang="ts">
+import { findDeveloperDocumentationPage } from '~/config/developerDocumentation'
+
+const route = useRoute()
+const slug = computed(() => String(route.params.slug || ''))
+const page = computed(() => findDeveloperDocumentationPage(slug.value))
+
+if (!page.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Entwicklerdokumentation nicht gefunden.' })
+}
+useDocumentationSeo(page.value)
+</script>

--- a/frontend/app/pages/dokumentation/entwickler/index.vue
+++ b/frontend/app/pages/dokumentation/entwickler/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <DeveloperDocsLayout :page="page" />
+</template>
+
+<script setup lang="ts">
+import { developerDocumentationPages } from '~/config/developerDocumentation'
+
+const page = developerDocumentationPages[0]
+if (!page) throw createError({ statusCode: 500, statusMessage: 'Entwicklerdokumentation ist nicht konfiguriert.' })
+useDocumentationSeo(page)
+</script>

--- a/frontend/app/pages/dokumentation/entwickler/index.vue
+++ b/frontend/app/pages/dokumentation/entwickler/index.vue
@@ -7,5 +7,5 @@ import { developerDocumentationPages } from '~/config/developerDocumentation'
 
 const page = developerDocumentationPages[0]
 if (!page) throw createError({ statusCode: 500, statusMessage: 'Entwicklerdokumentation ist nicht konfiguriert.' })
-useDocumentationSeo(page)
+useDeveloperDocumentationSeo(page)
 </script>

--- a/frontend/tests/developer-documentation.test.ts
+++ b/frontend/tests/developer-documentation.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { developerDocumentationPages, findDeveloperDocumentationPage } from '../app/config/developerDocumentation'
+import { projectConfig } from '../app/config/project'
+
+const appFile = (path: string) => readFileSync(fileURLToPath(new URL(`../app/${path}`, import.meta.url)), 'utf8')
+
+describe('developer documentation', () => {
+  it('defines unique and complete technical pages', () => {
+    const slugs = developerDocumentationPages.map(page => page.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+    expect(developerDocumentationPages.every(page => page.title.trim() && page.description.trim())).toBe(true)
+    expect(findDeveloperDocumentationPage('osm')?.title).toContain('OpenStreetMap')
+    expect(findDeveloperDocumentationPage('assistant')?.keywords).toContain('Groq')
+    expect(findDeveloperDocumentationPage('deployment')?.title).toContain('Deployment')
+  })
+
+  it('uses the dedicated developer origin as canonical target', () => {
+    expect(projectConfig.documentation.developerUrl).toBe('https://developer.stadtplaner.oklabflensburg.de')
+    const seo = appFile('composables/useDeveloperDocumentationSeo.ts')
+    expect(seo).toContain('projectConfig.documentation.developerUrl')
+    expect(seo).toContain("robots: 'index,follow'")
+  })
+
+  it('keeps local developer routes and maps the production subdomain', () => {
+    const middleware = appFile('middleware/developer-docs.global.ts')
+    expect(middleware).toContain("const developerPrefix = '/dokumentation/entwickler'")
+    expect(middleware).toContain("host === 'stadtplaner.oklabflensburg.de'")
+    expect(middleware).toContain('redirectCode: 301')
+    expect(appFile('pages/dokumentation/entwickler/index.vue')).toContain('<DeveloperDocsLayout')
+    expect(appFile('pages/dokumentation/entwickler/[slug].vue')).toContain('findDeveloperDocumentationPage')
+  })
+
+  it('links deep technical references to the repository instead of duplicating them', () => {
+    const links = developerDocumentationPages
+      .flatMap(page => page.sections)
+      .flatMap(section => section.blocks)
+      .filter(block => block.type === 'links')
+      .flatMap(block => block.type === 'links' ? block.items : [])
+      .map(item => item.to)
+
+    expect(links).toContain(`${projectConfig.github.url}/blob/main/docs/osm-data.md`)
+    expect(links).toContain(`${projectConfig.github.url}/blob/main/docs/ci.md`)
+    expect(links).toContain(`${projectConfig.github.url}/blob/main/docs/deployment.md`)
+  })
+})


### PR DESCRIPTION
## Überblick

Dieser PR führt eine eigene öffentliche Entwicklerdokumentation für `developer.stadtplaner.oklabflensburg.de` ein, ohne eine zweite Anwendung oder ein separates Doku-Framework zu bauen.

## Änderungen

- neue technische Dokumentationsseiten unter `/dokumentation/entwickler`
- eigene Navigation und Layout für Entwickler
- hostbasierte Weiterleitung für `developer.stadtplaner.oklabflensburg.de`
- 301-Weiterleitung von der Hauptdomain auf die kanonische Entwickler-Subdomain
- eigene Canonical-/SEO-Origin für Entwicklerseiten
- zentrale Projektkonfiguration für die Developer-Domain
- technische Referenz `docs/developer-documentation-site.md`
- Tests für Slugs, Metadaten, Canonicals, Routing und Repository-Referenzen

## Inhalt

Die Entwicklerdokumentation bietet Einstiege für:

- Architektur
- API / Backend
- OpenStreetMap / GIS
- kommunale Statistik
- intelligente Suche / Assistant / Groq
- CI / Tests
- Deployment / Betrieb

Tiefe technische Dokumente unter `docs/` bleiben Source of Truth und werden verlinkt statt 1:1 gespiegelt.

## Betrieb außerhalb des Repositorys

Für die tatsächliche Freischaltung der Subdomain sind zusätzlich DNS, TLS und ein Reverse-Proxy-VHost erforderlich. Die nötige Architektur und ein Nginx-Beispiel sind in `docs/developer-documentation-site.md` dokumentiert.

## Prüfung

Bitte in CI mindestens `pnpm test`, `pnpm typecheck` und `pnpm build` ausführen.