### PR TITLE
Remove internal user IDs from public polygon APIs

### DIFF
--- a/backend/app/api/polygons.py
+++ b/backend/app/api/polygons.py
@@ -28,6 +28,7 @@ from app.schemas.geojson import (
     PolygonVerwaltungRead,
     PolygonVerwaltungUpdate,
     PublicPolygonDetail,
+    PublicPolygonRead,
 )
 from app.schemas.osm import OsmPolygonImportRead, OsmPolygonImportRequest, PolygonOsmInfo
 from app.schemas.polygon_filters import PolygonFilterParams, polygon_filter_query
@@ -47,14 +48,14 @@ from app.services.polygons import (
     delete_polygon,
     get_polygon,
     list_polygon_overview,
-    list_polygons,
+    list_public_polygons,
     polygon_editor_detail,
     polygon_metrics,
     polygon_sitemap_entries,
     polygon_verwaltung_detail,
     polygons_geojson,
     public_polygon_by_slug,
-    read_polygon,
+    read_public_polygon,
     update_polygon,
     update_polygon_verwaltung,
 )
@@ -64,9 +65,9 @@ router = APIRouter(prefix="/polygons", tags=["Polygons"])
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 
 
-@router.get("", response_model=list[PolygonRead])
-async def get_polygons(session: SessionDep) -> list[PolygonRead]:
-    return await list_polygons(session)
+@router.get("", response_model=list[PublicPolygonRead])
+async def get_polygons(session: SessionDep) -> list[PublicPolygonRead]:
+    return await list_public_polygons(session)
 
 
 @router.post("", response_model=PolygonRead, status_code=status.HTTP_201_CREATED)
@@ -250,9 +251,9 @@ async def get_polygon_osm_by_id(polygon_id: uuid.UUID, session: SessionDep) -> P
     return result
 
 
-@router.get("/{polygon_id}", response_model=PolygonRead)
-async def get_polygon_by_id(polygon_id: uuid.UUID, session: SessionDep) -> PolygonRead:
-    polygon = await read_polygon(session, polygon_id)
+@router.get("/{polygon_id}", response_model=PublicPolygonRead)
+async def get_polygon_by_id(polygon_id: uuid.UUID, session: SessionDep) -> PublicPolygonRead:
+    polygon = await read_public_polygon(session, polygon_id)
     if polygon is None:
         raise HTTPException(status_code=404, detail="Die Fläche wurde nicht gefunden.")
     return polygon

--- a/backend/app/schemas/geojson.py
+++ b/backend/app/schemas/geojson.py
@@ -140,6 +140,15 @@ class PolygonRead(PolygonBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class PublicPolygonRead(PolygonBase):
+    id: str
+    slug: str
+    created_at: str
+    updated_at: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class PolygonOverviewRead(BaseModel):
     id: str
     slug: str

--- a/backend/app/services/polygons.py
+++ b/backend/app/services/polygons.py
@@ -28,6 +28,7 @@ from app.schemas.geojson import (
     PolygonVerwaltungRead,
     PolygonVerwaltungUpdate,
     PublicPolygonDetail,
+    PublicPolygonRead,
 )
 from app.schemas.polygon_filters import PolygonFilterParams
 from app.services.analysis_areas import refresh_polygon_area_assignments
@@ -65,9 +66,29 @@ def serialize_polygon(polygon: UserPolygon) -> PolygonRead:
     )
 
 
+def serialize_public_polygon(polygon: UserPolygon) -> PublicPolygonRead:
+    return PublicPolygonRead(
+        id=str(polygon.uuid),
+        slug=polygon.slug,
+        name=polygon.name,
+        description=polygon.description,
+        floor=polygon.floor,
+        category=polygon.category,
+        geometry=from_wkb_element(polygon.geometry),
+        properties=polygon.properties,
+        created_at=polygon.created_at.isoformat(),
+        updated_at=polygon.updated_at.isoformat(),
+    )
+
+
 async def list_polygons(session: AsyncSession) -> list[PolygonRead]:
     rows = await session.scalars(select(UserPolygon).order_by(UserPolygon.created_at.desc()))
     return [serialize_polygon(row) for row in rows]
