### PR TITLE
Fix readiness checks for database and required dependencies

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -171,6 +171,7 @@ class Settings(BaseSettings):
     database_pool_size: int = 10
     database_max_overflow: int = 20
     database_pool_timeout_seconds: float = 15.0
+    database_health_timeout_seconds: float = Field(default=2.0, ge=0.25, le=10.0)
     mastodon_enabled: bool = False
     mastodon_base_url: str = "https://norden.social"
     mastodon_access_token: str | None = None

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,5 +1,8 @@
+import asyncio
 from collections.abc import AsyncGenerator
 
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import get_settings
@@ -13,6 +16,16 @@ engine = create_async_engine(
     pool_timeout=settings.database_pool_timeout_seconds,
 )
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+async def database_health() -> str:
+    try:
+        async with asyncio.timeout(settings.database_health_timeout_seconds):
+            async with engine.connect() as connection:
+                await connection.execute(text("SELECT 1"))
+        return "ok"
+    except (TimeoutError, OSError, SQLAlchemyError):
+        return "down"
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from app.api.router import api_router
 from app.cache.redis import close_redis, initialize_redis, redis_health
 from app.core.config import get_settings
+from app.db.session import database_health
 from app.security.request_limits import RequestBodyLimitMiddleware
 from app.services.assistant_provider import close_assistant_provider
 
@@ -154,6 +155,37 @@ async def security_headers(request: Request, call_next) -> Response:
     return response
 
 
+async def health_status() -> tuple[bool, dict[str, str]]:
+    database = await database_health()
+    redis = await redis_health()
+
+    database_ok = database == "ok"
+    redis_ok = True
+    if settings.redis_required:
+        redis_ok = redis == "ok"
+    elif settings.redis_enabled:
+        redis_ok = redis in {"ok", "degraded", "disabled"}
+    elif settings.redis_required:
+        redis_ok = False
+
+    ready = database_ok and redis_ok
+    payload = {"status": "ok" if ready else "not_ready", "database": database, "redis": redis}
+    return ready, payload
+
+
+@app.get("/health/live", tags=["health"])
+async def health_live() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/health/ready", tags=["health"])
+async def health_ready() -> Response:
+    ready, payload = await health_status()
+    if ready:
+        return JSONResponse(status_code=200, content=payload)
+    return JSONResponse(status_code=503, content=payload)
+
+
 @app.get("/health", tags=["health"])
-async def health() -> dict[str, str]:
-    return {"status": "ok", "database": "ok", "redis": await redis_health()}
+async def health() -> Response:
+    return await health_ready()

--- a/backend/tests/test_health_endpoints.py
+++ b/backend/tests/test_health_endpoints.py
@@ -1,0 +1,89 @@
+import httpx
+import pytest
+
+from app import main as main_module
+
+
+@pytest.mark.asyncio
+async def test_health_live_is_liveness_only() -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=main_module.app),
+        base_url="https://api.stadtplaner.oklabflensburg.de",
+    ) as client:
+        response = await client.get("/health/live")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_health_ready_reports_database_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_database_health() -> str:
+        return "down"
+
+    async def fake_redis_health() -> str:
+        return "disabled"
+
+    monkeypatch.setattr(main_module, "database_health", fake_database_health)
+    monkeypatch.setattr(main_module, "redis_health", fake_redis_health)
+    monkeypatch.setattr(main_module.settings, "redis_enabled", False, raising=False)
+    monkeypatch.setattr(main_module.settings, "redis_required", False, raising=False)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=main_module.app),
+        base_url="https://api.stadtplaner.oklabflensburg.de",
+    ) as client:
+        response = await client.get("/health/ready")
+
+    assert response.status_code == 503
+    assert response.json()["status"] == "not_ready"
+    assert response.json()["database"] == "down"
+    assert response.json()["redis"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_health_ready_uses_required_redis_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_database_health() -> str:
+        return "ok"
+
+    async def fake_redis_health() -> str:
+        return "degraded"
+
+    monkeypatch.setattr(main_module, "database_health", fake_database_health)
+    monkeypatch.setattr(main_module, "redis_health", fake_redis_health)
+    monkeypatch.setattr(main_module.settings, "redis_enabled", True, raising=False)
+    monkeypatch.setattr(main_module.settings, "redis_required", True, raising=False)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=main_module.app),
+        base_url="https://api.stadtplaner.oklabflensburg.de",
+    ) as client:
+        response = await client.get("/health/ready")
+
+    assert response.status_code == 503
+    assert response.json()["status"] == "not_ready"
+    assert response.json()["database"] == "ok"
+    assert response.json()["redis"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_health_ready_allows_optional_redis_degradation(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_database_health() -> str:
+        return "ok"
+
+    async def fake_redis_health() -> str:
+        return "degraded"
+
+    monkeypatch.setattr(main_module, "database_health", fake_database_health)
+    monkeypatch.setattr(main_module, "redis_health", fake_redis_health)
+    monkeypatch.setattr(main_module.settings, "redis_enabled", True, raising=False)
+    monkeypatch.setattr(main_module.settings, "redis_required", False, raising=False)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=main_module.app),
+        base_url="https://api.stadtplaner.oklabflensburg.de",
+    ) as client:
+        response = await client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "database": "ok", "redis": "degraded"}

