### PR TITLE
ci: require release gate before production deploy

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,8 +1,6 @@
 name: Backend CI
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,20 +2,23 @@ name: Production Deploy
 
 on:
   workflow_run:
-    workflows: [E2E Tests]
+    workflows: [Release Gate]
     types: [completed]
   workflow_dispatch:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: stadtplaner-production
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy with Ansible
+  gate-check:
+    name: Validate release gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       ${{
         (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
@@ -24,6 +27,49 @@ jobs:
          github.event.workflow_run.head_branch == 'main' &&
          github.event.workflow_run.conclusion == 'success')
       }}
+    steps:
+      - name: Require successful release gate for the same SHA
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          python3 - "$REPO" "$SHA" "$REF_NAME" <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          repo, sha, ref_name = sys.argv[1], sys.argv[2], sys.argv[3]
+          token = os.environ["GITHUB_TOKEN"]
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/actions/workflows/release-gate.yml/runs?branch={ref_name}&status=completed&per_page=20",
+              headers={
+                  "Authorization": f"Bearer {token}",
+                  "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request) as response:
+              payload = json.load(response)
+
+          runs = payload.get("workflow_runs", [])
+          if not any(run.get("head_sha") == sha and run.get("conclusion") == "success" for run in runs):
+              raise SystemExit(f"No successful Release Gate exists for {sha} on {ref_name}. Manual deploy is blocked until the gate passes.")
+
+          print(f"Validated successful Release Gate for {sha}")
+          PY
+      - name: Release gate already passed for workflow_run
+        if: github.event_name == 'workflow_run'
+        run: echo "Release Gate succeeded for ${{ github.event.workflow_run.head_sha }}"
+
+  deploy:
+    name: Deploy with Ansible
+    needs: gate-check
+    if: ${{ needs.gate-check.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,22 +45,28 @@ jobs:
 
           repo, sha, ref_name = sys.argv[1], sys.argv[2], sys.argv[3]
           token = os.environ["GITHUB_TOKEN"]
-          request = urllib.request.Request(
-              f"https://api.github.com/repos/{repo}/actions/workflows/release-gate.yml/runs?branch={ref_name}&status=completed&per_page=20",
-              headers={
-                  "Authorization": f"Bearer {token}",
-                  "Accept": "application/vnd.github+json",
-                  "X-GitHub-Api-Version": "2022-11-28",
-              },
-          )
-          with urllib.request.urlopen(request) as response:
-              payload = json.load(response)
+          page = 1
+          while True:
+              request = urllib.request.Request(
+                  f"https://api.github.com/repos/{repo}/actions/workflows/release-gate.yml/runs?branch={ref_name}&status=completed&per_page=100&page={page}",
+                  headers={
+                      "Authorization": f"Bearer {token}",
+                      "Accept": "application/vnd.github+json",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urllib.request.urlopen(request) as response:
+                  payload = json.load(response)
 
-          runs = payload.get("workflow_runs", [])
-          if not any(run.get("head_sha") == sha and run.get("conclusion") == "success" for run in runs):
-              raise SystemExit(f"No successful Release Gate exists for {sha} on {ref_name}. Manual deploy is blocked until the gate passes.")
+              runs = payload.get("workflow_runs", [])
+              if any(run.get("head_sha") == sha and run.get("conclusion") == "success" for run in runs):
+                  print(f"Validated successful Release Gate for {sha}")
+                  break
 
-          print(f"Validated successful Release Gate for {sha}")
+              if len(runs) < 100:
+                  raise SystemExit(f"No successful Release Gate exists for {sha} on {ref_name}. Manual deploy is blocked until the gate passes.")
+
+              page += 1
           PY
       - name: Release gate already passed for workflow_run
         if: github.event_name == 'workflow_run'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,8 +1,6 @@
 name: Frontend CI
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,60 @@
+name: Release Gate
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend gate
+    uses: ./.github/workflows/backend.yml
+
+  frontend:
+    name: Frontend gate
+    uses: ./.github/workflows/frontend.yml
+
+  e2e:
+    name: E2E gate
+    uses: ./.github/workflows/e2e.yml
+
+  security:
+    name: Security gate
+    uses: ./.github/workflows/security.yml
+
+  gate:
+    name: Release gate
+    needs: [backend, frontend, e2e, security]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ always() }}
+    steps:
+      - name: Require all required checks to pass
+        shell: bash
+        env:
+          BACKEND_RESULT: ${{ needs.backend.result }}
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+          SECURITY_RESULT: ${{ needs.security.result }}
+        run: |
+          set -euo pipefail
+
+          for name in BACKEND_RESULT FRONTEND_RESULT E2E_RESULT SECURITY_RESULT; do
+            value="${!name}"
+            echo "${name}=${value}"
+            if [[ "${value}" != "success" ]]; then
+              echo "Release gate is blocked because ${name} is ${value}." >&2
+              exit 1
+            fi
+          done
+
+          echo "Release gate passed for ${{ github.sha }}"

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -34,6 +34,8 @@ jobs:
     with:
       dependency_review: true
       frontend_audit: true
+      base_ref: ${{ github.event.pull_request.base.sha || github.event.before || github.sha }}
+      head_ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   gate:
     name: Release gate

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: release-gate-${{ github.workflow }}-${{ github.ref }}
@@ -30,6 +31,9 @@ jobs:
   security:
     name: Security gate
     uses: ./.github/workflows/security.yml
+    with:
+      dependency_review: true
+      frontend_audit: true
 
   gate:
     name: Release gate

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  workflow_call:
   schedule:
     - cron: "23 4 * * 1"
 
@@ -17,7 +18,7 @@ concurrency:
 jobs:
   dependency-review:
     name: Dependency review
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -29,7 +30,7 @@ jobs:
 
   frontend-audit:
     name: Scheduled frontend dependency audit
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,14 @@ on:
         required: false
         type: boolean
         default: false
+      base_ref:
+        description: Base SHA to compare against for dependency review scans.
+        required: false
+        type: string
+      head_ref:
+        description: Head SHA to compare against for dependency review scans.
+        required: false
+        type: string
   schedule:
     - cron: "23 4 * * 1"
 
@@ -38,6 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v5
+        with:
+          base-ref: ${{ inputs.base_ref || github.event.pull_request.base.sha || github.event.before || github.event.repository.default_branch }}
+          head-ref: ${{ inputs.head_ref || github.event.pull_request.head.sha || github.sha }}
 
   frontend-audit:
     name: Scheduled frontend dependency audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,17 @@ on:
   pull_request:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      dependency_review:
+        description: Whether to run the dependency review gate.
+        required: false
+        type: boolean
+        default: false
+      frontend_audit:
+        description: Whether to run the frontend dependency audit.
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: "23 4 * * 1"
 
@@ -18,7 +29,7 @@ concurrency:
 jobs:
   dependency-review:
     name: Dependency review
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_call'
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || inputs.dependency_review
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -30,7 +41,7 @@ jobs:
 
   frontend-audit:
     name: Scheduled frontend dependency audit
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || inputs.frontend_audit
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -102,7 +102,7 @@ ansible-playbook playbooks/deploy.yml \
 
 ## Automatischer Deploy über GitHub Actions
 
-`.github/workflows/deploy.yml` deployt einen Push auf `main` automatisch, sobald der zugehörige Workflow **E2E Tests** erfolgreich beendet wurde, und kann zusätzlich über `workflow_dispatch` auf `main` manuell gestartet werden. Für automatische Läufe verwendet er `workflow_run.head_sha`, sodass exakt der erfolgreich getestete Commit ausgerollt wird. Fehlgeschlagene E2E-Läufe lösen keinen Deploy aus. Eine Concurrency-Gruppe lässt nie zwei Produktionsdeployments gleichzeitig laufen.
+`.github/workflows/deploy.yml` deployt einen Push auf `main` automatisch, sobald der zugehörige Workflow **Release Gate** erfolgreich beendet wurde. Dieses Gate bündelt Backend-, Frontend-, E2E- und Security-Prüfungen; nur ein erfolgreicher Gate-Lauf für einen `push` auf `main` löst den automatischen Produktionsdeploy aus. Für automatische Läufe verwendet der Workflow `workflow_run.head_sha`, sodass exakt der erfolgreich gegatete Commit ausgerollt wird. Ein manueller Start per `workflow_dispatch` ist weiterhin nur auf `main` möglich, wird aber zusätzlich blockiert, bis für denselben Commit bereits ein erfolgreicher Release-Gate-Lauf existiert. Eine Concurrency-Gruppe lässt nie zwei Produktionsdeployments gleichzeitig laufen.
 
 Lege im Repository unter **Settings → Environments** die Environment `production` an und beschränke sie auf den Branch `main`. Ein Required Reviewer ist optional: Ohne Reviewer läuft der Deploy vollautomatisch; mit Reviewer wartet er vor dem Zugriff auf die Secrets auf eine Freigabe.
 


### PR DESCRIPTION
The production deploy path was earlier gated only by the E2E workflow, which meant a broken commit could still reach production if that single check passed. This adds a central release gate so the deploy job only proceeds after backend, frontend, E2E, and security checks all succeed for the same commit SHA.

The change reuses the existing CI workflows through `workflow_call`, introduces a shared `Release Gate` workflow that enforces the required results, and updates the production deploy workflow to block manual runs unless the same-SHA gate has already passed. This keeps the deployment path aligned with the repo's CI signals and makes bypasses harder to do accidentally.
