### PR TITLE
Add repeatable Ansible production deployment

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,0 +1,37 @@
+name: Ansible
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/ansible/**'
+      - 'deploy/nginx/**'
+      - 'deploy/systemd/**'
+      - '.github/workflows/ansible.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/ansible/**'
+      - 'deploy/nginx/**'
+      - 'deploy/systemd/**'
+      - '.github/workflows/ansible.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install ansible-core
+        run: python -m pip install 'ansible-core>=2.17,<2.20'
+      - name: Syntax-check deployment playbooks
+        working-directory: deploy/ansible
+        run: |
+          ansible-playbook --syntax-check playbooks/bootstrap.yml
+          ansible-playbook --syntax-check playbooks/deploy.yml
+          ansible-playbook --syntax-check playbooks/certificates.yml
+          ansible-playbook --syntax-check playbooks/osm-initial-import.yml

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Der Stadtplaner macht Verkaufsflächen, OpenStreetMap-Informationen, Analysegebi
 backend/          API, Datenmodelle, Migrationen, CLI und Tests
 frontend/         Webanwendung, öffentliches Benutzerhandbuch und E2E-Tests
 docs/             technische Entwickler-, Architektur- und Betriebsdokumentation
+deploy/ansible/   reproduzierbares Produktionsdeployment
+deploy/nginx/     Stadtplaner-spezifische Nginx-Hardening-Vorlagen
 deploy/systemd/   mitgelieferte Units für Hintergrundaufgaben
 scripts/osm/      initialer OSM-Import und Replikationsupdate
 ```
@@ -85,6 +87,8 @@ Die vollständigen CI-Jobs und stabilen Check-Namen stehen in [docs/ci.md](docs/
 - Das öffentliche Benutzerhandbuch ist in der Anwendung unter `/dokumentation` erreichbar und wird aus `frontend/app/config/documentation.ts` erzeugt.
 - [Technische Dokumentation](docs/README.md)
 - [Deployment und Betrieb](docs/deployment.md)
+- [Ansible-Deployment](deploy/ansible/README.md)
+- [Nginx-Hardening und Rate Limits](deploy/nginx/README.md)
 - [OpenStreetMap-Daten](docs/osm-data.md)
 - [Kommunale Statistik](docs/flensburg-statistics.md)
 - [Intelligente Suche](docs/intelligent-search.md) und [Stadtplaner-Assistent](docs/stadtplaner-assistant.md)

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -1,0 +1,241 @@
+# Ansible Deployment
+
+Dieses Verzeichnis automatisiert den produktiven Betrieb des Open City Planner auf dem bestehenden Shared Host. Es ersetzt bewusst nicht die globale Serververwaltung aller OK-Lab-Projekte. Nginx, PostgreSQL, Redis und Node können weitere Anwendungen bedienen; die Playbooks verändern deshalb nur Stadtplaner-spezifische Dateien und prüfen globale Voraussetzungen, statt `/etc/nginx/nginx.conf`, PostgreSQL oder Redis blind neu zu konfigurieren.
+
+## Warum Ansible?
+
+Für diesen Server ist ein idempotenter Deployment-Ablauf sicherer als wiederholte manuelle Änderungen: dieselben Pfade, Benutzer, systemd-Units, Builds, Migrationen, Nginx-Dateien und Smoke Tests werden bei jedem Lauf reproduzierbar angewendet. Ein normaler Deploy führt **keinen** OSM-Initialimport und **keine** Certbot-Ausstellung aus.
+
+## Aus dem Repository abgeleitete Produktionsarchitektur
+
+- Checkout: `/opt/git/open-city-planner`
+- Arbeits-/SSH-Benutzer: `awendelk` mit `become`
+- Service-Benutzer: `oklab`
+- FastAPI: `127.0.0.1:8008`
+- Nuxt/Nitro: `127.0.0.1:3008`
+- PostgreSQL/PostGIS: fachliche Source of Truth
+- Redis: Cache und produktive Rate-Limit-Zähler
+- Nginx: Reverse Proxy für Frontend/API und optional Entwicklerdokumentation
+- Certbot: bestehende Let's-Encrypt-Zertifikate; neue Zertifikate nur über ein separates Playbook
+- OSM: `scripts/osm/*`, persistente Daten unter `/data/stadtplaner`, stündlicher systemd-Timer
+- Kommunale Statistik: wöchentlicher Import-Timer
+- E-Mail-Outbox: minütlicher Timer
+- Mastodon Publisher: optionaler minütlicher Timer
+
+Backend-Settings werden aus `backend/.env` geladen. Ansible verlinkt diese Datei auf `/etc/stadtplaner/backend.env`, damit Secrets nicht im Git-Checkout liegen. Für das Frontend wird analog `/etc/stadtplaner/frontend.env` verwendet. Der OSM-Sync liest `/etc/stadtplaner/osm-sync.env`.
+
+## Controller installieren
+
+Ansible sollte **nicht aus dem produktiven Checkout `/opt/git/open-city-planner` heraus** laufen, weil dieser Checkout während des Deployments aktualisiert wird. Nutze einen separaten Admin-/Workstation-Checkout.
+
+Auf Debian/Ubuntu beispielsweise:
+
+```bash
+python3 -m venv ~/.venvs/stadtplaner-ansible
+~/.venvs/stadtplaner-ansible/bin/pip install 'ansible-core>=2.17,<2.20'
+cd /pfad/zum/open-city-planner/deploy/ansible
+```
+
+Der Inventory-Eintrag verwendet `89.58.56.254` und `awendelk`. SSH Host Keys bleiben absichtlich aktiviert. Test:
+
+```bash
+ansible stadtplaner -m ping
+ansible stadtplaner -b -m command -a 'id'
+```
+
+## Einmalige Voraussetzungen
+
+`bootstrap.yml` prüft bewusst nur den vorhandenen Shared Host und legt Stadtplaner-Verzeichnisse an. Es fügt keine fremden APT-Repositories hinzu und ersetzt keine globale Nginx-/PostgreSQL-/Redis-Konfiguration.
+
+```bash
+ansible-playbook playbooks/bootstrap.yml
+```
+
+Erwartet werden unter anderem Python 3.12+, Node 22, Corepack, Nginx, Certbot, PostgreSQL-Client, Redis-CLI, `osm2pgsql` und `osmium`.
+
+## Secrets und Environment
+
+Bestehende Produktionsdateien können unverändert unter `/etc/stadtplaner/` verbleiben. Alternativ kann Ansible sie aus einem **extern gespeicherten verschlüsselten Vault** schreiben.
+
+```bash
+cp vault.example.yml ~/stadtplaner-vault.yml
+ansible-vault encrypt ~/stadtplaner-vault.yml
+```
+
+Danach:
+
+```bash
+ansible-playbook playbooks/deploy.yml \
+  -e @~/stadtplaner-vault.yml \
+  --ask-vault-pass \
+  -e stadtplaner_deploy_ref=<commit-sha>
+```
+
+`vault.example.yml` enthält nur Platzhalter. Reale Secrets niemals committen.
+
+## Datenbankbackup vor Migrationen
+
+Das Playbook verlangt standardmäßig einen expliziten Backup-Befehl, bevor `alembic upgrade head` ausgeführt wird. Das Repository kennt absichtlich keine Produktions-Datenbank-Credentials und erfindet daher keinen `pg_dump`-Aufruf.
+
+Beispiel als verschlüsselte Variable:
+
+```yaml
+stadtplaner_pre_migration_backup_command: >-
+  /usr/local/sbin/stadtplaner-backup-before-deploy
+```
+
+Der angegebene Befehl muss selbst mit Fehlercode != 0 abbrechen, wenn kein verifiziertes Backup erzeugt werden konnte. Für einen Deploy ohne Schemaänderungen kann bewusst gesetzt werden:
+
+```bash
+-e stadtplaner_run_migrations=false
+```
+
+Nicht dauerhaft den Backup-Guard abschalten.
+
+## Normaler Deploy nach einem Push
+
+Am sichersten wird **ein konkreter Commit** deployed, nicht ein beweglicher Branchname:
+
+```bash
+git fetch origin
+SHA=$(git rev-parse origin/main)
+cd deploy/ansible
+ansible-playbook playbooks/deploy.yml \
+  -e stadtplaner_deploy_ref="$SHA" \
+  -e @~/stadtplaner-vault.yml \
+  --ask-vault-pass
+```
+
+Der Ablauf ist:
+
+1. Runtime-Versionen prüfen.
+2. persistente Env-Dateien prüfen/schreiben;
+3. Git auf exakt den gewünschten Ref aktualisieren, ohne lokale Änderungen zu verwerfen;
+4. Backend-Venv und Python-Abhängigkeiten aktualisieren;
+5. Frontend-Abhängigkeiten per Lockfile installieren und Nuxt bauen;
+6. optional Tests/Typecheck ausführen;
+7. Backup-Guard und Alembic-Migrationen;
+8. systemd-Units installieren/aktualisieren;
+9. Hintergrund-Timer synchronisieren;
+10. Stadtplaner-Nginx-Konfiguration installieren und mit `nginx -t` validieren;
+11. API und Frontend kontrolliert neu starten;
+12. lokale Health-/HTTP-Smoke-Tests durchführen.
+
+Ein Fehler stoppt den Lauf. `serial: 1` und `any_errors_fatal: true` verhindern ein Weiterrollen nach einem Fehler.
+
+## Optionale Prüfungen auf dem Server
+
+CI sollte die Hauptqualitätsgrenze bleiben. Für ein besonders sensibles Release können zusätzlich aktiviert werden:
+
+```bash
+-e stadtplaner_run_backend_tests=true \
+-e stadtplaner_run_frontend_tests=true \
+-e stadtplaner_run_frontend_typecheck=true
+```
+
+Diese Prüfungen verlängern das Produktionsdeployment und sind standardmäßig aus.
+
+## Nginx und Rate Limits
+
+Ansible ersetzt **nicht** `/etc/nginx/nginx.conf`. Es verwaltet nur:
+
+- `/etc/nginx/conf.d/stadtplaner-rate-limits.conf`
+- `/etc/nginx/sites-available/stadtplaner`
+- `/etc/nginx/sites-enabled/stadtplaner`
+
+Damit bleiben die vielen anderen Projekte auf dem Shared Host außerhalb dieses Deployments. Die Rate-Limit-Zonen stammen aus `deploy/nginx/conf.d/stadtplaner-rate-limits.conf`.
+
+Initial ist `stadtplaner_enable_rate_limit_dry_run: true`. Erst nach Auswertung von `REJECTED_DRY_RUN` sollte auf echte 429-Ablehnung umgestellt werden:
+
+```bash
+-e stadtplaner_enable_rate_limit_dry_run=false
+```
+
+FastAPI/Redis bleibt die fachlich zuständige Rate-Limit-Schicht.
+
+## Entwickler-Subdomain und Certbot
+
+Die Entwickler-Subdomain ist standardmäßig aus, damit ein fehlendes Zertifikat niemals `nginx -t` kaputt macht.
+
+Nach gesetztem DNS zunächst einmalig:
+
+```bash
+ansible-playbook playbooks/certificates.yml \
+  -e stadtplaner_manage_certificates=true \
+  -e stadtplaner_certbot_email=DEINE-ADMIN-MAIL
+```
+
+Danach deployen mit:
+
+```bash
+-e stadtplaner_enable_developer_host=true
+```
+
+Normale Deployments führen Certbot nicht aus. Die reguläre Certbot-Renewal-Infrastruktur des Servers bleibt zuständig.
+
+## OSM
+
+Der Initialimport ist absichtlich aus dem normalen Deployment ausgeschlossen. Er ist groß, extern datenabhängig und darf nur explizit gestartet werden:
+
+```bash
+ansible-playbook playbooks/osm-initial-import.yml \
+  -e confirm_osm_initial_import=true
+```
+
+Vorher `docs/osm-hourly-sync.md` und `/etc/stadtplaner/osm-sync.env` prüfen. Der normale Deploy installiert nur den stündlichen Sync-Timer.
+
+## Hintergrunddienste
+
+Standardmäßig:
+
+- `stadtplaner-osm-update.timer`: aktiv
+- `stadtplaner-flensburg-statistics-sync.timer`: aktiv
+- `stadtplaner-email-outbox.timer`: aktiv
+- `stadtplaner-social-publisher.timer`: aus
+
+Mastodon nur aktivieren, wenn die Backend-Konfiguration vollständig ist:
+
+```bash
+-e stadtplaner_enable_social_publisher_timer=true
+```
+
+## Rollback
+
+Für Code ohne inkompatible Datenbankänderung kann ein zuvor bekannter Commit wieder deployed werden:
+
+```bash
+ansible-playbook playbooks/deploy.yml \
+  -e stadtplaner_deploy_ref=<previous-good-sha> \
+  -e stadtplaner_run_migrations=false
+```
+
+Bei Datenbankmigrationen entscheidet die konkrete Migration plus Backup über den Rollback. Das Playbook führt niemals automatisch `alembic downgrade` aus.
+
+## Nachkontrolle
+
+```bash
+sudo systemctl status stadtplaner-api stadtplaner-frontend
+sudo systemctl list-timers 'stadtplaner-*'
+sudo nginx -t
+curl --fail https://api.stadtplaner.oklabflensburg.de/health
+```
+
+Für Nginx-Dry-Run-Limits:
+
+```bash
+grep REJECTED_DRY_RUN /var/log/nginx/access.log
+```
+
+## Was Ansible bewusst nicht verwaltet
+
+- globale `/etc/nginx/nginx.conf` für alle Projekte;
+- PostgreSQL-Cluster-/Rollen-/Firewall-Konfiguration des Shared Hosts;
+- Redis-Serverkonfiguration anderer Anwendungen;
+- Firewall/SSH des gesamten Servers;
+- DNS;
+- automatische Certbot-Ausstellung bei jedem Deploy;
+- OSM-Initialimport bei jedem Deploy;
+- echte Secrets im Repository;
+- automatische Datenbank-Downgrades.
+
+Diese Grenzen sind Absicht: Das Stadtplaner-Repository soll andere Dienste auf demselben Server nicht unbeabsichtigt verändern.

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -9,7 +9,7 @@ Für diesen Server ist ein idempotenter Deployment-Ablauf sicherer als wiederhol
 ## Aus dem Repository abgeleitete Produktionsarchitektur
 
 - Checkout: `/opt/git/open-city-planner`
-- Arbeits-/SSH-Benutzer: `awendelk` mit `become`
+- administrativer SSH-Zugang mit `become`; der konkrete Login bleibt lokale Operator-Konfiguration
 - Service-Benutzer: `oklab`
 - FastAPI: `127.0.0.1:8008`
 - Nuxt/Nitro: `127.0.0.1:3008`
@@ -36,12 +36,15 @@ python3 -m venv ~/.venvs/stadtplaner-ansible
 cd /pfad/zum/open-city-planner/deploy/ansible
 ```
 
-Der Inventory-Eintrag verwendet `89.58.56.254` und `awendelk`. SSH Host Keys bleiben absichtlich aktiviert. Test:
+Das committed Inventory verwendet den öffentlichen Stadtplaner-Hostnamen, aber absichtlich keinen SSH-Benutzernamen oder private SSH-Optionen. Für den aktuellen Operator kann der Login lokal gesetzt werden, zum Beispiel:
 
 ```bash
+export ANSIBLE_REMOTE_USER=awendelk
 ansible stadtplaner -m ping
 ansible stadtplaner -b -m command -a 'id'
 ```
+
+Alternativ kann der Login in `~/.ssh/config` oder einem nicht committeten lokalen Inventory gesetzt werden. SSH Host Keys bleiben absichtlich aktiviert.
 
 ## Einmalige Voraussetzungen
 
@@ -100,7 +103,7 @@ Am sichersten wird **ein konkreter Commit** deployed, nicht ein beweglicher Bran
 git fetch origin
 SHA=$(git rev-parse origin/main)
 cd deploy/ansible
-ansible-playbook playbooks/deploy.yml \
+ANSIBLE_REMOTE_USER=awendelk ansible-playbook playbooks/deploy.yml \
   -e stadtplaner_deploy_ref="$SHA" \
   -e @~/stadtplaner-vault.yml \
   --ask-vault-pass
@@ -133,7 +136,7 @@ CI sollte die Hauptqualitätsgrenze bleiben. Für ein besonders sensibles Releas
 -e stadtplaner_run_frontend_typecheck=true
 ```
 
-Diese Prüfungen verlängern das Produktionsdeployment und sind standardmäßig aus.
+Diese Prüfungen verlängern das Produktionsdeployment und sind standardmäßig aus. Für Backend-Pytest müssen die Development-Extras im produktiven Venv vorhanden sein; im Normalbetrieb wird deshalb die CI als Testgrenze empfohlen.
 
 ## Nginx und Rate Limits
 
@@ -160,7 +163,7 @@ Die Entwickler-Subdomain ist standardmäßig aus, damit ein fehlendes Zertifikat
 Nach gesetztem DNS zunächst einmalig:
 
 ```bash
-ansible-playbook playbooks/certificates.yml \
+ANSIBLE_REMOTE_USER=awendelk ansible-playbook playbooks/certificates.yml \
   -e stadtplaner_manage_certificates=true \
   -e stadtplaner_certbot_email=DEINE-ADMIN-MAIL
 ```
@@ -178,7 +181,7 @@ Normale Deployments führen Certbot nicht aus. Die reguläre Certbot-Renewal-Inf
 Der Initialimport ist absichtlich aus dem normalen Deployment ausgeschlossen. Er ist groß, extern datenabhängig und darf nur explizit gestartet werden:
 
 ```bash
-ansible-playbook playbooks/osm-initial-import.yml \
+ANSIBLE_REMOTE_USER=awendelk ansible-playbook playbooks/osm-initial-import.yml \
   -e confirm_osm_initial_import=true
 ```
 
@@ -204,7 +207,7 @@ Mastodon nur aktivieren, wenn die Backend-Konfiguration vollständig ist:
 Für Code ohne inkompatible Datenbankänderung kann ein zuvor bekannter Commit wieder deployed werden:
 
 ```bash
-ansible-playbook playbooks/deploy.yml \
+ANSIBLE_REMOTE_USER=awendelk ansible-playbook playbooks/deploy.yml \
   -e stadtplaner_deploy_ref=<previous-good-sha> \
   -e stadtplaner_run_migrations=false
 ```

--- a/deploy/ansible/ansible.cfg
+++ b/deploy/ansible/ansible.cfg
@@ -1,0 +1,12 @@
+[defaults]
+inventory = inventory/production.yml
+roles_path = roles
+host_key_checking = True
+retry_files_enabled = False
+interpreter_python = auto_silent
+stdout_callback = default
+timeout = 30
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/deploy/ansible/deploy-current.sh
+++ b/deploy/ansible/deploy-current.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git fetch origin main
+SHA="${STADTPLANER_DEPLOY_REF:-$(git rev-parse origin/main)}"
+VAULT_FILE="${STADTPLANER_VAULT_FILE:-}"
+
+cd deploy/ansible
+args=(playbooks/deploy.yml -e "stadtplaner_deploy_ref=${SHA}")
+
+if [[ -n "$VAULT_FILE" ]]; then
+  args+=( -e "@${VAULT_FILE}" --ask-vault-pass )
+fi
+
+printf 'Deploying Open City Planner commit %s\n' "$SHA"
+exec ansible-playbook "${args[@]}" "$@"

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -13,7 +13,6 @@ stadtplaner_backend_env_file: /etc/stadtplaner/backend.env
 stadtplaner_frontend_env_file: /etc/stadtplaner/frontend.env
 stadtplaner_osm_env_file: /etc/stadtplaner/osm-sync.env
 
-stadtplaner_manage_system_packages: false
 stadtplaner_manage_nginx: true
 stadtplaner_manage_background_timers: true
 stadtplaner_enable_osm_timer: true
@@ -32,6 +31,7 @@ stadtplaner_api_certificate_name: api.stadtplaner.oklabflensburg.de
 stadtplaner_developer_certificate_name: developer.stadtplaner.oklabflensburg.de
 
 stadtplaner_run_migrations: true
+stadtplaner_require_pre_migration_backup: true
 stadtplaner_run_frontend_typecheck: false
 stadtplaner_run_backend_tests: false
 stadtplaner_run_frontend_tests: false

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -1,0 +1,46 @@
+stadtplaner_repo_url: https://github.com/oklabflensburg/open-city-planner.git
+stadtplaner_repo_path: /opt/git/open-city-planner
+stadtplaner_deploy_ref: main
+stadtplaner_service_user: oklab
+stadtplaner_service_group: oklab
+stadtplaner_config_dir: /etc/stadtplaner
+stadtplaner_data_dir: /data/stadtplaner
+stadtplaner_social_dir: /data/stadtplaner-social
+
+stadtplaner_backend_port: 8008
+stadtplaner_frontend_port: 3008
+stadtplaner_backend_env_file: /etc/stadtplaner/backend.env
+stadtplaner_frontend_env_file: /etc/stadtplaner/frontend.env
+stadtplaner_osm_env_file: /etc/stadtplaner/osm-sync.env
+
+stadtplaner_manage_system_packages: false
+stadtplaner_manage_nginx: true
+stadtplaner_manage_background_timers: true
+stadtplaner_enable_osm_timer: true
+stadtplaner_enable_statistics_timer: true
+stadtplaner_enable_email_outbox_timer: true
+stadtplaner_enable_social_publisher_timer: false
+
+stadtplaner_public_host: stadtplaner.oklabflensburg.de
+stadtplaner_api_host: api.stadtplaner.oklabflensburg.de
+stadtplaner_developer_host: developer.stadtplaner.oklabflensburg.de
+stadtplaner_enable_developer_host: false
+stadtplaner_enable_rate_limit_dry_run: true
+
+stadtplaner_public_certificate_name: stadtplaner.oklabflensburg.de
+stadtplaner_api_certificate_name: api.stadtplaner.oklabflensburg.de
+stadtplaner_developer_certificate_name: developer.stadtplaner.oklabflensburg.de
+
+stadtplaner_run_migrations: true
+stadtplaner_run_frontend_typecheck: false
+stadtplaner_run_backend_tests: false
+stadtplaner_run_frontend_tests: false
+stadtplaner_require_clean_checkout: true
+
+# Set this to a command that creates a verified production backup before migrations.
+# It is intentionally empty by default; Ansible will never invent database credentials.
+stadtplaner_pre_migration_backup_command: ''
+
+# Certbot is opt-in and must never run on each normal deploy.
+stadtplaner_certbot_email: ''
+stadtplaner_manage_certificates: false

--- a/deploy/ansible/inventory/production.yml
+++ b/deploy/ansible/inventory/production.yml
@@ -3,6 +3,5 @@ all:
     stadtplaner:
       hosts:
         stadtplaner-prod:
-          ansible_host: 89.58.56.254
-          ansible_user: awendelk
+          ansible_host: stadtplaner.oklabflensburg.de
           ansible_become: true

--- a/deploy/ansible/inventory/production.yml
+++ b/deploy/ansible/inventory/production.yml
@@ -1,0 +1,8 @@
+all:
+  children:
+    stadtplaner:
+      hosts:
+        stadtplaner-prod:
+          ansible_host: 89.58.56.254
+          ansible_user: awendelk
+          ansible_become: true

--- a/deploy/ansible/playbooks/bootstrap.yml
+++ b/deploy/ansible/playbooks/bootstrap.yml
@@ -1,0 +1,60 @@
+---
+- name: Bootstrap Open City Planner host prerequisites
+  hosts: stadtplaner
+  become: true
+  serial: 1
+  tasks:
+    - name: Verify Python 3.12+
+      ansible.builtin.command:
+        argv: [python3, -c, "import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)"]
+      changed_when: false
+
+    - name: Verify Node 22
+      ansible.builtin.command: node --version
+      register: node_version
+      changed_when: false
+
+    - name: Require Node 22
+      ansible.builtin.assert:
+        that: node_version.stdout is match('^v22\\.')
+        fail_msg: "Install Node 22 using the shared server's package policy before deploying Stadtplaner."
+
+    - name: Verify required executables
+      ansible.builtin.command: "sh -lc 'command -v {{ item }}'"
+      changed_when: false
+      loop:
+        - git
+        - corepack
+        - nginx
+        - certbot
+        - psql
+        - redis-cli
+        - osm2pgsql
+        - osmium
+
+    - name: Ensure application parent directory exists
+      ansible.builtin.file:
+        path: "{{ stadtplaner_repo_path | dirname }}"
+        state: directory
+        owner: "{{ stadtplaner_service_user }}"
+        group: "{{ stadtplaner_service_group }}"
+        mode: '0755'
+
+    - name: Ensure persistent configuration directory exists
+      ansible.builtin.file:
+        path: "{{ stadtplaner_config_dir }}"
+        state: directory
+        owner: root
+        group: "{{ stadtplaner_service_group }}"
+        mode: '0750'
+
+    - name: Ensure persistent data directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ stadtplaner_service_user }}"
+        group: "{{ stadtplaner_service_group }}"
+        mode: '0750'
+      loop:
+        - "{{ stadtplaner_data_dir }}"
+        - "{{ stadtplaner_social_dir }}"

--- a/deploy/ansible/playbooks/certificates.yml
+++ b/deploy/ansible/playbooks/certificates.yml
@@ -1,0 +1,90 @@
+---
+- name: Issue developer documentation TLS certificate
+  hosts: stadtplaner
+  become: true
+  serial: 1
+  tasks:
+    - name: Require explicit certificate opt-in and contact email
+      ansible.builtin.assert:
+        that:
+          - stadtplaner_manage_certificates | bool
+          - stadtplaner_certbot_email | length > 3
+        fail_msg: >-
+          Certificate issuance is deliberately opt-in. Set
+          stadtplaner_manage_certificates=true and stadtplaner_certbot_email.
+
+    - name: Check whether developer certificate already exists
+      ansible.builtin.stat:
+        path: "/etc/letsencrypt/live/{{ stadtplaner_developer_certificate_name }}/fullchain.pem"
+      register: developer_certificate
+
+    - name: Create ACME webroot
+      ansible.builtin.file:
+        path: /var/www/letsencrypt
+        state: directory
+        owner: www-data
+        group: www-data
+        mode: '0755'
+      when: not developer_certificate.stat.exists
+
+    - name: Install temporary HTTP-only developer ACME vhost
+      ansible.builtin.copy:
+        dest: /etc/nginx/sites-available/stadtplaner-developer-acme
+        owner: root
+        group: root
+        mode: '0644'
+        content: |
+          server {
+              listen 80;
+              listen [::]:80;
+              server_name {{ stadtplaner_developer_host }};
+              location /.well-known/acme-challenge/ { root /var/www/letsencrypt; }
+              location / { return 404; }
+          }
+      when: not developer_certificate.stat.exists
+
+    - name: Enable temporary developer ACME vhost
+      ansible.builtin.file:
+        src: /etc/nginx/sites-available/stadtplaner-developer-acme
+        dest: /etc/nginx/sites-enabled/stadtplaner-developer-acme
+        state: link
+      when: not developer_certificate.stat.exists
+
+    - name: Validate nginx before certificate request
+      ansible.builtin.command: nginx -t
+      changed_when: false
+      when: not developer_certificate.stat.exists
+
+    - name: Reload nginx for ACME challenge
+      ansible.builtin.systemd_service:
+        name: nginx
+        state: reloaded
+      when: not developer_certificate.stat.exists
+
+    - name: Obtain developer certificate through webroot challenge
+      ansible.builtin.command:
+        argv:
+          - certbot
+          - certonly
+          - --webroot
+          - -w
+          - /var/www/letsencrypt
+          - -d
+          - "{{ stadtplaner_developer_host }}"
+          - --non-interactive
+          - --agree-tos
+          - --email
+          - "{{ stadtplaner_certbot_email }}"
+      when: not developer_certificate.stat.exists
+
+    - name: Remove temporary ACME vhost symlink
+      ansible.builtin.file:
+        path: /etc/nginx/sites-enabled/stadtplaner-developer-acme
+        state: absent
+      when: not developer_certificate.stat.exists
+
+    - name: Enable developer host for subsequent deploys
+      ansible.builtin.debug:
+        msg: >-
+          Certificate is available. Run deploy.yml with
+          -e stadtplaner_enable_developer_host=true to publish the developer subdomain.

--- a/deploy/ansible/playbooks/deploy.yml
+++ b/deploy/ansible/playbooks/deploy.yml
@@ -1,0 +1,8 @@
+---
+- name: Deploy Open City Planner production
+  hosts: stadtplaner
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  roles:
+    - role: stadtplaner

--- a/deploy/ansible/playbooks/osm-initial-import.yml
+++ b/deploy/ansible/playbooks/osm-initial-import.yml
@@ -1,0 +1,30 @@
+---
+- name: Run guarded OpenStreetMap initial import
+  hosts: stadtplaner
+  become: true
+  serial: 1
+  tasks:
+    - name: Require explicit destructive/expensive import confirmation
+      ansible.builtin.assert:
+        that: confirm_osm_initial_import | default(false) | bool
+        fail_msg: >-
+          OSM initial import is never part of a normal deployment. Rerun with
+          -e confirm_osm_initial_import=true after reviewing docs/osm-hourly-sync.md.
+
+    - name: Verify OSM environment exists
+      ansible.builtin.stat:
+        path: "{{ stadtplaner_osm_env_file }}"
+      register: osm_env
+
+    - name: Refuse import without OSM environment
+      ansible.builtin.assert:
+        that: osm_env.stat.exists
+        fail_msg: "Missing {{ stadtplaner_osm_env_file }}"
+
+    - name: Run repository initial import script
+      ansible.builtin.command:
+        cmd: "{{ stadtplaner_repo_path }}/scripts/osm/initial-import.sh"
+        chdir: "{{ stadtplaner_repo_path }}"
+      become_user: "{{ stadtplaner_service_user }}"
+      environment:
+        OSM_ENV_FILE: "{{ stadtplaner_osm_env_file }}"

--- a/deploy/ansible/roles/stadtplaner/handlers/main.yml
+++ b/deploy/ansible/roles/stadtplaner/handlers/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
+- name: Restart Stadtplaner API
+  ansible.builtin.systemd_service:
+    name: stadtplaner-api.service
+    state: restarted
+    daemon_reload: true
+
+- name: Restart Stadtplaner frontend
+  ansible.builtin.systemd_service:
+    name: stadtplaner-frontend.service
+    state: restarted
+    daemon_reload: true
+
+- name: Validate nginx configuration
+  ansible.builtin.command: nginx -t
+  changed_when: false
+  listen: Nginx configuration changed
+
+- name: Reload nginx
+  ansible.builtin.systemd_service:
+    name: nginx
+    state: reloaded
+  listen: Nginx configuration changed

--- a/deploy/ansible/roles/stadtplaner/tasks/main.yml
+++ b/deploy/ansible/roles/stadtplaner/tasks/main.yml
@@ -1,0 +1,403 @@
+---
+- name: Validate supported runtime versions
+  block:
+    - name: Validate Python 3.12+
+      ansible.builtin.command:
+        argv: [python3, -c, "import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)"]
+      changed_when: false
+
+    - name: Read Node version
+      ansible.builtin.command: node --version
+      register: stadtplaner_node_version
+      changed_when: false
+
+    - name: Require Node 22
+      ansible.builtin.assert:
+        that: stadtplaner_node_version.stdout is match('^v22\\.')
+        fail_msg: "Node 22 is required by the current CI/deployment baseline; found {{ stadtplaner_node_version.stdout }}"
+
+    - name: Read pnpm version through Corepack
+      ansible.builtin.command: corepack pnpm --version
+      register: stadtplaner_pnpm_version
+      changed_when: false
+
+    - name: Require pnpm 11
+      ansible.builtin.assert:
+        that: stadtplaner_pnpm_version.stdout is match('^11\\.')
+        fail_msg: "pnpm 11 is required; found {{ stadtplaner_pnpm_version.stdout }}"
+
+- name: Ensure service and configuration directories exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ stadtplaner_config_dir }}", owner: root, group: "{{ stadtplaner_service_group }}", mode: '0750' }
+    - { path: "{{ stadtplaner_data_dir }}", owner: "{{ stadtplaner_service_user }}", group: "{{ stadtplaner_service_group }}", mode: '0750' }
+    - { path: "{{ stadtplaner_social_dir }}", owner: "{{ stadtplaner_service_user }}", group: "{{ stadtplaner_service_group }}", mode: '0750' }
+
+- name: Install backend environment from encrypted variable when supplied
+  ansible.builtin.copy:
+    content: "{{ stadtplaner_backend_env_content }}"
+    dest: "{{ stadtplaner_backend_env_file }}"
+    owner: root
+    group: "{{ stadtplaner_service_group }}"
+    mode: '0640'
+  when: stadtplaner_backend_env_content is defined
+  no_log: true
+
+- name: Install frontend environment from encrypted variable when supplied
+  ansible.builtin.copy:
+    content: "{{ stadtplaner_frontend_env_content }}"
+    dest: "{{ stadtplaner_frontend_env_file }}"
+    owner: root
+    group: "{{ stadtplaner_service_group }}"
+    mode: '0640'
+  when: stadtplaner_frontend_env_content is defined
+  no_log: true
+
+- name: Install OSM environment from encrypted variable when supplied
+  ansible.builtin.copy:
+    content: "{{ stadtplaner_osm_env_content }}"
+    dest: "{{ stadtplaner_osm_env_file }}"
+    owner: root
+    group: "{{ stadtplaner_service_group }}"
+    mode: '0640'
+  when: stadtplaner_osm_env_content is defined
+  no_log: true
+
+- name: Verify required environment files exist
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: >-
+    {{ [stadtplaner_backend_env_file, stadtplaner_frontend_env_file]
+       + ([stadtplaner_osm_env_file] if stadtplaner_enable_osm_timer else []) }}
+  register: stadtplaner_env_stats
+
+- name: Refuse deployment without persistent environment files
+  ansible.builtin.assert:
+    that: item.stat.exists and item.stat.isreg
+    fail_msg: "Required environment file {{ item.item }} is missing. Use an encrypted external vault or create the server-side file first."
+  loop: "{{ stadtplaner_env_stats.results }}"
+  no_log: true
+
+- name: Update repository to the requested ref without discarding local changes
+  ansible.builtin.git:
+    repo: "{{ stadtplaner_repo_url }}"
+    dest: "{{ stadtplaner_repo_path }}"
+    version: "{{ stadtplaner_deploy_ref }}"
+    update: true
+    force: false
+  become_user: "{{ stadtplaner_service_user }}"
+  register: stadtplaner_git
+
+- name: Link persistent backend environment into the checkout
+  ansible.builtin.file:
+    src: "{{ stadtplaner_backend_env_file }}"
+    dest: "{{ stadtplaner_repo_path }}/backend/.env"
+    state: link
+    force: true
+
+- name: Link persistent frontend environment into the checkout
+  ansible.builtin.file:
+    src: "{{ stadtplaner_frontend_env_file }}"
+    dest: "{{ stadtplaner_repo_path }}/frontend/.env"
+    state: link
+    force: true
+
+- name: Ensure backend writable data directory exists
+  ansible.builtin.file:
+    path: "{{ stadtplaner_repo_path }}/backend/data"
+    state: directory
+    owner: "{{ stadtplaner_service_user }}"
+    group: "{{ stadtplaner_service_group }}"
+    mode: '0750'
+
+- name: Create backend virtual environment
+  ansible.builtin.command:
+    cmd: python3 -m venv .venv
+    chdir: "{{ stadtplaner_repo_path }}/backend"
+    creates: "{{ stadtplaner_repo_path }}/backend/.venv/bin/python"
+  become_user: "{{ stadtplaner_service_user }}"
+
+- name: Install backend production dependencies
+  ansible.builtin.command:
+    cmd: .venv/bin/python -m pip install -e .
+    chdir: "{{ stadtplaner_repo_path }}/backend"
+  become_user: "{{ stadtplaner_service_user }}"
+  notify: Restart Stadtplaner API
+
+- name: Run optional backend test suite before migration
+  ansible.builtin.command:
+    cmd: .venv/bin/python -m pytest
+    chdir: "{{ stadtplaner_repo_path }}/backend"
+  become_user: "{{ stadtplaner_service_user }}"
+  when: stadtplaner_run_backend_tests
+  changed_when: false
+
+- name: Install frontend dependencies from lockfile
+  ansible.builtin.command:
+    cmd: corepack pnpm install --frozen-lockfile
+    chdir: "{{ stadtplaner_repo_path }}/frontend"
+  become_user: "{{ stadtplaner_service_user }}"
+
+- name: Run optional frontend typecheck
+  ansible.builtin.command:
+    cmd: corepack pnpm typecheck
+    chdir: "{{ stadtplaner_repo_path }}/frontend"
+  become_user: "{{ stadtplaner_service_user }}"
+  when: stadtplaner_run_frontend_typecheck
+  changed_when: false
+
+- name: Run optional frontend unit tests
+  ansible.builtin.command:
+    cmd: corepack pnpm test
+    chdir: "{{ stadtplaner_repo_path }}/frontend"
+  become_user: "{{ stadtplaner_service_user }}"
+  when: stadtplaner_run_frontend_tests
+  changed_when: false
+
+- name: Build production frontend
+  ansible.builtin.command:
+    cmd: corepack pnpm build
+    chdir: "{{ stadtplaner_repo_path }}/frontend"
+  become_user: "{{ stadtplaner_service_user }}"
+  environment:
+    NODE_ENV: production
+  notify: Restart Stadtplaner frontend
+
+- name: Require configured backup before migrations
+  ansible.builtin.assert:
+    that: stadtplaner_pre_migration_backup_command | length > 0
+    fail_msg: >-
+      Migrations are enabled but no pre-migration backup command is configured.
+      Set stadtplaner_pre_migration_backup_command or explicitly set stadtplaner_run_migrations=false.
+  when:
+    - stadtplaner_run_migrations
+    - stadtplaner_require_pre_migration_backup | default(true)
+
+- name: Create pre-migration database backup
+  ansible.builtin.shell: "{{ stadtplaner_pre_migration_backup_command }}"
+  args:
+    executable: /bin/bash
+  when:
+    - stadtplaner_run_migrations
+    - stadtplaner_pre_migration_backup_command | length > 0
+  changed_when: true
+  no_log: true
+
+- name: Apply Alembic migrations
+  ansible.builtin.command:
+    cmd: .venv/bin/alembic upgrade head
+    chdir: "{{ stadtplaner_repo_path }}/backend"
+  become_user: "{{ stadtplaner_service_user }}"
+  when: stadtplaner_run_migrations
+  notify: Restart Stadtplaner API
+
+- name: Install primary systemd units
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "/etc/systemd/system/{{ item.dest }}"
+    owner: root
+    group: root
+    mode: '0644'
+  loop:
+    - { src: stadtplaner-api.service.j2, dest: stadtplaner-api.service }
+    - { src: stadtplaner-frontend.service.j2, dest: stadtplaner-frontend.service }
+  notify:
+    - Reload systemd
+    - Restart Stadtplaner API
+    - Restart Stadtplaner frontend
+
+- name: Define background services
+  ansible.builtin.set_fact:
+    stadtplaner_background_services:
+      - name: stadtplaner-osm-update
+        description: Stadtplaner OpenStreetMap replication update
+        enabled: "{{ stadtplaner_enable_osm_timer }}"
+        working_directory: "{{ stadtplaner_repo_path }}"
+        environment_file: "{{ stadtplaner_osm_env_file }}"
+        exec_start: "{{ stadtplaner_repo_path }}/scripts/osm/update.sh"
+        read_write_paths: ["{{ stadtplaner_data_dir }}"]
+        timer_description: Run Stadtplaner OpenStreetMap synchronization hourly
+        on_boot: 10m
+        on_unit_active: 1h
+        on_calendar: ''
+        accuracy: 1m
+        randomized_delay: 5m
+      - name: stadtplaner-flensburg-statistics-sync
+        description: Stadtplaner Flensburg statistics synchronization
+        enabled: "{{ stadtplaner_enable_statistics_timer }}"
+        working_directory: "{{ stadtplaner_repo_path }}/backend"
+        environment_file: "{{ stadtplaner_backend_env_file }}"
+        exec_start: "{{ stadtplaner_repo_path }}/backend/.venv/bin/python -m app.cli.import_flensburg_statistics"
+        read_write_paths: ["{{ stadtplaner_repo_path }}/backend/data"]
+        timer_description: Weekly check for updated Flensburg statistics
+        on_boot: ''
+        on_unit_active: ''
+        on_calendar: 'Mon *-*-* 03:15:00 Europe/Berlin'
+        accuracy: 1m
+        randomized_delay: 30m
+      - name: stadtplaner-email-outbox
+        description: Stadtplaner E-Mail-Outbox verarbeiten
+        enabled: "{{ stadtplaner_enable_email_outbox_timer }}"
+        working_directory: "{{ stadtplaner_repo_path }}/backend"
+        environment_file: "{{ stadtplaner_backend_env_file }}"
+        exec_start: "{{ stadtplaner_repo_path }}/backend/.venv/bin/python -m app.cli.process_email_outbox --limit 20"
+        read_write_paths: []
+        timer_description: Fällige Stadtplaner-E-Mails regelmäßig versenden
+        on_boot: 1m
+        on_unit_active: 1m
+        on_calendar: ''
+        accuracy: 10s
+        randomized_delay: ''
+      - name: stadtplaner-social-publisher
+        description: Stadtplaner Mastodon outbox publisher
+        enabled: "{{ stadtplaner_enable_social_publisher_timer }}"
+        working_directory: "{{ stadtplaner_repo_path }}/backend"
+        environment_file: "{{ stadtplaner_backend_env_file }}"
+        exec_start: "{{ stadtplaner_repo_path }}/backend/.venv/bin/python -m app.cli.publish_social_outbox --limit 20"
+        read_write_paths: ["{{ stadtplaner_social_dir }}"]
+        timer_description: Publish due Stadtplaner Mastodon outbox events
+        on_boot: 2m
+        on_unit_active: 1m
+        on_calendar: ''
+        accuracy: 10s
+        randomized_delay: ''
+  when: stadtplaner_manage_background_timers
+
+- name: Install background oneshot services
+  ansible.builtin.template:
+    src: oneshot.service.j2
+    dest: "/etc/systemd/system/{{ item.name }}.service"
+    owner: root
+    group: root
+    mode: '0644'
+  vars:
+    unit_description: "{{ item.description }}"
+    unit_working_directory: "{{ item.working_directory }}"
+    unit_environment_file: "{{ item.environment_file }}"
+    unit_exec_start: "{{ item.exec_start }}"
+    unit_read_write_paths: "{{ item.read_write_paths }}"
+  loop: "{{ stadtplaner_background_services | default([]) }}"
+  when: stadtplaner_manage_background_timers
+  notify: Reload systemd
+
+- name: Install background timers
+  ansible.builtin.template:
+    src: timer.timer.j2
+    dest: "/etc/systemd/system/{{ item.name }}.timer"
+    owner: root
+    group: root
+    mode: '0644'
+  vars:
+    timer_description: "{{ item.timer_description }}"
+    timer_on_boot: "{{ item.on_boot }}"
+    timer_on_unit_active: "{{ item.on_unit_active }}"
+    timer_on_calendar: "{{ item.on_calendar }}"
+    timer_accuracy: "{{ item.accuracy }}"
+    timer_randomized_delay: "{{ item.randomized_delay }}"
+    timer_service: "{{ item.name }}.service"
+  loop: "{{ stadtplaner_background_services | default([]) }}"
+  when: stadtplaner_manage_background_timers
+  notify: Reload systemd
+
+- name: Enable or disable background timers according to configuration
+  ansible.builtin.systemd_service:
+    name: "{{ item.name }}.timer"
+    enabled: "{{ item.enabled | bool }}"
+    state: "{{ 'started' if (item.enabled | bool) else 'stopped' }}"
+    daemon_reload: true
+  loop: "{{ stadtplaner_background_services | default([]) }}"
+  when: stadtplaner_manage_background_timers
+
+- name: Install Stadtplaner nginx rate-limit zones
+  ansible.builtin.copy:
+    src: "{{ stadtplaner_repo_path }}/deploy/nginx/conf.d/stadtplaner-rate-limits.conf"
+    dest: /etc/nginx/conf.d/stadtplaner-rate-limits.conf
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0644'
+  when: stadtplaner_manage_nginx
+  notify: Nginx configuration changed
+
+- name: Verify required TLS certificates before writing nginx vhost
+  ansible.builtin.stat:
+    path: "/etc/letsencrypt/live/{{ item }}/fullchain.pem"
+  loop: >-
+    {{ [stadtplaner_public_certificate_name, stadtplaner_api_certificate_name]
+       + ([stadtplaner_developer_certificate_name] if stadtplaner_enable_developer_host else []) }}
+  register: stadtplaner_certificate_stats
+  when: stadtplaner_manage_nginx
+
+- name: Refuse nginx rollout with missing certificate
+  ansible.builtin.assert:
+    that: item.stat.exists
+    fail_msg: "TLS certificate {{ item.item }} is missing; issue it first with playbooks/certificates.yml."
+  loop: "{{ stadtplaner_certificate_stats.results | default([]) }}"
+  when: stadtplaner_manage_nginx
+
+- name: Install managed Stadtplaner nginx vhost
+  ansible.builtin.template:
+    src: stadtplaner.nginx.conf.j2
+    dest: /etc/nginx/sites-available/stadtplaner
+    owner: root
+    group: root
+    mode: '0644'
+  when: stadtplaner_manage_nginx
+  notify: Nginx configuration changed
+
+- name: Enable managed Stadtplaner nginx vhost
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/stadtplaner
+    dest: /etc/nginx/sites-enabled/stadtplaner
+    state: link
+  when: stadtplaner_manage_nginx
+  notify: Nginx configuration changed
+
+- name: Enable and start primary application services
+  ansible.builtin.systemd_service:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+    daemon_reload: true
+  loop:
+    - stadtplaner-api.service
+    - stadtplaner-frontend.service
+
+- name: Apply pending service and nginx handlers before smoke tests
+  ansible.builtin.meta: flush_handlers
+
+- name: Wait for local API listener
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ stadtplaner_backend_port }}"
+    timeout: 30
+
+- name: Verify API health
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ stadtplaner_backend_port }}/health"
+    status_code: 200
+    return_content: true
+  register: stadtplaner_health
+  failed_when: >-
+    stadtplaner_health.status != 200 or
+    (stadtplaner_health.json.status | default('')) != 'ok'
+
+- name: Wait for local frontend listener
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ stadtplaner_frontend_port }}"
+    timeout: 30
+
+- name: Verify frontend root
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ stadtplaner_frontend_port }}/"
+    status_code: 200
+
+- name: Report deployed revision
+  ansible.builtin.debug:
+    msg: "Deployed {{ stadtplaner_git.after | default(stadtplaner_deploy_ref) }} to {{ inventory_hostname }}"

--- a/deploy/ansible/roles/stadtplaner/templates/oneshot.service.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/oneshot.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description={{ unit_description }}
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User={{ stadtplaner_service_user }}
+Group={{ stadtplaner_service_group }}
+WorkingDirectory={{ unit_working_directory }}
+{% if unit_environment_file %}EnvironmentFile={{ unit_environment_file }}
+{% endif %}ExecStart={{ unit_exec_start }}
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+{% if unit_read_write_paths | length > 0 %}ReadWritePaths={{ unit_read_write_paths | join(' ') }}
+{% endif %}UMask=0027

--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner-api.service.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner-api.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Open City Planner FastAPI API
+After=network-online.target postgresql.service redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ stadtplaner_service_user }}
+Group={{ stadtplaner_service_group }}
+WorkingDirectory={{ stadtplaner_repo_path }}/backend
+EnvironmentFile={{ stadtplaner_backend_env_file }}
+ExecStart={{ stadtplaner_repo_path }}/backend/.venv/bin/uvicorn app.main:app --host 127.0.0.1 --port {{ stadtplaner_backend_port }} --proxy-headers --forwarded-allow-ips=127.0.0.1,::1
+Restart=on-failure
+RestartSec=3
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths={{ stadtplaner_repo_path }}/backend/data {{ stadtplaner_data_dir }} {{ stadtplaner_social_dir }}
+UMask=0027
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner-frontend.service.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner-frontend.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=Open City Planner Nuxt frontend
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ stadtplaner_service_user }}
+Group={{ stadtplaner_service_group }}
+WorkingDirectory={{ stadtplaner_repo_path }}/frontend
+EnvironmentFile={{ stadtplaner_frontend_env_file }}
+Environment=NODE_ENV=production
+Environment=HOST=127.0.0.1
+Environment=PORT={{ stadtplaner_frontend_port }}
+Environment=NITRO_HOST=127.0.0.1
+Environment=NITRO_PORT={{ stadtplaner_frontend_port }}
+ExecStart=/usr/bin/node {{ stadtplaner_repo_path }}/frontend/.output/server/index.mjs
+Restart=on-failure
+RestartSec=3
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+UMask=0027
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner.nginx.conf.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner.nginx.conf.j2
@@ -1,0 +1,145 @@
+upstream stadtplaner_frontend {
+    server 127.0.0.1:{{ stadtplaner_frontend_port }};
+    keepalive 32;
+}
+
+upstream stadtplaner_api {
+    server 127.0.0.1:{{ stadtplaner_backend_port }};
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name {{ stadtplaner_public_host }};
+
+    location / {
+        proxy_pass http://stadtplaner_frontend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $stadtplaner_connection_upgrade;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    ssl_certificate /etc/letsencrypt/live/{{ stadtplaner_public_certificate_name }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ stadtplaner_public_certificate_name }}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+{% if stadtplaner_enable_developer_host %}
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name {{ stadtplaner_developer_host }};
+
+    location / {
+        proxy_pass http://stadtplaner_frontend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $stadtplaner_connection_upgrade;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    ssl_certificate /etc/letsencrypt/live/{{ stadtplaner_developer_certificate_name }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ stadtplaner_developer_certificate_name }}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+{% endif %}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name {{ stadtplaner_api_host }};
+
+    limit_req_dry_run {{ 'on' if stadtplaner_enable_rate_limit_dry_run else 'off' }};
+
+    location = /health {
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 10s;
+    }
+
+    location = /api/v1/assistant/query {
+        limit_req zone=stadtplaner_assistant_per_ip burst=20 nodelay;
+        limit_req_status 429;
+        limit_req_log_level notice;
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 35s;
+        proxy_read_timeout 35s;
+    }
+
+    location ^~ /api/v1/auth/ {
+        limit_req zone=stadtplaner_auth_per_ip burst=20 nodelay;
+        limit_req_status 429;
+        limit_req_log_level notice;
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location / {
+        limit_req zone=stadtplaner_api_per_ip burst=100 nodelay;
+        limit_req zone=stadtplaner_api_global burst=500 nodelay;
+        limit_req_status 429;
+        limit_req_log_level notice;
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $stadtplaner_connection_upgrade;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    ssl_certificate /etc/letsencrypt/live/{{ stadtplaner_api_certificate_name }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ stadtplaner_api_certificate_name }}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{ stadtplaner_public_host }} {{ stadtplaner_api_host }}{% if stadtplaner_enable_developer_host %} {{ stadtplaner_developer_host }}{% endif %};
+    return 301 https://$host$request_uri;
+}

--- a/deploy/ansible/roles/stadtplaner/templates/timer.timer.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/timer.timer.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description={{ timer_description }}
+
+[Timer]
+{% if timer_on_boot %}OnBootSec={{ timer_on_boot }}
+{% endif %}{% if timer_on_unit_active %}OnUnitActiveSec={{ timer_on_unit_active }}
+{% endif %}{% if timer_on_calendar %}OnCalendar={{ timer_on_calendar }}
+{% endif %}AccuracySec={{ timer_accuracy }}
+Persistent=true
+Unit={{ timer_service }}
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ansible/roles/stadtplaner/templates/timer.timer.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/timer.timer.j2
@@ -6,7 +6,8 @@ Description={{ timer_description }}
 {% endif %}{% if timer_on_unit_active %}OnUnitActiveSec={{ timer_on_unit_active }}
 {% endif %}{% if timer_on_calendar %}OnCalendar={{ timer_on_calendar }}
 {% endif %}AccuracySec={{ timer_accuracy }}
-Persistent=true
+{% if timer_randomized_delay %}RandomizedDelaySec={{ timer_randomized_delay }}
+{% endif %}Persistent=true
 Unit={{ timer_service }}
 
 [Install]

--- a/deploy/ansible/vault.example.yml
+++ b/deploy/ansible/vault.example.yml
@@ -3,7 +3,9 @@
 # Pass it with:
 #   ansible-playbook playbooks/deploy.yml -e @/path/to/stadtplaner-vault.yml --ask-vault-pass
 #
-# The values below are whole .env file payloads. Do not commit real secrets.
+# The values below are a MINIMAL orientation, not a replacement for comparing
+# the production environment with backend/.env.example and frontend/.env.example.
+# Do not commit real secrets.
 
 stadtplaner_backend_env_content: |
   APP_ENVIRONMENT=production
@@ -11,13 +13,17 @@ stadtplaner_backend_env_content: |
   API_BASE_URL=https://api.stadtplaner.oklabflensburg.de
   CORS_ORIGINS=https://stadtplaner.oklabflensburg.de
   DATABASE_URL=REPLACE_ME
-  JWT_SECRET_KEY=REPLACE_ME
-  OAUTH_STATE_SECRET=REPLACE_ME
-  MFA_RECOVERY_PEPPER=REPLACE_ME
+  JWT_SECRET_KEY=REPLACE_WITH_32_PLUS_RANDOM_CHARS
+  JWT_ISSUER=https://api.stadtplaner.oklabflensburg.de
+  OAUTH_STATE_SECRET=REPLACE_WITH_DISTINCT_32_PLUS_RANDOM_CHARS
+  MFA_RECOVERY_PEPPER=REPLACE_WITH_DISTINCT_32_PLUS_RANDOM_CHARS
   AUTH_COOKIE_SECURE=true
   REFRESH_REQUIRE_ORIGIN=true
   AUTH_RATE_LIMIT_BACKEND=redis
   RATE_LIMIT_FAIL_CLOSED=true
+  REQUIRE_MFA_FOR_SUPERUSERS=true
+  WEBAUTHN_RP_ID=stadtplaner.oklabflensburg.de
+  WEBAUTHN_ORIGIN=https://stadtplaner.oklabflensburg.de
   REDIS_ENABLED=true
   REDIS_REQUIRED=true
   REDIS_URL=redis://127.0.0.1:6379/0
@@ -30,5 +36,9 @@ stadtplaner_frontend_env_content: |
 
 # OSM replication uses a separate shell-compatible environment file.
 stadtplaner_osm_env_content: |
-  # Copy the actual values from deploy/osm-sync.env.example and adjust them.
-  # Never place database passwords in this example file.
+  # Copy the required values from deploy/osm-sync.env.example and adjust them.
+  # Never place real database passwords in this example file.
+
+# Example only: point this at a root-owned backup wrapper that exits non-zero
+# unless a verified backup was written successfully.
+stadtplaner_pre_migration_backup_command: /usr/local/sbin/stadtplaner-backup-before-deploy

--- a/deploy/ansible/vault.example.yml
+++ b/deploy/ansible/vault.example.yml
@@ -1,0 +1,34 @@
+# Copy this file OUTSIDE the repository, fill it, then encrypt it with:
+#   ansible-vault encrypt /path/to/stadtplaner-vault.yml
+# Pass it with:
+#   ansible-playbook playbooks/deploy.yml -e @/path/to/stadtplaner-vault.yml --ask-vault-pass
+#
+# The values below are whole .env file payloads. Do not commit real secrets.
+
+stadtplaner_backend_env_content: |
+  APP_ENVIRONMENT=production
+  APP_BASE_URL=https://stadtplaner.oklabflensburg.de
+  API_BASE_URL=https://api.stadtplaner.oklabflensburg.de
+  CORS_ORIGINS=https://stadtplaner.oklabflensburg.de
+  DATABASE_URL=REPLACE_ME
+  JWT_SECRET_KEY=REPLACE_ME
+  OAUTH_STATE_SECRET=REPLACE_ME
+  MFA_RECOVERY_PEPPER=REPLACE_ME
+  AUTH_COOKIE_SECURE=true
+  REFRESH_REQUIRE_ORIGIN=true
+  AUTH_RATE_LIMIT_BACKEND=redis
+  RATE_LIMIT_FAIL_CLOSED=true
+  REDIS_ENABLED=true
+  REDIS_REQUIRED=true
+  REDIS_URL=redis://127.0.0.1:6379/0
+  CACHE_PREFIX=stadtplaner:prod
+  TRUSTED_PROXIES=127.0.0.1,::1
+
+stadtplaner_frontend_env_content: |
+  NUXT_PUBLIC_SITE_URL=https://stadtplaner.oklabflensburg.de
+  NUXT_PUBLIC_API_BASE_URL=https://api.stadtplaner.oklabflensburg.de/api/v1
+
+# OSM replication uses a separate shell-compatible environment file.
+stadtplaner_osm_env_content: |
+  # Copy the actual values from deploy/osm-sync.env.example and adjust them.
+  # Never place database passwords in this example file.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 ## Betrieb und Integrationen
 
 - [Deployment und Betrieb](deployment.md)
+- [Wiederholbares Ansible-Deployment](../deploy/ansible/README.md)
+- [Nginx-Hardening und Rate Limits](../deploy/nginx/README.md)
 - [Social Publishing mit Mastodon](social-publishing.md)
 - [Produktions-Sicherheitscheckliste](security/production-checklist.md)
 - [Zwei-Faktor-Authentifizierung](security/mfa.md)


### PR DESCRIPTION
## Überblick

Dieser PR führt ein reproduzierbares, bewusst konservatives Ansible-Deployment für den bestehenden Stadtplaner-Produktionshost ein. Ziel ist, nach einem Push einen konkreten Commit deployen zu können, ohne wiederholt manuell Nginx, systemd, Builds, Migrationen, Timer und Smoke Tests anfassen zu müssen.

## Aus dem aktuellen Repo abgeleitet

- Nuxt/Nitro Frontend auf `127.0.0.1:3008`
- FastAPI auf `127.0.0.1:8008`
- PostgreSQL/PostGIS als fachliche Datenbank
- Redis als Cache und produktive Rate-Limit-Infrastruktur
- OSM-Import/-Replikation aus `scripts/osm/`
- systemd-Timer für OSM, Statistik, E-Mail-Outbox und optional Mastodon
- vorhandene gehärtete Nginx-/Rate-Limit-Konfiguration unter `deploy/nginx/`
- Backend-Environment aus `backend/.env`, das nun auf eine persistente Datei unter `/etc/stadtplaner/` verlinkt werden kann

## Enthalten

- `deploy/ansible/` mit Inventory über den öffentlichen Stadtplaner-Hostnamen; der Operator-Login wird bewusst lokal gesetzt, z. B. `ANSIBLE_REMOTE_USER=awendelk`
- normaler `deploy.yml` für exakte Git-Refs/Commit-SHAs
- konservatives `bootstrap.yml`, das auf dem Shared Host nur Voraussetzungen validiert und Stadtplaner-Verzeichnisse anlegt
- systemd-Templates für API und Nuxt-Frontend
- parametrisierte Background-Units/Timer statt der bisherigen unterschiedlichen Hardcodings (`oklab`/`stadtplaner`, `/opt/git/...`/`/opt/stadtplaner`)
- Stadtplaner-spezifisches Nginx-Template mit Rate-Limit-Dry-Run und optionaler Developer-Subdomain
- getrenntes, explizit opt-in `certificates.yml`
- getrenntes, explizit bestätigungspflichtiges `osm-initial-import.yml`
- externe/verschlüsselte Vault-Unterstützung; keine Secrets im Repo
- verpflichtender Backup-Guard vor Alembic-Migrationen
- lokale API-/Frontend-Smoke-Tests nach Restart
- CI-Workflow mit `ansible-playbook --syntax-check` für alle Playbooks
- Dokumentation und Verlinkung aus README/docs

## Sicherheitsgrenzen

Das Ansible-Setup verwaltet absichtlich **nicht** die globale `/etc/nginx/nginx.conf`, PostgreSQL-Clusterkonfiguration, Redis-Konfiguration, Firewall/SSH oder DNS des Shared Hosts. OSM-Initialimport und Certbot laufen niemals bei einem normalen Deploy. Datenbank-Downgrades werden nicht automatisiert.

## Normaler Ablauf

```bash
git fetch origin
SHA=$(git rev-parse origin/main)
cd deploy/ansible
ANSIBLE_REMOTE_USER=awendelk ansible-playbook playbooks/deploy.yml \
  -e stadtplaner_deploy_ref="$SHA" \
  -e @~/stadtplaner-vault.yml \
  --ask-vault-pass
```

Die vollständige Betriebsanleitung steht in `deploy/ansible/README.md`.

## Vor Merge

Bitte den neuen `Ansible`-Workflow abwarten. Er führt Syntax-Checks aller vier Playbooks aus. Danach sollte der erste Produktionslauf zunächst mit Nginx Rate-Limit-Dry-Run und Developer-Subdomain deaktiviert erfolgen.