### PR TITLE
feat: Atomic polygon mutations and outbox for side effects

### DIFF
--- a/backend/alembic/versions/20260822_0033_polygon_outbox.py
+++ b/backend/alembic/versions/20260822_0033_polygon_outbox.py
@@ -1,0 +1,43 @@
+"""Add polygon outbox
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-08-22 15:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '0033'
+down_revision = '0032'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column('user_polygons', sa.Column('idempotency_key', sa.String(length=255), nullable=True))
+    op.create_unique_constraint('uq_user_polygons_idempotency_key', 'user_polygons', ['idempotency_key'])
+    op.create_table(
+        'polygon_outbox',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('polygon_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('event_type', sa.String(length=32), nullable=False),
+        sa.Column('payload', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('status', sa.String(length=16), server_default='PENDING', nullable=False),
+        sa.Column('attempt_count', sa.Integer(), server_default='0', nullable=False),
+        sa.Column('last_error', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('next_attempt_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('processing_started_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.CheckConstraint("status IN ('PENDING','PROCESSING','COMPLETED','FAILED','DEAD_LETTER')", name='ck_polygon_outbox_status')
+    )
+    op.create_index('idx_polygon_outbox_due', 'polygon_outbox', ['status', 'next_attempt_at'], unique=False)
+
+def downgrade() -> None:
+    op.drop_index('idx_polygon_outbox_due', table_name='polygon_outbox')
+    op.drop_table('polygon_outbox')
+    op.drop_constraint('uq_user_polygons_idempotency_key', 'user_polygons', type_='unique')
+    op.drop_column('user_polygons', 'idempotency_key')

--- a/backend/alembic/versions/20260822_0033_polygon_outbox.py
+++ b/backend/alembic/versions/20260822_0033_polygon_outbox.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = '0033'
-down_revision = '0032'
+revision = '20260822_0033'
+down_revision = '20260819_0032'
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260822_0033_polygon_outbox.py
+++ b/backend/alembic/versions/20260822_0033_polygon_outbox.py
@@ -5,9 +5,10 @@ Revises: 0032
 Create Date: 2026-08-22 15:00:00.000000
 
 """
-from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '20260822_0033'

--- a/backend/app/cli/process_polygon_outbox.py
+++ b/backend/app/cli/process_polygon_outbox.py
@@ -1,0 +1,23 @@
+import argparse
+import asyncio
+import logging
+
+from app.db.base import AsyncSessionLocal
+from app.services.polygon_outbox import process_due_polygon_outbox
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+async def async_main(limit: int) -> None:
+    async with AsyncSessionLocal() as session:
+        result = await process_due_polygon_outbox(session, limit=limit)
+        logger.info("Polygon outbox processing complete. processed=%d failed=%d dead_letter=%d", result["processed"], result["failed"], result["dead_letter"])
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fällige Polygon-Ereignisse aus der Outbox verarbeiten")
+    parser.add_argument("--limit", type=int, default=50, help="Maximale Anzahl zu verarbeitender Ereignisse")
+    args = parser.parse_args()
+    asyncio.run(async_main(args.limit))
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,7 @@ from app.models.oauth_account import MastodonOAuthInstance, OAuthFlowGrant, User
 from app.models.osm_feature import OsmFeature
 from app.models.password_reset_token import PasswordResetToken
 from app.models.polygon_osm_source import PolygonOsmSource
+from app.models.polygon_outbox import PolygonOutbox
 from app.models.social_publication import (
     SocialPublication,
     SocialPublicationOutbox,
@@ -57,6 +58,7 @@ __all__ = [
     "PasswordResetToken",
     "PolygonAnalysisArea",
     "PolygonOsmSource",
+    "PolygonOutbox",
     "SocialPublication",
     "SocialPublicationOutbox",
     "SocialPublishingSettings",

--- a/backend/app/models/polygon_outbox.py
+++ b/backend/app/models/polygon_outbox.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
 
+
 class PolygonOutbox(Base):
     __tablename__ = "polygon_outbox"
 

--- a/backend/app/models/polygon_outbox.py
+++ b/backend/app/models/polygon_outbox.py
@@ -1,0 +1,43 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+class PolygonOutbox(Base):
+    __tablename__ = "polygon_outbox"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    polygon_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), default="PENDING", nullable=False)
+    attempt_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    next_attempt_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    processing_started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('PENDING','PROCESSING','COMPLETED','FAILED','DEAD_LETTER')",
+            name="ck_polygon_outbox_status",
+        ),
+        Index("idx_polygon_outbox_due", "status", "next_attempt_at"),
+    )

--- a/backend/app/models/user_polygon.py
+++ b/backend/app/models/user_polygon.py
@@ -54,6 +54,7 @@ class UserPolygon(Base):
     occupancy_source_updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     business_structure: Mapped[str] = mapped_column(String(16), default="UNKNOWN", nullable=False)
     category: Mapped[str] = mapped_column(String(80), default="custom", nullable=False)
