### PR TITLE
fix: release DB sessions before external calls

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -28,6 +28,21 @@ async def database_health() -> str:
         return "down"
 
 
+async def close_session(session: AsyncSession | None) -> None:
+    if session is None:
+        return
+    if hasattr(session, "rollback"):
+        try:
+            await session.rollback()
+        except SQLAlchemyError:
+            pass
+    if hasattr(session, "close"):
+        try:
+            await session.close()
+        except SQLAlchemyError:
+            pass
+
+
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with AsyncSessionLocal() as session:
         yield session

--- a/backend/app/services/assistant.py
+++ b/backend/app/services/assistant.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
+from app.db.session import AsyncSessionLocal, close_session
 from app.schemas.assistant import (
     AnswerPresentation,
     AnswerPresentationSection,
@@ -109,13 +110,17 @@ async def answer_assistant_query(
             code="ASSISTANT_TOOL_LIMIT_REACHED",
         )
 
+    tool_session = session
+    if prepared.llm_used and not getattr(session, "closed", False):
+        tool_session = AsyncSessionLocal()
+
     results: list[tuple[AssistantToolName, Any]] = []
     success = True
     warnings: list[str] = []
     failure_code: str | None = None
     try:
         for step in prepared.plan.steps:
-            result = await execute_assistant_tool(session, step.tool, step.arguments)
+            result = await execute_assistant_tool(tool_session, step.tool, step.arguments)
             results.append((step.tool, result.model_dump(mode="json")))
     except AssistantToolError as error:
         success = False
@@ -138,7 +143,9 @@ async def answer_assistant_query(
                 for item in error.errors(include_url=False, include_input=False)
             }),
         )
-
+    finally:
+        if tool_session is not session:
+            await tool_session.close()
     response = _build_response(request, prepared, results, warnings, failure_code)
     duration_ms = max(0, round((time.monotonic() - started) * 1000))
     settings = get_settings()