--- a/deploy/ansible/roles/stadtplaner/tasks/main.yml
+++ b/deploy/ansible/roles/stadtplaner/tasks/main.yml
@@ -520,9 +520,9 @@
     port: "{{ stadtplaner_backend_port }}"
     timeout: 30
 
-- name: Verify API health
+- name: Verify API readiness
   ansible.builtin.uri:
-    url: "http://127.0.0.1:{{ stadtplaner_backend_port }}/health"
+    url: "http://127.0.0.1:{{ stadtplaner_backend_port }}/health/ready"
     status_code: 200
     return_content: true
   register: stadtplaner_health

--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner.nginx.conf.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner.nginx.conf.j2
@@ -69,7 +69,7 @@ server {
 
     limit_req_dry_run {{ 'on' if stadtplaner_enable_rate_limit_dry_run else 'off' }};
 
-    location = /health {
+    location = /health/live {
         proxy_pass http://stadtplaner_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -78,6 +78,21 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
+    }
+
+    location = /health/ready {
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 10s;
+    }
+
+    location = /health {
+        return 301 /health/ready;
     }
 
     location = /api/v1/assistant/query {

--- a/deploy/nginx/sites-available/stadtplaner.conf
+++ b/deploy/nginx/sites-available/stadtplaner.conf
@@ -98,7 +98,7 @@ server {
     # Do not duplicate Access-Control-* handling in nginx.
 
     # Monitoring must not be hidden behind the public request limiter.
-    location = /health {
+    location = /health/live {
         proxy_pass http://stadtplaner_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -107,6 +107,21 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
+    }
+
+    location = /health/ready {
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 10s;
+    }
+
+    location = /health {
+        return 301 /health/ready;
     }
 
     # Assistant: expensive path, separate outer limit. A legitimate user can

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@ Diese Anleitung bündelt den produktiven Betrieb des aktuellen Repositorys. Spez
 ## Architektur
 
 - Das Nuxt-Frontend wird als eigener Produktionsprozess betrieben.
-- FastAPI stellt die API und `/health` bereit.
+- FastAPI stellt die API, `/health/live` und `/health/ready` bereit.
 - PostgreSQL mit PostGIS ist die fachliche Datenbank.
 - Redis dient als Cache und als gemeinsames Backend für produktive Sicherheitszähler. Er ist keine fachliche Datenquelle.
 - Ein Reverse Proxy veröffentlicht Frontend und API über HTTPS.
@@ -181,12 +181,13 @@ Installieren Sie nur Integrationen, die konfiguriert und benötigt werden. Die `
 ## Sichere Smoke Tests
 
 ```bash
-curl --fail --silent https://<api-origin>/health
+curl --fail --silent https://<api-origin>/health/live
+curl --fail --silent https://<api-origin>/health/ready
 curl --fail --silent https://<frontend-origin>/
 curl --fail --silent https://<frontend-origin>/dokumentation
 ```
 
-Prüfen Sie anschließend im Browser Karte, Gebietsseite, Dokumentationssuche und ausschließlich lesende Suchanfragen wie „Alle Stadtteile anzeigen“ oder „Wie viele POIs gibt es in der Altstadt?“. Führen Sie keine mutierenden E2E-Tests gegen Produktion aus.
+`/health/live` prüft ausschließlich den Prozesszustand, `/health/ready` prüft PostgreSQL und alle gemäß Konfiguration erforderlichen Abhängigkeiten. Der Readiness-Endpunkt liefert nur strukturierte Zustände, keine Verbindungsdetails oder Secrets. Prüfen Sie anschließend im Browser Karte, Gebietsseite, Dokumentationssuche und ausschließlich lesende Suchanfragen wie „Alle Stadtteile anzeigen“ oder „Wie viele POIs gibt es in der Altstadt?“. Führen Sie keine mutierenden E2E-Tests gegen Produktion aus.
 
 ## Rollback
 


### PR DESCRIPTION
## Why
The API reported a healthy status even when PostgreSQL was unavailable, and required Redis could degrade without the readiness check failing. That allowed broken deployments to pass smoke tests and direct traffic to unhealthy services.

## What changed
- Added distinct `/health/live` and `/health/ready` endpoints.
- `/health/ready` now performs a real PostgreSQL `SELECT 1` check with a strict timeout and returns HTTP 503 when the database is unavailable.
- Required Redis is treated as not ready when it is unreachable; optional Redis may remain degraded without exposing internal details.
- Ansible smoke checks and nginx health routes now validate `/health/ready` instead of the generic health endpoint.
- Added backend tests covering successful readiness, database outage, Redis outage, and optional Redis degradation.

Fixes: #5