+    idempotency_key: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
     geometry: Mapped[object] = mapped_column(Geometry("GEOMETRY", srid=4326, spatial_index=False), nullable=False)
     properties: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
     user_id: Mapped[str | None] = mapped_column(String(120))

--- a/backend/app/schemas/geojson.py
+++ b/backend/app/schemas/geojson.py
@@ -87,7 +87,7 @@ class PolygonBase(BaseModel):
 
 
 class PolygonCreate(PolygonBase):
-    pass
+    idempotency_key: str | None = Field(default=None, max_length=255)
 
 
 class PolygonUpdate(BaseModel):

--- a/backend/app/services/polygon_outbox.py
+++ b/backend/app/services/polygon_outbox.py
@@ -1,15 +1,19 @@
-import uuid
 import logging
+import uuid
+from datetime import UTC, datetime, timedelta
 from typing import Any
-from datetime import datetime, UTC, timedelta
 
-from sqlalchemy import select, update, or_
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.polygon_outbox import PolygonOutbox
 from app.models.user_polygon import UserPolygon
-from app.services.notification_policy import NotificationEventType, DomainEvent
-from app.services.notifications import notify_users, publish_notifications, subscription_recipient_ids
+from app.services.notification_policy import DomainEvent, NotificationEventType
+from app.services.notifications import (
+    notify_users,
+    publish_notifications,
+    subscription_recipient_ids,
+)
 from app.services.polygons import enrich_polygon_address
 from app.services.social_publishing import cancel_pending_polygon_publications
 
@@ -33,6 +37,7 @@ def _now() -> datetime:
     return datetime.now(UTC)
 
 from app.services.polygons import generate_unique_polygon_slug, polygon_slug_source
+
 
 async def _process_created_event(session: AsyncSession, event: PolygonOutbox) -> None:
     polygon = await session.scalar(select(UserPolygon).where(UserPolygon.uuid == event.polygon_id))

--- a/backend/app/services/polygon_outbox.py
+++ b/backend/app/services/polygon_outbox.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.polygon_outbox import PolygonOutbox
 from app.models.user_polygon import UserPolygon
-from app.models.notification import NotificationEventType, DomainEvent
+from app.services.notification_policy import NotificationEventType, DomainEvent
 from app.services.notifications import notify_users, publish_notifications, subscription_recipient_ids
 from app.services.polygons import enrich_polygon_address
 from app.services.social_publishing import cancel_pending_polygon_publications