@@ -291,7 +298,7 @@ async def _plan_query(
     area = areas[0] if areas else None
     if area is None:
         return await _provider_or_unsupported(
-            request, provider, filters, [], normalized
+            session, request, provider, filters, [], normalized
         )
 
     prefix = _resolve_steps([area])
@@ -367,7 +374,7 @@ async def _plan_query(
         topic = "AREA_DETAIL"
     else:
         return await _provider_or_unsupported(
-            request, provider, filters, [area], normalized
+            session, request, provider, filters, [area], normalized
         )
     intent = AssistantIntent.SHOW_FEATURES if topic in {"FEATURES", "POLYGON_FEATURES"} else AssistantIntent.ANSWER_QUESTION
     return _PreparedPlan(AssistantPlan(intent=intent, steps=prefix + [step]), [area], filters, topic)
@@ -491,6 +498,7 @@ def _statistic_metric_keys(normalized: str) -> list[str]:
 
 
 async def _provider_or_unsupported(
+    session: AsyncSession,
     request: AssistantQueryRequest,
     provider: AssistantLLMProvider | None,
     filters: SearchFilters,
@@ -520,6 +528,7 @@ async def _provider_or_unsupported(
     if areas:
         provider_context.active_area = areas[0]
     try:
+        await close_session(session)
         plan = AssistantPlan.model_validate(
             await provider.plan(request.query, provider_context, tools)
         )

--- a/backend/app/services/assistant_provider.py
+++ b/backend/app/services/assistant_provider.py
@@ -47,6 +47,7 @@ class GroqProvider:
         self._client = client or httpx.AsyncClient(
             base_url=settings.groq_base_url.rstrip("/"),
             timeout=httpx.Timeout(settings.groq_timeout_seconds),
+            limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
         )
         self.usage: dict[str, int] = {}
 

--- a/backend/app/services/nominatim.py
+++ b/backend/app/services/nominatim.py
@@ -45,6 +45,7 @@ class NominatimService:
         endpoint = f"{settings.nominatim_base_url.rstrip('/')}/reverse"
         async with httpx.AsyncClient(
             timeout=settings.nominatim_timeout_seconds,
+            limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
             headers={"User-Agent": settings.nominatim_user_agent},
         ) as client:
             response = await client.get(endpoint, params=params)

--- a/backend/app/services/osm_lookup.py
+++ b/backend/app/services/osm_lookup.py
@@ -9,6 +9,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
+from app.db.session import close_session
 from app.models.user_polygon import UserPolygon
 from app.schemas.osm import OsmAddress, OsmCentroid, OsmObjectInfo, PolygonOsmInfo
 from app.services.external_links import external_links_from_osm_tags
@@ -253,6 +254,7 @@ class OsmLookupService:
         # The result is plain Python values and carries no reference to the
         # session, so it is safe to hand into a globally-shared task.
         local_matches = await self._local_matches(session, str(polygon.uuid))
+        await close_session(session)
 
         task = _inflight.get(key)
         if task is None:
@@ -352,6 +354,7 @@ class OsmLookupService:
         try:
             async with httpx.AsyncClient(
                 timeout=settings.overpass_timeout_seconds,
+                limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
                 headers={
                     "User-Agent": settings.overpass_user_agent,
                     "Accept": "application/json",

--- a/backend/app/services/polygons.py
+++ b/backend/app/services/polygons.py
@@ -213,6 +213,19 @@ async def polygon_point_on_surface(
     return float(row["latitude"]), float(row["longitude"])
 
 
+def _apply_polygon_address(polygon: Any, address: Any) -> None:
+    if address is None:
+        polygon.address_lookup_status = "failed"
+        return
+    polygon.address_display_name = address.display_name
+    polygon.address_street = address.street
+    polygon.address_house_number = address.house_number
+    polygon.address_postal_code = address.postal_code
+    polygon.address_city = address.city
+    polygon.address_country = address.country
+    polygon.address_lookup_status = "resolved"
+
+
 async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) -> bool:
     """Best-effort enrichment. Geometry has already been committed when this runs."""
     polygon_id = polygon.uuid
@@ -223,21 +236,13 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
             await close_session(session)
             released = True
         address = await NominatimService().reverse(*point) if point else None
+        _apply_polygon_address(polygon, address)
 
         async with AsyncSessionLocal() as write_session:
             fresh = await get_polygon(write_session, polygon_id)
             if fresh is None:
                 return address is not None
-            if address is None:
-                fresh.address_lookup_status = "failed"
-            else:
-                fresh.address_display_name = address.display_name
-                fresh.address_street = address.street
-                fresh.address_house_number = address.house_number
-                fresh.address_postal_code = address.postal_code
-                fresh.address_city = address.city
-                fresh.address_country = address.country
-                fresh.address_lookup_status = "resolved"
+            _apply_polygon_address(fresh, address)
             await write_session.commit()
             await write_session.refresh(fresh)
             return address is not None
@@ -245,15 +250,23 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
         if not released:
             await close_session(session)
             released = True
+        _apply_polygon_address(polygon, None)
         try:
             async with AsyncSessionLocal() as write_session:
                 fresh = await get_polygon(write_session, polygon_id)
                 if fresh is not None:
-                    fresh.address_lookup_status = "failed"
+                    _apply_polygon_address(fresh, None)
                     await write_session.commit()
                     await write_session.refresh(fresh)
         except Exception:  # noqa: BLE001 - status persistence is best effort as well
-            logger.warning("Polygon address lookup failed for polygon_id=%s", polygon_id)
+            try:
+                fresh = await get_polygon(session, polygon_id)
+                if fresh is not None:
+                    _apply_polygon_address(fresh, None)
+                    await session.commit()
+                    await session.refresh(fresh)
+            except Exception:  # noqa: BLE001 - status persistence is best effort as well
+                logger.warning("Polygon address lookup failed for polygon_id=%s", polygon_id)
         logger.warning("Polygon address lookup failed for polygon_id=%s", polygon_id)
         return False
 

--- a/backend/app/services/polygons.py
+++ b/backend/app/services/polygons.py
@@ -232,9 +232,8 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
     released = False
     try:
         point = await polygon_point_on_surface(session, polygon.uuid)
-        if not released:
-            await close_session(session)
-            released = True
+        await close_session(session)
+        released = True
         address = await NominatimService().reverse(*point) if point else None
         _apply_polygon_address(polygon, address)
 
@@ -258,15 +257,12 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
                     _apply_polygon_address(fresh, None)
                     await write_session.commit()
                     await write_session.refresh(fresh)
-        except Exception:  # noqa: BLE001 - status persistence is best effort as well
-            try:
-                fresh = await get_polygon(session, polygon_id)
-                if fresh is not None:
-                    _apply_polygon_address(fresh, None)
-                    await session.commit()
-                    await session.refresh(fresh)
-            except Exception:  # noqa: BLE001 - status persistence is best effort as well
-                logger.warning("Polygon address lookup failed for polygon_id=%s", polygon_id)
+        except Exception:
+            logger.debug(
+                "Failed to persist polygon address failure status for polygon_id=%s",
+                polygon_id,
+                exc_info=True,
+            )
         logger.warning("Polygon address lookup failed for polygon_id=%s", polygon_id)
         return False
 

--- a/backend/app/services/polygons.py
+++ b/backend/app/services/polygons.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.cache.keys import build_cache_key
 from app.cache.service import cache_service
 from app.core.config import get_settings
+from app.db.session import AsyncSessionLocal, close_session
 from app.models.admin_audit_log import AdminAuditLog
 from app.models.polygon_osm_source import PolygonOsmSource
 from app.models.user_polygon import UserPolygon, utcnow
@@ -215,32 +216,44 @@ async def polygon_point_on_surface(
 async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) -> bool:
     """Best-effort enrichment. Geometry has already been committed when this runs."""
     polygon_id = polygon.uuid
+    released = False
     try:
         point = await polygon_point_on_surface(session, polygon.uuid)
+        if not released:
+            await close_session(session)
+            released = True
         address = await NominatimService().reverse(*point) if point else None
-        if address is None:
-            polygon.address_lookup_status = "failed"
-        else:
-            polygon.address_display_name = address.display_name
-            polygon.address_street = address.street
-            polygon.address_house_number = address.house_number
-            polygon.address_postal_code = address.postal_code
-            polygon.address_city = address.city
-            polygon.address_country = address.country
-            polygon.address_lookup_status = "resolved"
-        await session.commit()
-        await session.refresh(polygon)
-        return address is not None
-    except Exception:  # noqa: BLE001 - enrichment must never roll back a saved geometry
-        await session.rollback()
-        try:
-            fresh = await get_polygon(session, polygon_id)
-            if fresh is not None:
+
+        async with AsyncSessionLocal() as write_session:
+            fresh = await get_polygon(write_session, polygon_id)
+            if fresh is None:
+                return address is not None
+            if address is None:
                 fresh.address_lookup_status = "failed"
-                await session.commit()
-                await session.refresh(fresh)
+            else:
+                fresh.address_display_name = address.display_name
+                fresh.address_street = address.street
+                fresh.address_house_number = address.house_number
+                fresh.address_postal_code = address.postal_code
+                fresh.address_city = address.city
+                fresh.address_country = address.country
+                fresh.address_lookup_status = "resolved"
+            await write_session.commit()
+            await write_session.refresh(fresh)
+            return address is not None
+    except Exception:  # noqa: BLE001 - enrichment must never roll back a saved geometry
+        if not released:
+            await close_session(session)
+            released = True
+        try:
+            async with AsyncSessionLocal() as write_session:
+                fresh = await get_polygon(write_session, polygon_id)
+                if fresh is not None:
+                    fresh.address_lookup_status = "failed"
+                    await write_session.commit()
+                    await write_session.refresh(fresh)
         except Exception:  # noqa: BLE001 - status persistence is best effort as well
-            await session.rollback()
+            logger.warning("Polygon address lookup failed for polygon_id=%s", polygon_id)
         logger.warning("Polygon address lookup failed for polygon_id=%s", polygon_id)
         return False
 

--- a/backend/tests/test_polygon_management.py
+++ b/backend/tests/test_polygon_management.py
@@ -208,6 +208,21 @@ async def test_address_enrichment_failure_does_not_fail_saved_polygon(
         async def refresh(self, _polygon: object) -> None:
             return None
 
+    class WriteSession:
+        commit_count = 0
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def commit(self) -> None:
+            self.commit_count += 1
+
+        async def refresh(self, _polygon: object) -> None:
+            return None
+
     async def point(*_args: object) -> tuple[float, float]:
         return 54.78, 9.43
 
@@ -220,12 +235,15 @@ async def test_address_enrichment_failure_does_not_fail_saved_polygon(
     monkeypatch.setattr(polygons, "polygon_point_on_surface", point)
     monkeypatch.setattr(polygons.NominatimService, "reverse", timeout)
     monkeypatch.setattr(polygons, "get_polygon", get_polygon)
+    write_session = WriteSession()
+    monkeypatch.setattr(polygons, "AsyncSessionLocal", lambda: write_session)
     session = Session()
 
     assert await polygons.enrich_polygon_address(session, polygon) is False
     assert polygon.address_lookup_status == "failed"
     assert session.rollback_count == 1
-    assert session.commit_count == 1
+    assert session.commit_count == 0
+    assert write_session.commit_count == 1
 
 
 class PolygonApiSession:

--- a/backend/tests/test_stadtplaner_assistant.py
+++ b/backend/tests/test_stadtplaner_assistant.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import AsyncMock
 
 import pytest
 from pydantic import ValidationError
@@ -110,6 +111,45 @@ async def test_poi_count_is_copied_exactly_from_tool(monkeypatch: pytest.MonkeyP
     assert "17 POIs" in response.answer
     assert "18" not in response.answer
     assert response.telemetry.tool_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_llm_plan_releases_db_session_before_external_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = AsyncMock()
+    close_session = AsyncMock()
+    monkeypatch.setattr(assistant, "close_session", close_session)
+
+    async def no_areas(_session: object, _normalized: str) -> list[SearchArea]:
+        return []
+
+    monkeypatch.setattr(assistant, "_mentioned_areas", no_areas)
+    monkeypatch.setattr(
+        assistant,
+        "execute_assistant_tool",
+        AsyncMock(return_value=ToolDataResult(data={"ok": True})),
+    )
+
+    class Provider:
+        name = "groq"
+
+        async def plan(self, _query: str, _context: object, _tools: list[dict]) -> dict:
+            return {
+                "intent": "ANSWER_QUESTION",
+                "steps": [{
+                    "tool": AssistantToolName.GET_AREA_DETAIL,
+                    "arguments": {"slug": "altstadt-15630273"},
+                }],
+                "response_mode": "ANSWER",
+            }
+
+    response = await answer_assistant_query(
+        session,
+        AssistantQueryRequest(query="Warum sind die Daten für Altstadt wichtig?"),
+        provider=Provider(),
+    )
+
+    close_session.assert_awaited_with(session)
+    assert response.telemetry.llm_used is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Why this change matters:

The backend was keeping request-scoped database sessions open while it waited on external HTTP and LLM calls. In slow or failing provider responses, that left connections checked out and could exhaust the DB pool. This change splits the work into a short DB phase, an explicit session release, and a fresh session only when later database work is still needed.

What changed:

- Added a safe session-closing helper that rolls back and closes request-scoped sessions defensively.
- Released the DB session before provider-based LLM planning in the assistant flow.
- Switched follow-up assistant tool execution to a fresh session when the original request session is no longer valid.
- Released DB state before Overpass and Nominatim calls, then reopened a fresh session for any later persistence.
- Added connection limits to outbound HTTP clients to reduce pressure on the database pool.
- Added a focused regression test covering the assistant LLM path.

Fixes: #9