### PR TITLE
Add hardened nginx deployment templates

### DIFF
--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -1,0 +1,170 @@
+# Nginx-Konfiguration
+
+Dieses Verzeichnis enthält eine gehärtete, aber bewusst konservative Nginx-Vorlage für den Stadtplaner. Die Dateien sind **Vorlagen**: Vor dem Kopieren immer Diff, lokale Pfade, Zertifikate und Ports prüfen.
+
+## Dateien
+
+- `nginx.conf.example`: projektneutrale Basis für `/etc/nginx/nginx.conf` auf einem Server mit mehreren Projekten.
+- `conf.d/stadtplaner-rate-limits.conf`: Stadtplaner-spezifische `limit_req_zone`-Definitionen und die Upgrade-Map für den `http {}`-Kontext.
+- `sites-available/stadtplaner.conf`: Frontend, API und `developer.stadtplaner.oklabflensburg.de`.
+
+## Warum die globale nginx.conf nicht Stadtplaner-spezifisch sein sollte
+
+`/etc/nginx/nginx.conf` gilt für alle Projekte auf dem Host. Deshalb enthält die Beispielkonfiguration dort nur gemeinsame Parser-, TLS-, Logging- und Kompressionsdefaults. Die Stadtplaner-Limits liegen separat unter `conf.d/` und werden nur in der Stadtplaner-Site tatsächlich angewendet.
+
+Die bisherige Serverkonfiguration sollte insbesondere an diesen Punkten modernisiert werden:
+
+- TLS 1.0 und TLS 1.1 deaktivieren; nur TLS 1.2/1.3 zulassen.
+- `X-XSS-Protection` nicht global setzen; der Header ist veraltet.
+- keine globale CSP oder `X-Frame-Options` erzwingen, weil die Anwendungen im Repository bereits eigene Security Header liefern.
+- sehr große Header-Puffer (`3m`, `4 x 256k`) auf normale Größen zurückführen; solche Werte erhöhen den Speicherverbrauch pro Verbindung und maskieren problematische Clients.
+- Gzip-Level 9 vermeiden; Level 6 ist auf einem Shared Host meist das bessere CPU-/Größen-Verhältnis.
+- JPEG/PNG/WebP nicht nochmals mit gzip komprimieren.
+- `Connection: upgrade` nicht für jeden Proxy-Request erzwingen.
+- `X-Forwarded-Proto` und `X-Forwarded-Host` an die Anwendung weiterreichen.
+
+## CORS
+
+Nginx soll für den Stadtplaner **keine zweite CORS-Implementierung** besitzen. FastAPI konfiguriert `CORSMiddleware` selbst. Dadurch gelten Preflight und eigentliche Antwort aus einer Source of Truth und es entstehen keine doppelten oder widersprüchlichen `Access-Control-*`-Header.
+
+Die produktive Backend-Konfiguration muss `CORS_ORIGINS` bzw. die im Backend verwendeten Origin-Settings korrekt setzen.
+
+## Rate-Limiting-Philosophie
+
+Nginx ist nur der äußere Überlastungsschutz. Fachliche, benutzerbezogene oder sicherheitsrelevante Limits gehören weiterhin in FastAPI/Redis.
+
+Die Vorlage verwendet absichtlich großzügige Grenzen:
+
+| Bereich | Sustained Limit | Burst | Zweck |
+| --- | ---: | ---: | --- |
+| normale API | 20 Requests/s/IP | 100 | normale Karten- und Datenabrufe nicht behindern |
+| API global | 500 Requests/s/VHost | 500 | Notbremse gegen verteilte Last |
+| Assistant | 60 Requests/min/IP | 20 | LLM-/Tool-Kosten vor offensichtlicher Automation schützen |
+| Auth | 5 Requests/s/IP | 20 | äußerer Schutz; Redis/FastAPI bleibt maßgeblich |
+
+Die Werte sind Startwerte, keine universellen Kapazitätsgrenzen. NAT-Gateways können viele legitime Nutzer hinter einer IP bündeln, deshalb sind niedrige Per-IP-Limits für eine öffentliche GIS-API ungeeignet.
+
+### Erst beobachten, dann schärfen
+
+Für die normale öffentliche API empfiehlt sich beim ersten Rollout eine Beobachtungsphase. Dazu temporär in der API-`location` ergänzen:
+
+```nginx
+limit_req_dry_run on;
+```
+
+Nginx blockiert dann nicht, setzt aber `$limit_req_status` auf Werte wie `REJECTED_DRY_RUN`. Das mitgelieferte `main`-Logformat schreibt diesen Status mit.
+
+Beispielauswertung:
+
+```bash
+grep 'limit_req=REJECTED_DRY_RUN' /var/log/nginx/access.log | tail -100
+```
+
+Nach einigen Tagen realer Last können die Werte angepasst und `limit_req_dry_run` entfernt werden.
+
+## Installation
+
+Vor Änderungen sichern:
+
+```bash
+sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.$(date +%Y%m%d-%H%M%S).bak
+sudo cp /etc/nginx/sites-available/stadtplaner /etc/nginx/sites-available/stadtplaner.$(date +%Y%m%d-%H%M%S).bak
+```
+
+Projektdateien kopieren:
+
+```bash
+sudo cp deploy/nginx/conf.d/stadtplaner-rate-limits.conf /etc/nginx/conf.d/stadtplaner-rate-limits.conf
+sudo cp deploy/nginx/sites-available/stadtplaner.conf /etc/nginx/sites-available/stadtplaner
+```
+
+Die globale `nginx.conf.example` nicht blind kopieren. Zuerst mit der Konfiguration der anderen Projekte vergleichen. Wenn sie übernommen werden soll:
+
+```bash
+sudo diff -u /etc/nginx/nginx.conf deploy/nginx/nginx.conf.example
+```
+
+Danach kontrolliert editieren oder ersetzen.
+
+## Developer-Subdomain: DNS und Zertifikat
+
+Vor Aktivierung des TLS-vHosts muss DNS für
+
+`developer.stadtplaner.oklabflensburg.de`
+
+auf den Webserver zeigen.
+
+Da Nginx keine Site mit einem noch nicht vorhandenen Zertifikat laden kann, ist der sichere Ablauf:
+
+1. zunächst nur einen HTTP-Serverblock für `developer.stadtplaner.oklabflensburg.de` anlegen oder den TLS-Block in der Vorlage vorübergehend auskommentieren;
+2. `sudo nginx -t && sudo systemctl reload nginx`;
+3. Zertifikat mit Certbot ausstellen;
+4. vollständigen TLS-vHost aus `stadtplaner.conf` aktivieren.
+
+Beispiel mit dem vorhandenen Nginx-Plugin:
+
+```bash
+sudo certbot --nginx -d developer.stadtplaner.oklabflensburg.de
+```
+
+Für Frontend und API können die vorhandenen Zertifikate weiterverwendet werden. Es ist nicht nötig, Certbot mit allen Domains des Servers gleichzeitig aufzurufen.
+
+## Validierung vor Reload
+
+Immer zuerst:
+
+```bash
+sudo nginx -t
+```
+
+Nur bei erfolgreichem Test:
+
+```bash
+sudo systemctl reload nginx
+```
+
+Danach prüfen:
+
+```bash
+curl -I https://stadtplaner.oklabflensburg.de/
+curl -I https://api.stadtplaner.oklabflensburg.de/health
+curl -I https://developer.stadtplaner.oklabflensburg.de/
+```
+
+## Rate-Limit-Monitoring
+
+Das Beispiel-Logformat enthält:
+
+- `request_time`
+- `upstream_time`
+- `limit_req`
+
+Nützliche Prüfungen:
+
+```bash
+grep 'limit_req=REJECTED' /var/log/nginx/access.log | tail -100
+grep 'limit_req=REJECTED_DRY_RUN' /var/log/nginx/access.log | tail -100
+grep 'limit_req=DELAYED' /var/log/nginx/access.log | tail -100
+```
+
+Wenn legitime Kartenaufrufe regelmäßig am Limit liegen, zuerst Caching/Query-Kosten untersuchen und das äußere Limit erhöhen. Eine offene Daten-API sollte nicht künstlich knapp gehalten werden.
+
+## Wichtige Grenzen
+
+Nginx kann nur IP, Pfad, Methode, Verbindung und Trafficrate sehen. Es weiß nicht, ob ein Request einen teuren PostGIS-Plan, mehrere Assistant-Tools oder einen authentifizierten Benutzer betrifft. Deshalb bleiben folgende Regeln im Backend:
+
+- Login-/MFA-Schutz;
+- nutzerbezogene Limits;
+- Assistant-/Provider-Limits;
+- Request-Body-Verträge;
+- Datenbank-Statement-Timeouts;
+- Rollen und Berechtigungen.
+
+## Rollback
+
+Bei Problemen die gesicherten Dateien zurückspielen und immer vor Reload testen:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```

--- a/deploy/nginx/conf.d/stadtplaner-rate-limits.conf
+++ b/deploy/nginx/conf.d/stadtplaner-rate-limits.conf
@@ -1,0 +1,33 @@
+# Stadtplaner-specific request limiting zones.
+#
+# Install as /etc/nginx/conf.d/stadtplaner-rate-limits.conf. The directives in
+# this file must live in nginx's http{} context, therefore they are kept out of
+# the site vhost itself.
+#
+# Limits are intentionally generous. Nginx is only the outer overload guard;
+# route-, account- and cost-aware limits remain the responsibility of FastAPI
+# and Redis.
+
+# Public GIS/API traffic: normal map interaction may legitimately generate
+# short bursts. 20 requests/second/IP is the sustained outer guard.
+limit_req_zone $binary_remote_addr zone=stadtplaner_api_per_ip:20m rate=20r/s;
+
+# Assistant requests can trigger LLM and multiple read-only tools. The backend
+# still owns the fine-grained policy; this only prevents obviously abusive
+# request rates before they reach the application.
+limit_req_zone $binary_remote_addr zone=stadtplaner_assistant_per_ip:10m rate=60r/m;
+
+# Authentication endpoints get a separate outer guard. The application also
+# implements its own Redis-backed security counters.
+limit_req_zone $binary_remote_addr zone=stadtplaner_auth_per_ip:10m rate=5r/s;
+
+# A server-wide emergency ceiling also helps against distributed traffic where
+# per-IP limits alone are ineffective. $server_name is a single key for this
+# virtual host, so this is intentionally a coarse safety valve.
+limit_req_zone $server_name zone=stadtplaner_api_global:1m rate=500r/s;
+
+# Do not force Connection: upgrade on every proxied HTTP request.
+map $http_upgrade $stadtplaner_connection_upgrade {
+    default upgrade;
+    ''      close;
+}

--- a/deploy/nginx/nginx.conf.example
+++ b/deploy/nginx/nginx.conf.example
@@ -1,0 +1,95 @@
+# Shared nginx baseline for a host that serves multiple projects.
+#
+# This is intentionally project-neutral. Project-specific rate limits belong in
+# /etc/nginx/conf.d/*.conf and are only applied by the corresponding vhost.
+# Compare with the server's existing /etc/nginx/nginx.conf before replacing it.
+
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+    worker_connections 2048;
+    use epoll;
+    multi_accept on;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Do not expose the nginx version in generated responses.
+    server_tokens off;
+
+    # Efficient file/network handling.
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    reset_timedout_connection on;
+    types_hash_max_size 2048;
+    server_names_hash_bucket_size 128;
+
+    # Modern TLS baseline. Certbot's options-ssl-nginx.conf may add compatible
+    # per-vhost settings, but TLS 1.0/1.1 should not be re-enabled globally.
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_cache shared:SSL:20m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    # Let the TLS library negotiate modern suites. TLS 1.3 ciphers are not
+    # controlled by ssl_ciphers. This conservative TLS 1.2 list avoids legacy
+    # CBC/3DES/RC4 suites without pretending to be a complete TLS policy.
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305';
+    ssl_prefer_server_ciphers off;
+
+    # Global request parser limits. Keep these sane for all projects. Individual
+    # applications can lower client_max_body_size in their server/location.
+    client_max_body_size 10m;
+    client_body_buffer_size 128k;
+    client_header_buffer_size 8k;
+    large_client_header_buffers 4 16k;
+    client_body_timeout 30s;
+    client_header_timeout 30s;
+    send_timeout 60s;
+
+    # Generic per-IP connection zone. Defining a zone does not limit anything
+    # until a vhost explicitly uses limit_conn.
+    limit_conn_zone $binary_remote_addr zone=conn_limit_per_ip:10m;
+
+    # Logging includes request/upstream timing and nginx request-limit status so
+    # rate limits can be tuned from real traffic instead of guesses.
+    log_format main '$remote_addr - $remote_user [$time_local] "$host" '
+                    '"$request" status=$status bytes=$body_bytes_sent '
+                    'request_time=$request_time upstream_time=$upstream_response_time '
+                    'limit_req=$limit_req_status referer="$http_referer" '
+                    'ua="$http_user_agent" xff="$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
+
+    # Compression. Level 6 is a better CPU/size trade-off than level 9 on a
+    # shared host. Do not gzip formats that are already compressed (JPEG/PNG).
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        application/xml
+        application/rss+xml
+        image/svg+xml;
+
+    # Do not set application CSP/X-Frame-Options/X-XSS-Protection globally.
+    # Different projects need different policies, and modern applications in
+    # this repository already emit their own security headers. X-XSS-Protection
+    # is obsolete and should not be used as a global hardening mechanism.
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+}

--- a/deploy/nginx/sites-available/developer-bootstrap-http.conf
+++ b/deploy/nginx/sites-available/developer-bootstrap-http.conf
@@ -1,0 +1,22 @@
+# Temporary bootstrap vhost for the first Let's Encrypt issuance of
+# developer.stadtplaner.oklabflensburg.de.
+#
+# Use only until the certificate exists, then remove/disable this file and use
+# sites-available/stadtplaner.conf instead.
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name developer.stadtplaner.oklabflensburg.de;
+
+    location / {
+        proxy_pass http://127.0.0.1:3008;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+}

--- a/deploy/nginx/sites-available/stadtplaner.conf
+++ b/deploy/nginx/sites-available/stadtplaner.conf
@@ -1,0 +1,205 @@
+# Hardened production vhost for the Stadtplaner frontend, API and developer docs.
+#
+# Install as /etc/nginx/sites-available/stadtplaner and symlink into sites-enabled.
+# The rate-limit zones referenced here are defined in
+# /etc/nginx/conf.d/stadtplaner-rate-limits.conf.
+#
+# IMPORTANT: certificate paths below assume Certbot certificates with exactly
+# these names. Issue/renew them before enabling the corresponding TLS vhost.
+
+upstream stadtplaner_frontend {
+    server 127.0.0.1:3008;
+    keepalive 32;
+}
+
+upstream stadtplaner_api {
+    server 127.0.0.1:8008;
+    keepalive 32;
+}
+
+# -----------------------------------------------------------------------------
+# Public frontend
+# -----------------------------------------------------------------------------
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name stadtplaner.oklabflensburg.de;
+
+    client_max_body_size 10m;
+
+    location / {
+        proxy_pass http://stadtplaner_frontend;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $stadtplaner_connection_upgrade;
+
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    ssl_certificate /etc/letsencrypt/live/stadtplaner.oklabflensburg.de/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/stadtplaner.oklabflensburg.de/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+# -----------------------------------------------------------------------------
+# Developer documentation subdomain
+# -----------------------------------------------------------------------------
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name developer.stadtplaner.oklabflensburg.de;
+
+    location / {
+        proxy_pass http://stadtplaner_frontend;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $stadtplaner_connection_upgrade;
+
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    ssl_certificate /etc/letsencrypt/live/developer.stadtplaner.oklabflensburg.de/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/developer.stadtplaner.oklabflensburg.de/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+# -----------------------------------------------------------------------------
+# Public API
+# -----------------------------------------------------------------------------
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name api.stadtplaner.oklabflensburg.de;
+
+    # The application already owns CORS through FastAPI CORSMiddleware.
+    # Do not duplicate Access-Control-* handling in nginx.
+
+    # Monitoring must not be hidden behind the public request limiter.
+    location = /health {
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 10s;
+    }
+
+    # Assistant: expensive path, separate outer limit. A legitimate user can
+    # still burst several requests; sustained automation is rejected with 429.
+    location = /api/v1/assistant/query {
+        limit_req zone=stadtplaner_assistant_per_ip burst=20 nodelay;
+        limit_req_status 429;
+        limit_req_log_level notice;
+
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 35s;
+        proxy_read_timeout 35s;
+    }
+
+    # Authentication has its own coarse outer guard. FastAPI/Redis remains the
+    # authoritative place for login/security policy.
+    location ^~ /api/v1/auth/ {
+        limit_req zone=stadtplaner_auth_per_ip burst=20 nodelay;
+        limit_req_status 429;
+        limit_req_log_level notice;
+
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # All remaining public API traffic. The limits are deliberately high enough
+    # for map interaction and short client-side request bursts.
+    location / {
+        limit_req zone=stadtplaner_api_per_ip burst=100 nodelay;
+        limit_req zone=stadtplaner_api_global burst=500 nodelay;
+        limit_req_status 429;
+        limit_req_log_level notice;
+
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+
+        # Keep upgrade support for realtime endpoints without forcing it for
+        # ordinary HTTP requests.
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $stadtplaner_connection_upgrade;
+
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    ssl_certificate /etc/letsencrypt/live/api.stadtplaner.oklabflensburg.de/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.stadtplaner.oklabflensburg.de/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+# -----------------------------------------------------------------------------
+# HTTP -> HTTPS
+# -----------------------------------------------------------------------------
+server {
+    listen 80;
+    listen [::]:80;
+    server_name stadtplaner.oklabflensburg.de;
+    return 301 https://stadtplaner.oklabflensburg.de$request_uri;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.stadtplaner.oklabflensburg.de;
+    return 301 https://api.stadtplaner.oklabflensburg.de$request_uri;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name developer.stadtplaner.oklabflensburg.de;
+    return 301 https://developer.stadtplaner.oklabflensburg.de$request_uri;
+}


### PR DESCRIPTION
## Überblick

Dieser PR ergänzt gehärtete Nginx-Vorlagen für den Stadtplaner und trennt bewusst globale Shared-Host-Konfiguration von projektspezifischen Limits.

## Enthalten

- `deploy/nginx/nginx.conf.example` als projektneutrale Shared-Host-Basis
- `deploy/nginx/conf.d/stadtplaner-rate-limits.conf` mit großzügigen API-/Assistant-/Auth-Limits
- `deploy/nginx/sites-available/stadtplaner.conf` für Frontend, API und Developer-Subdomain
- `deploy/nginx/sites-available/developer-bootstrap-http.conf` für die erste Certbot-Ausstellung
- `deploy/nginx/README.md` mit Rollout, Dry-Run, Monitoring, Certbot und Rollback

## Wichtige Änderungen gegenüber der aktuellen Server-Konfiguration

- TLS 1.0/1.1 werden in der Beispiel-Baseline nicht mehr zugelassen
- keine globale CSP/X-Frame-/X-XSS-Policy über alle Projekte
- deutlich kleinere Header-Buffer
- Gzip Level 6 statt 9 und keine erneute Kompression bereits komprimierter Bildformate
- `Connection: upgrade` nur bei tatsächlichem Upgrade
- `X-Forwarded-Proto`/`X-Forwarded-Host`
- CORS bleibt vollständig in FastAPI
- `/health` wird nicht durch das öffentliche API-Limit blockiert
- normale API bewusst großzügig: 20 r/s/IP, Burst 100 + globaler Safety-Guard
- Assistant separat: 60 r/min/IP, Burst 20
- HTTP 429 bei Rate-Limit-Ablehnung

## Rollout

Die Dateien sind Vorlagen und sollen nicht blind auf einen Shared Host kopiert werden. Insbesondere `nginx.conf.example` zuerst gegen `/etc/nginx/nginx.conf` diffen. Für die öffentliche API wird im README eine initiale `limit_req_dry_run`-Phase empfohlen.

Vor jedem Reload: `sudo nginx -t`.