--- a/backend/app/services/polygon_outbox.py
+++ b/backend/app/services/polygon_outbox.py
@@ -1,0 +1,172 @@
+import uuid
+import logging
+from typing import Any
+from datetime import datetime, UTC, timedelta
+
+from sqlalchemy import select, update, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.polygon_outbox import PolygonOutbox
+from app.models.user_polygon import UserPolygon
+from app.models.notification import NotificationEventType, DomainEvent
+from app.services.notifications import notify_users, publish_notifications, subscription_recipient_ids
+from app.services.polygons import enrich_polygon_address
+from app.services.social_publishing import cancel_pending_polygon_publications
+
+logger = logging.getLogger(__name__)
+
+async def enqueue_polygon_mutation_event(
+    session: AsyncSession,
+    polygon_id: uuid.UUID,
+    event_type: str,
+    payload: dict[str, Any],
+) -> PolygonOutbox:
+    event = PolygonOutbox(
+        polygon_id=polygon_id,
+        event_type=event_type,
+        payload=payload,
+    )
+    session.add(event)
+    return event
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+from app.services.polygons import generate_unique_polygon_slug, polygon_slug_source
+
+async def _process_created_event(session: AsyncSession, event: PolygonOutbox) -> None:
+    polygon = await session.scalar(select(UserPolygon).where(UserPolygon.uuid == event.polygon_id))
+    if not polygon:
+        return
+    success = await enrich_polygon_address(session, polygon)
+    if success:
+        polygon.slug = await generate_unique_polygon_slug(session, polygon_slug_source(polygon))
+
+async def _process_updated_event(session: AsyncSession, event: PolygonOutbox) -> None:
+    polygon = await session.scalar(select(UserPolygon).where(UserPolygon.uuid == event.polygon_id))
+    if not polygon:
+        return
+    payload = event.payload
+    geometry_changed = payload.get("geometry_changed", False)
+    if geometry_changed:
+        await enrich_polygon_address(session, polygon)
+
+    occupancy_status_changed = payload.get("occupancy_status_changed", False)
+    actor_id_str = payload.get("actor_user_id")
+    actor_user_id = uuid.UUID(actor_id_str) if actor_id_str else None
+
+    notification_event_type = (
+        NotificationEventType.GIS_AREA_STATUS_CHANGED
+        if occupancy_status_changed
+        else NotificationEventType.GIS_AREA_UPDATED
+    )
+    recipients = await subscription_recipient_ids(
+        session, resource_type="POLYGON", resource_id=str(polygon.uuid), event_type=notification_event_type
+    )
+    if polygon.created_by_user_id:
+        recipients.append(polygon.created_by_user_id)
+
+    notifications = await notify_users(
+        session,
+        recipients,
+        DomainEvent(
+            event_type=notification_event_type,
+            actor_user_id=actor_user_id,
+            resource_type="POLYGON",
+            resource_id=str(polygon.uuid),
+            resource_slug=polygon.slug,
+            resource_title=polygon.name,
+        ),
+    )
+    publish_notifications(notifications)
+
+async def _process_deleted_event(session: AsyncSession, event: PolygonOutbox) -> None:
+    payload = event.payload
+    polygon_id = event.polygon_id
+    deleted_by_str = payload.get("deleted_by_user_id")
+    deleted_by_user_id = uuid.UUID(deleted_by_str) if deleted_by_str else None
+    
+    recipients = await subscription_recipient_ids(
+        session,
+        resource_type="POLYGON",
+        resource_id=str(polygon_id),
+        event_type=NotificationEventType.GIS_AREA_DELETED,
+    )
+    created_by_str = payload.get("created_by_user_id")
+    if created_by_str:
+        recipients.append(uuid.UUID(created_by_str))
+
+    notifications = await notify_users(
+        session,
+        recipients,
+        DomainEvent(
+            event_type=NotificationEventType.GIS_AREA_DELETED,
+            actor_user_id=deleted_by_user_id,
+            resource_type="POLYGON",
+            resource_id=str(polygon_id),
+            resource_slug=payload.get("slug"),
+            resource_title=payload.get("name"),
+        ),
+    )
+    await cancel_pending_polygon_publications(session, polygon_id)
+    publish_notifications(notifications)
+
+async def process_due_polygon_outbox(session: AsyncSession, *, limit: int = 50) -> dict[str, int]:
+    stale = _now() - timedelta(minutes=10)
+    
+    # Recover stale
+    await session.execute(
+        update(PolygonOutbox)
+        .where(PolygonOutbox.status == "PROCESSING", or_(PolygonOutbox.processing_started_at.is_(None), PolygonOutbox.processing_started_at < stale))
+        .values(status="PENDING", processing_started_at=None)
+    )
+    await session.commit()
+    
+    result = await session.scalars(
+        select(PolygonOutbox)
+        .where(PolygonOutbox.status == "PENDING", PolygonOutbox.next_attempt_at <= _now())
+        .order_by(PolygonOutbox.next_attempt_at, PolygonOutbox.created_at)
+        .limit(limit)
+        .with_for_update(skip_locked=True)
+    )
+    events = result.all()
+    if not events:
+        return {"processed": 0, "failed": 0, "dead_letter": 0}
+
+    stats = {"processed": 0, "failed": 0, "dead_letter": 0}
+    
+    for event in events:
+        event.status = "PROCESSING"
+        event.processing_started_at = _now()
+        event.attempt_count += 1
+        await session.commit()
+        
+        success = False
+        try:
+            if event.event_type == "CREATED":
+                await _process_created_event(session, event)
+            elif event.event_type == "UPDATED":
+                await _process_updated_event(session, event)
+            elif event.event_type == "DELETED":
+                await _process_deleted_event(session, event)
+            success = True
+        except Exception as e:
+            logger.exception("Polygon outbox event failed event_id=%s", event.id)
+            event.last_error = str(e)
+            
+        if success:
+            event.status = "COMPLETED"
+            event.completed_at = _now()
+            stats["processed"] += 1
+        else:
+            if event.attempt_count >= 8:
+                event.status = "DEAD_LETTER"
+                stats["dead_letter"] += 1
+            else:
+                event.status = "PENDING"
+                event.next_attempt_at = _now() + timedelta(minutes=2 ** event.attempt_count)
+                stats["failed"] += 1
+                
+        await session.commit()
+        
+    return stats

--- a/backend/app/services/polygons.py
+++ b/backend/app/services/polygons.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.cache.keys import build_cache_key
 from app.cache.service import cache_service
 from app.core.config import get_settings
-from app.db.session import AsyncSessionLocal, close_session
+from app.db.session import AsyncSessionLocal
 from app.models.admin_audit_log import AdminAuditLog
 from app.models.polygon_osm_source import PolygonOsmSource
 from app.models.user_polygon import UserPolygon, utcnow
@@ -38,12 +38,6 @@ from app.services.external_links import external_links_from_osm_tags
 from app.services.geometry import from_wkb_element, to_wkb_element
 from app.services.gis_mutations import invalidate_gis_after_mutation
 from app.services.nominatim import NominatimService
-from app.services.notification_policy import DomainEvent, NotificationEventType
-from app.services.notifications import (
-    notify_users,
-    publish_notifications,
-    subscription_recipient_ids,
-)
 from app.services.polygon_filters import polygon_filter_clauses
 
 METRIC_SRID = 25832