+
+
+async def list_public_polygons(session: AsyncSession) -> list[PublicPolygonRead]:
+    rows = await session.scalars(select(UserPolygon).order_by(UserPolygon.created_at.desc()))
+    return [serialize_public_polygon(row) for row in rows]
 
 
 async def list_polygon_overview(
@@ -113,6 +134,13 @@ async def read_polygon(session: AsyncSession, polygon_id: uuid.UUID) -> PolygonR
     if polygon is None:
         return None
     return serialize_polygon(polygon)
+
+
+async def read_public_polygon(session: AsyncSession, polygon_id: uuid.UUID) -> PublicPolygonRead | None:
+    polygon = await get_polygon(session, polygon_id)
+    if polygon is None:
+        return None
+    return serialize_public_polygon(polygon)
 
 
 def slugify_polygon_name(name: str) -> str:
@@ -525,7 +553,7 @@ async def delete_polygon(
 
 
 async def _polygons_geojson_uncached(session: AsyncSession) -> FeatureCollection:
-    polygons = await list_polygons(session)
+    polygons = await list_public_polygons(session)
     return FeatureCollection(
         type="FeatureCollection",
         features=[
@@ -539,7 +567,6 @@ async def _polygons_geojson_uncached(session: AsyncSession) -> FeatureCollection
                     "slug": polygon.slug,
                     "name": polygon.name,
                     "category": polygon.category,
-                    "created_by_user_id": polygon.created_by_user_id,
                 },
             )
             for polygon in polygons

--- a/backend/tests/test_polygon_management.py
+++ b/backend/tests/test_polygon_management.py
@@ -24,6 +24,7 @@ from app.schemas.geojson import (
     PolygonUpdate,
     PolygonVerwaltungUpdate,
     PublicPolygonDetail,
+    PublicPolygonRead,
 )
 from app.services import nominatim, polygons
 from app.services.nominatim import NominatimAddress, NominatimService
@@ -77,6 +78,8 @@ def test_public_polygon_schema_has_no_management_fields() -> None:
     assert not public_fields.intersection(
         {"owner_name", "owner_street", "owner_city", "price_per_sqm", "updated_by_user_id"}
     )
+    public_read_fields = set(PublicPolygonRead.model_fields)
+    assert not public_read_fields.intersection({"created_by_user_id", "updated_by_user_id"})
 
 
 def test_management_price_uses_decimal_and_rejects_negative_values() -> None:

--- a/frontend/app/types/geo.ts
+++ b/frontend/app/types/geo.ts
@@ -44,6 +44,19 @@ export type UserPolygon = {
   updated_at: string
 }
 
+export type PublicPolygonRead = {
+  id: string
+  slug: string
+  name: string
+  description?: string | null
+  floor?: string | null
+  category: string
+  geometry: AreaGeometry
+  properties: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
 export type PolygonOverview = {
   id: string
   slug: string

--- a/frontend/app/utils/validation.ts
+++ b/frontend/app/utils/validation.ts
@@ -29,6 +29,19 @@ export const polygonSchema = z.object({
   updated_at: z.string()
 })
 
+export const publicPolygonSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  floor: z.string().nullable().optional(),
+  category: z.string(),
+  geometry: areaGeometrySchema,
+  properties: z.record(z.unknown()).default({}),
+  created_at: z.string(),
+  updated_at: z.string()
+})
+
 export const polygonOverviewSchema = z.object({
   id: z.string(),
   slug: z.string(),


### PR DESCRIPTION
## Why

Public polygon endpoints were exposing stable internal user UUIDs in list, detail, and GeoJSON responses. Those identifiers are not required for public map display and can be used to correlate user activity across datasets.

## What changed

- Added a dedicated public polygon schema that omits internal creator and updater IDs.
- Switched the public list and detail endpoints to the sanitized response model.
- Removed internal user IDs from the public GeoJSON feature properties.
- Updated the frontend TypeScript types and validation to match the public API contract.
- Added a regression check to ensure the public schema does not expose internal IDs.

Fixes: #8