@@ -270,9 +264,10 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
 async def create_polygon(
     session: AsyncSession, payload: PolygonCreate, user_id: uuid.UUID | None = None
 ) -> PolygonRead:
-    from app.services.polygon_outbox import enqueue_polygon_mutation_event
     from sqlalchemy import select
     from sqlalchemy.exc import IntegrityError
+
+    from app.services.polygon_outbox import enqueue_polygon_mutation_event
     
     if payload.idempotency_key:
         existing = await session.scalar(select(UserPolygon).where(UserPolygon.idempotency_key == payload.idempotency_key))
@@ -299,7 +294,7 @@ async def create_polygon(
     
     try:
         await session.flush()
-    except IntegrityError as exc:
+    except IntegrityError:
         await session.rollback()
         if payload.idempotency_key:
             existing = await session.scalar(select(UserPolygon).where(UserPolygon.idempotency_key == payload.idempotency_key))
@@ -518,7 +513,6 @@ async def delete_polygon(
     polygon: UserPolygon,
     deleted_by_user_id: uuid.UUID,
 ) -> None:
-    from app.services.social_publishing import cancel_pending_polygon_publications
 
     polygon_id = polygon.uuid
     

--- a/backend/app/services/polygons.py
+++ b/backend/app/services/polygons.py
@@ -243,7 +243,12 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
             # Update the in-memory object too
             _apply_polygon_address(polygon, address)
             return address is not None
-    except Exception:
+    except Exception as exc:
+        logger.debug(
+            "Address lookup failed for polygon_id=%s",
+            polygon_id,
+            exc_info=exc,
+        )
         try:
             async with AsyncSessionLocal() as write_session:
                 fresh = await get_polygon(write_session, polygon_id)
@@ -252,11 +257,11 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
                     await write_session.commit()
                     await write_session.refresh(fresh)
                     _apply_polygon_address(polygon, None)
-        except Exception:
+        except Exception as address_exc:
             logger.debug(
                 "Failed to persist polygon address failure status for polygon_id=%s",
                 polygon_id,
-                exc_info=True,
+                exc_info=address_exc,
             )
         logger.warning("Polygon address lookup failed for polygon_id=%s", polygon_id)
         return False
@@ -300,7 +305,7 @@ async def create_polygon(
             existing = await session.scalar(select(UserPolygon).where(UserPolygon.idempotency_key == payload.idempotency_key))
             if existing:
                 return serialize_polygon(existing)
-        raise exc
+        raise
 
     await refresh_polygon_area_assignments(session, polygon.id)
     await enqueue_polygon_mutation_event(session, polygon.uuid, "CREATED", {})

--- a/backend/app/services/polygons.py
+++ b/backend/app/services/polygons.py
@@ -229,14 +229,10 @@ def _apply_polygon_address(polygon: Any, address: Any) -> None:
 async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) -> bool:
     """Best-effort enrichment. Geometry has already been committed when this runs."""
     polygon_id = polygon.uuid
-    released = False
     try:
         point = await polygon_point_on_surface(session, polygon.uuid)
-        await close_session(session)
-        released = True
         address = await NominatimService().reverse(*point) if point else None
-        _apply_polygon_address(polygon, address)
-
+        
         async with AsyncSessionLocal() as write_session:
             fresh = await get_polygon(write_session, polygon_id)
             if fresh is None:
@@ -244,12 +240,10 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
             _apply_polygon_address(fresh, address)
             await write_session.commit()
             await write_session.refresh(fresh)
+            # Update the in-memory object too
+            _apply_polygon_address(polygon, address)
             return address is not None
-    except Exception:  # noqa: BLE001 - enrichment must never roll back a saved geometry
-        if not released:
-            await close_session(session)
-            released = True
-        _apply_polygon_address(polygon, None)
+    except Exception:
         try:
             async with AsyncSessionLocal() as write_session:
                 fresh = await get_polygon(write_session, polygon_id)
@@ -257,6 +251,7 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
                     _apply_polygon_address(fresh, None)
                     await write_session.commit()
                     await write_session.refresh(fresh)
+                    _apply_polygon_address(polygon, None)
         except Exception:
             logger.debug(
                 "Failed to persist polygon address failure status for polygon_id=%s",
@@ -270,9 +265,19 @@ async def enrich_polygon_address(session: AsyncSession, polygon: UserPolygon) ->
 async def create_polygon(
     session: AsyncSession, payload: PolygonCreate, user_id: uuid.UUID | None = None
 ) -> PolygonRead:
+    from app.services.polygon_outbox import enqueue_polygon_mutation_event
+    from sqlalchemy import select
+    from sqlalchemy.exc import IntegrityError
+    
+    if payload.idempotency_key:
+        existing = await session.scalar(select(UserPolygon).where(UserPolygon.idempotency_key == payload.idempotency_key))
+        if existing:
+            return serialize_polygon(existing)
+
     polygon_uuid = uuid.uuid4()
     polygon = UserPolygon(
         uuid=polygon_uuid,
+        idempotency_key=payload.idempotency_key,
         name=payload.name,
         slug=await generate_unique_polygon_slug(
             session, f"{payload.floor or 'flaeche'} flaeche {str(polygon_uuid)[:8]}"
@@ -286,15 +291,22 @@ async def create_polygon(
         updated_by_user_id=user_id,
     )
     session.add(polygon)
-    await session.commit()
-    await session.refresh(polygon)
-    if await enrich_polygon_address(session, polygon):
-        polygon.slug = await generate_unique_polygon_slug(session, polygon_slug_source(polygon))
-        await session.commit()
-        await session.refresh(polygon)
+    
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        await session.rollback()
+        if payload.idempotency_key:
+            existing = await session.scalar(select(UserPolygon).where(UserPolygon.idempotency_key == payload.idempotency_key))
+            if existing:
+                return serialize_polygon(existing)
+        raise exc
+
     await refresh_polygon_area_assignments(session, polygon.id)
+    await enqueue_polygon_mutation_event(session, polygon.uuid, "CREATED", {})
     await invalidate_gis_after_mutation(session)
     await session.commit()
+    await session.refresh(polygon)
     return serialize_polygon(polygon)
 
 
@@ -438,36 +450,21 @@ async def update_polygon(
         setattr(polygon, key, value)
     polygon.updated_by_user_id = user_id
     polygon.updated_at = utcnow()
+    await session.flush()
+    if geometry_changed:
+        await refresh_polygon_area_assignments(session, polygon.id)
+    
+    from app.services.polygon_outbox import enqueue_polygon_mutation_event
+    await enqueue_polygon_mutation_event(session, polygon.uuid, "UPDATED", {
+        "geometry_changed": geometry_changed,
+        "previous_occupancy_status": previous_occupancy_status,
+        "occupancy_status_changed": "occupancy_status" in data and polygon.occupancy_status != previous_occupancy_status,
+        "actor_user_id": str(user_id) if user_id else None
+    })
+    
+    await invalidate_gis_after_mutation(session)
     await session.commit()
     await session.refresh(polygon)
-    if geometry_changed:
-        await enrich_polygon_address(session, polygon)
-        await refresh_polygon_area_assignments(session, polygon.id)
-    await invalidate_gis_after_mutation(session)
-    event_type = (
-        NotificationEventType.GIS_AREA_STATUS_CHANGED
-        if "occupancy_status" in data and polygon.occupancy_status != previous_occupancy_status
-        else NotificationEventType.GIS_AREA_UPDATED
-    )
-    recipients = await subscription_recipient_ids(
-        session, resource_type="POLYGON", resource_id=str(polygon.uuid), event_type=event_type
-    )
-    if owner_id := getattr(polygon, "created_by_user_id", None):
-        recipients.append(owner_id)
-    notifications = await notify_users(
-        session,
-        recipients,
-        DomainEvent(
-            event_type=event_type,
-            actor_user_id=user_id,
-            resource_type="POLYGON",
-            resource_id=str(polygon.uuid),
-            resource_slug=getattr(polygon, "slug", None),
-            resource_title=getattr(polygon, "name", None),
-        ),
-    )
-    await session.commit()
-    publish_notifications(notifications)
     return serialize_polygon(polygon)
 
 
@@ -491,30 +488,16 @@ async def update_polygon_verwaltung(
     polygon.updated_by_user_id = user_id
     polygon.updated_at = utcnow()
     await invalidate_gis_after_mutation(session)
-    event_type = (
-        NotificationEventType.GIS_AREA_STATUS_CHANGED
-        if "occupancy_status" in data and polygon.occupancy_status != previous_occupancy_status
-        else NotificationEventType.GIS_AREA_UPDATED
-    )
-    recipients = await subscription_recipient_ids(
-        session, resource_type="POLYGON", resource_id=str(polygon.uuid), event_type=event_type
-    )
-    if owner_id := getattr(polygon, "created_by_user_id", None):
-        recipients.append(owner_id)
-    notifications = await notify_users(
-        session,
-        recipients,
-        DomainEvent(
-            event_type=event_type,
-            actor_user_id=user_id,
-            resource_type="POLYGON",
-            resource_id=str(polygon.uuid),
-            resource_slug=getattr(polygon, "slug", None),
-            resource_title=getattr(polygon, "name", None),
-        ),
-    )
+    
+    from app.services.polygon_outbox import enqueue_polygon_mutation_event
+    await enqueue_polygon_mutation_event(session, polygon.uuid, "UPDATED", {
+        "geometry_changed": False,
+        "previous_occupancy_status": previous_occupancy_status,
+        "occupancy_status_changed": "occupancy_status" in data and polygon.occupancy_status != previous_occupancy_status,
+        "actor_user_id": str(user_id) if user_id else None
+    })
+    
     await session.commit()
-    publish_notifications(notifications)
     await session.refresh(polygon)
     logger.info(
         "Polygon management fields changed polygon_id=%s user_id=%s fields=%s",
@@ -533,27 +516,15 @@ async def delete_polygon(
     from app.services.social_publishing import cancel_pending_polygon_publications
 
     polygon_id = polygon.uuid
-    recipients = await subscription_recipient_ids(
-        session,
-        resource_type="POLYGON",
-        resource_id=str(polygon_id),
-        event_type=NotificationEventType.GIS_AREA_DELETED,
-    )
-    if polygon.created_by_user_id:
-        recipients.append(polygon.created_by_user_id)
-    notifications = await notify_users(
-        session,
-        recipients,
-        DomainEvent(
-            event_type=NotificationEventType.GIS_AREA_DELETED,
-            actor_user_id=deleted_by_user_id,
-            resource_type="POLYGON",
-            resource_id=str(polygon_id),
-            resource_slug=polygon.slug,
-            resource_title=polygon.name,
-        ),
-    )
-    await cancel_pending_polygon_publications(session, polygon_id)
+    
+    from app.services.polygon_outbox import enqueue_polygon_mutation_event
+    await enqueue_polygon_mutation_event(session, polygon_id, "DELETED", {
+        "deleted_by_user_id": str(deleted_by_user_id),
+        "slug": polygon.slug,
+        "name": polygon.name,
+        "created_by_user_id": str(polygon.created_by_user_id) if polygon.created_by_user_id else None
+    })
+
     session.add(
         AdminAuditLog(
             actor_user_id=deleted_by_user_id,
@@ -566,7 +537,6 @@ async def delete_polygon(
     await session.delete(polygon)
     await invalidate_gis_after_mutation(session)
     await session.commit()
-    publish_notifications(notifications)
     logger.info(
         "Polygon deleted polygon_id=%s deleted_by_user_id=%s",
         polygon_id,

--- a/backend/tests/test_osm_import.py
+++ b/backend/tests/test_osm_import.py
@@ -57,13 +57,13 @@ def disable_nominatim_enrichment(monkeypatch) -> None:
         "app.services.osm_import.publish_notifications", lambda _items: None
     )
     monkeypatch.setattr(
-        "app.services.polygons.subscription_recipient_ids", AsyncMock(return_value=[])
+        "app.services.polygon_outbox.subscription_recipient_ids", AsyncMock(return_value=[])
     )
     monkeypatch.setattr(
-        "app.services.polygons.notify_users", AsyncMock(return_value=[])
+        "app.services.polygon_outbox.notify_users", AsyncMock(return_value=[])
     )
     monkeypatch.setattr(
-        "app.services.polygons.publish_notifications", lambda _items: None
+        "app.services.polygon_outbox.publish_notifications", lambda _items: None
     )
 
 
@@ -132,6 +132,7 @@ def test_import_schema_forbids_geometry_claims_and_management_fields() -> None:
 @pytest.mark.asyncio
 async def test_peninsula_cannot_be_imported_as_stadtplaner_polygon() -> None:
     session = AsyncMock()
+    session.add = MagicMock()
     session.execute.return_value = MappingRows(
         source(dimension=2, tags={"name": "Angeln", "natural": "peninsula"})
     )
@@ -148,6 +149,7 @@ async def test_peninsula_cannot_be_imported_as_stadtplaner_polygon() -> None:
 @pytest.mark.asyncio
 async def test_polygon_import_uses_authoritative_geometry_and_osm_vacancy(monkeypatch) -> None:
     session = AsyncMock()
+    session.add = MagicMock()
     session.add = MagicMock()
     session.execute.side_effect = [
         MappingRows(source(dimension=2, tags={"name": "Leerstand", "shop": "vacant"})),
@@ -182,6 +184,7 @@ async def test_point_import_uses_best_containing_area() -> None:
     point = {"type": "Point", "coordinates": [9.435, 54.785]}
     session = AsyncMock()
     session.add = MagicMock()
+    session.add = MagicMock()
     session.execute.side_effect = [
         MappingRows(source(dimension=0, tags={"name": "Laden", "shop": "clothes"}, geometry=point)),
         MappingRows({"osm_type": "way", "osm_id": 9, "tags": {"building": "yes"}, "geometry": POLYGON, "imported_at": datetime(2026, 8, 13, tzinfo=UTC)}),
@@ -207,6 +210,7 @@ async def test_point_without_area_requires_manual_geometry() -> None:
     point = {"type": "Point", "coordinates": [9.435, 54.785]}
     session = AsyncMock()
     session.add = MagicMock()
+    session.add = MagicMock()
     session.execute.side_effect = [
         MappingRows(source(dimension=0, tags={"shop": "books"}, geometry=point)),
         MappingRows(None),
@@ -222,6 +226,7 @@ async def test_point_without_area_requires_manual_geometry() -> None:
 async def test_point_accepts_explicit_manual_area_without_buffer() -> None:
     point = {"type": "Point", "coordinates": [9.435, 54.785]}
     session = AsyncMock()
+    session.add = MagicMock()
     session.add = MagicMock()
     session.execute.side_effect = [
         MappingRows(source(dimension=0, tags={"shop": "books"}, geometry=point)),
@@ -247,6 +252,7 @@ async def test_management_override_marks_occupancy_as_manual(monkeypatch) -> Non
         updated_by_user_id=None,
     )
     session = AsyncMock()
+    session.add = MagicMock()
     expected_result = object()
     monkeypatch.setattr(
         "app.services.polygons.polygon_verwaltung_detail",

--- a/backend/tests/test_polygon_management.py
+++ b/backend/tests/test_polygon_management.py
@@ -241,7 +241,7 @@ async def test_address_enrichment_failure_does_not_fail_saved_polygon(
 
     assert await polygons.enrich_polygon_address(session, polygon) is False
     assert polygon.address_lookup_status == "failed"
-    assert session.rollback_count == 1
+    assert session.rollback_count == 0
     assert session.commit_count == 0
     assert write_session.commit_count == 1
 

--- a/backend/tests/test_polygon_slugs.py
+++ b/backend/tests/test_polygon_slugs.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import app.services.polygon_outbox as outbox_service
 import app.services.polygons as polygon_service
 from app.models.user_polygon import UserPolygon
 from app.schemas.geojson import PolygonUpdate
@@ -16,9 +17,9 @@ from app.services.polygons import (
 
 @pytest.fixture(autouse=True)
 def disable_notification_delivery(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(polygon_service, "subscription_recipient_ids", AsyncMock(return_value=[]))
-    monkeypatch.setattr(polygon_service, "notify_users", AsyncMock(return_value=[]))
-    monkeypatch.setattr(polygon_service, "publish_notifications", lambda _items: None)
+    monkeypatch.setattr(outbox_service, "subscription_recipient_ids", AsyncMock(return_value=[]))
+    monkeypatch.setattr(outbox_service, "notify_users", AsyncMock(return_value=[]))
+    monkeypatch.setattr(outbox_service, "publish_notifications", lambda _items: None)
 
 
 @pytest.mark.parametrize(
@@ -79,6 +80,12 @@ async def test_polygon_slug_stays_stable_when_name_changes(
 
 
 class FakeUpdateSession:
+    def __init__(self) -> None:
+        self.added: list[object] = []
+
+    def add(self, item: object) -> None:
+        self.added.append(item)
+
     async def commit(self) -> None:
         pass
 
@@ -95,21 +102,16 @@ async def test_delete_invalidates_polygon_analytics_and_osm_namespaces(monkeypat
     polygon = UserPolygon(name="Delete me", slug="delete-me", category="custom")
     polygon.uuid = uuid.uuid4()
     bump = AsyncMock(return_value=None)
-    cancel_publications = AsyncMock(return_value=0)
     monkeypatch.setattr(polygon_service, "invalidate_gis_after_mutation", bump)
-    monkeypatch.setattr(
-        "app.services.social_publishing.cancel_pending_polygon_publications",
-        cancel_publications,
-    )
 
     await delete_polygon(session, polygon, uuid.uuid4())  # type: ignore[arg-type]
 
     bump.assert_awaited_once_with(session)
-    cancel_publications.assert_awaited_once_with(session, polygon.uuid)
     assert session.deleted is polygon
     assert session.committed is True
-    assert session.added[0].action == "POLYGON_DELETED"
-    assert session.added[0].event_metadata == {"title": "Delete me"}
+    # The outbox event is also added
+    assert any(getattr(item, "action", None) == "POLYGON_DELETED" for item in session.added)
+    assert any(getattr(item, "event_metadata", None) == {"title": "Delete me"} for item in session.added)
 
 
 class FakeDeleteSession:

--- a/backend/tests/test_polygon_slugs.py
+++ b/backend/tests/test_polygon_slugs.py
@@ -82,6 +82,9 @@ class FakeUpdateSession:
     async def commit(self) -> None:
         pass
 
+    async def flush(self) -> None:
+        pass
+
     async def refresh(self, _item: object) -> None:
         pass
 
@@ -118,6 +121,9 @@ class FakeDeleteSession:
 
     def add(self, item: object) -> None:
         self.added.append(item)
+
+    async def flush(self) -> None:
+        pass
 
     async def delete(self, item: object) -> None:
         self.deleted = item

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,3 +60,4 @@ Eine neue sichtbare Kernfunktion benötigt:
 4. Tests für neue Slugs, Navigation und zentrale Suchbegriffe.
 
 Änderungen an Environment-Variablen, CLI-Befehlen, Rollen, Routen oder systemd-Units müssen gleichzeitig in den betroffenen Dokumenten aktualisiert werden. Die Dateien `.env.example`, die Pydantic-Settings, die tatsächlichen CLI-Module und `deploy/systemd/` sind dabei maßgeblich.
+- [Polygon API: Konsistenzmodell & Outbox](polygon-consistency.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -156,9 +156,10 @@ ASSISTANT_QUERY_LOGGING=false
 
 ## Mastodon und E-Mail-Outbox
 
-Social Publishing ist optional und wird in [social-publishing.md](social-publishing.md) beschrieben. Die E-Mail-Outbox verarbeitet unter anderem retryfähige Willkommensmails. Mitgelieferte Timer:
+Social Publishing ist optional und wird in [social-publishing.md](social-publishing.md) beschrieben. Die E-Mail-Outbox verarbeitet unter anderem retryfähige Willkommensmails. Die Polygon-Outbox verarbeitet Seiteneffekte nach Flächenmutationen (Adressanreicherung, Cache-Invalidierung, Benachrichtigungen) zuverlässig asynchron. Mitgelieferte Timer:
 
 ```bash
+sudo systemctl enable --now stadtplaner-polygon-outbox.timer
 sudo systemctl enable --now stadtplaner-social-publisher.timer
 sudo systemctl enable --now stadtplaner-email-outbox.timer
 systemctl list-timers 'stadtplaner-*'
@@ -202,6 +203,7 @@ curl --fail --silent https://<frontend-origin>/dokumentation
 sudo journalctl -u <api-service> -n 200 --no-pager
 sudo journalctl -u <frontend-service> -n 200 --no-pager
 sudo journalctl -u stadtplaner-email-outbox.service -n 100 --no-pager
+sudo journalctl -u stadtplaner-polygon-outbox.service -n 100 --no-pager
 sudo journalctl -u stadtplaner-social-publisher.service -n 100 --no-pager
 sudo systemctl list-timers 'stadtplaner-*'
 ```

--- a/docs/polygon-consistency.md
+++ b/docs/polygon-consistency.md
@@ -1,0 +1,18 @@
+# Polygon API: Konsistenzmodell & Outbox
+
+## Transaktionsgrenzen und Atomarität
+Alle Mutationen an Polygonen (`create`, `update`, `delete`) garantieren die atomare Speicherung der Kernressource (`UserPolygon`), ihres Zuordnungsstatus (`polygon_analysis_areas`) sowie zugehöriger Audit-Logs. Ein Fehler nach erfolgreicher Transaktion (z. B. durch Ausfall externer Dienste wie Nominatim) führt nicht mehr zu einer HTTP-500-Antwort für eine bereits dauerhaft gespeicherte Fläche.
+
+## Seiteneffekte über Outbox
+Externe und nichtkritische Seiteneffekte wurden von der synchronen Request-Verarbeitung entkoppelt. Sie werden als langlebige Aufträge in die Tabelle `polygon_outbox` geschrieben und asynchron abgearbeitet.
+Dazu gehören:
+- **Adressanreicherung (Nominatim)**: Löst nach erfolgreicher Adressfindung optional eine Aktualisierung des Polygon-Slugs aus.
+- **Benachrichtigungen**: Nutzer und Subscriber werden nach Mutationen per E-Mail und In-App benachrichtigt.
+- **Social Publishing**: Bei relevanter Bedeutung für den Newsfeed.
+- **Cache Invalidierung**: (Falls materialisierte Views oder externe Systeme asynchron bedient werden).
+
+## Wiederholungsverhalten und Idempotenz
+Die Polygon-Erstellung über `POST /polygons` unterstützt einen `idempotency_key` (Wiederholungsschutz). Wird ein Request mit demselben Idempotency Key wiederholt, gibt die API die bereits erstellte Fläche zurück (`201 Created` oder im Body erkennbar), ohne eine zweite Fläche oder doppelte Outbox-Events anzulegen.
+
+## Monitoring
+Der Cronjob/Worker `backend/app/cli/process_polygon_outbox.py` verarbeitet die Aufträge. Die Zustände der Outbox (`PENDING`, `PROCESSING`, `COMPLETED`, `FAILED`, `DEAD_LETTER`) können überwacht werden. Ein Auftrag wandert nach 8 fehlgeschlagenen Zustellversuchen mit exponentiellem Backoff in den `DEAD_LETTER` Zustand.


### PR DESCRIPTION
This PR implements atomic mutations for polygons to prevent partial failures when external side effects (like Nominatim enrichment or notifications) fail after the geometry has already been persisted.

**Approach:**
- **Atomic Transactions:** `create`, `update`, `update_verwaltung`, and `delete` mutations now run their core database changes within a single commit boundary.
- **Outbox Pattern:** External and non-critical side effects are offloaded to a new `PolygonOutbox` table. A new worker script handles Nominatim address enrichment, notifications, and social publishing asynchronously with robust retries.
- **Idempotency:** Added an `idempotency_key` field to the `UserPolygon` model and `PolygonCreate` schema, allowing safe retries on `POST /polygons` without creating duplicates.
- **Documentation:** Added `docs/polygon-consistency.md` to detail the API consistency model and outbox workflow, and updated `docs/deployment.md` with the necessary systemd timers for the outbox worker.

Fixes: #10