### PR TITLE
Limit public polygon GeoJSON payloads

### DIFF
--- a/backend/app/api/analysis_areas.py
+++ b/backend/app/api/analysis_areas.py
@@ -64,9 +64,13 @@ async def get_areas(
 
 
 @router.get("/geojson", summary="Analysegebiete als GeoJSON laden")
-async def get_areas_geojson(session: SessionDep, response: Response) -> dict:
+async def get_areas_geojson(
+    session: SessionDep,
+    response: Response,
+    limit: Annotated[int, Query(ge=1)] = get_settings().public_polygon_response_limit,
+) -> dict:
     response.headers["Cache-Control"] = "public, max-age=300"
-    result = await areas_geojson(session)
+    result = await areas_geojson(session, limit=limit)
     if get_settings().cache_debug_headers and (status := last_cache_status()):
         response.headers["X-Cache"] = status
     return result

--- a/backend/app/api/polygons.py
+++ b/backend/app/api/polygons.py
@@ -13,6 +13,7 @@ from app.auth.dependencies import (
     get_verified_user,
     require_verwaltung_user,
 )
+from app.core.config import get_settings
 from app.db.session import get_session
 from app.models.user import User
 from app.schemas.analytics import ComparableResult, LocationAnalysis
@@ -66,8 +67,11 @@ SessionDep = Annotated[AsyncSession, Depends(get_session)]
 
 
 @router.get("", response_model=list[PublicPolygonRead])
-async def get_polygons(session: SessionDep) -> list[PublicPolygonRead]:
-    return await list_public_polygons(session)
+async def get_polygons(
+    session: SessionDep,
+    limit: Annotated[int, Query(ge=1)] = get_settings().public_polygon_response_limit,
+) -> list[PublicPolygonRead]:
+    return await list_public_polygons(session, limit=limit)
 
 
 @router.post("", response_model=PolygonRead, status_code=status.HTTP_201_CREATED)
@@ -162,16 +166,20 @@ async def post_polygon_from_osm(
 
 
 @router.get("/geojson", response_model=FeatureCollection)
-async def get_geojson(session: SessionDep) -> FeatureCollection:
-    return await polygons_geojson(session)
+async def get_geojson(
+    session: SessionDep,
+    limit: Annotated[int, Query(ge=1)] = get_settings().public_polygon_response_limit,
+) -> FeatureCollection:
+    return await polygons_geojson(session, limit=limit)
 
 
 @router.get("/overview", response_model=list[PolygonOverviewRead])
 async def get_polygon_overview(
     session: SessionDep,
     filters: Annotated[PolygonFilterParams, Depends(polygon_filter_query)],
+    limit: Annotated[int, Query(ge=1)] = get_settings().public_polygon_response_limit,
 ) -> list[PolygonOverviewRead]:
-    return await list_polygon_overview(session, filters)
+    return await list_polygon_overview(session, filters, limit=limit)
 
 
 @router.get("/sitemap", response_model=list[PolygonSitemapEntry])

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -166,6 +166,7 @@ class Settings(BaseSettings):
     flensburg_superset_dashboard_id: str = "3b53ff0b-6e8c-435e-83f6-666f8a7cc158"
     flensburg_superset_timeout_seconds: float = 60.0
     polygon_cache_ttl: int = 60
+    public_polygon_response_limit: int = Field(default=1_000, ge=10, le=10_000)
     comparable_cache_ttl: int = 600
     cache_payload_warning_bytes: int = 2_000_000
     database_pool_size: int = 10

--- a/backend/app/services/analysis_area_api.py
+++ b/backend/app/services/analysis_area_api.py
@@ -152,13 +152,15 @@ async def _area_detail_by_slug_uncached(session: AsyncSession, slug: str) -> Ana
     )
 
 
-async def _areas_geojson_uncached(session: AsyncSession) -> dict:
+async def _areas_geojson_uncached(session: AsyncSession, *, limit: int | None = None) -> dict:
+    effective_limit = min(limit or get_settings().public_polygon_response_limit, get_settings().public_polygon_response_limit)
     rows = (await session.execute(text("""
       SELECT uuid::text AS id, slug, name, area_type, parent_id, area_m2, source,
              source_osm_type, source_osm_id, source_admin_level,
              ST_AsGeoJSON(geometry,6)::json AS geometry
       FROM analysis_areas ORDER BY CASE area_type WHEN 'MUNICIPALITY' THEN 1 WHEN 'DISTRICT' THEN 2 ELSE 3 END,name
-    """))).mappings().all()
+      LIMIT :limit
+    """), {"limit": effective_limit})).mappings().all()
     return {"type": "FeatureCollection", "features": [
         {"type": "Feature", "id": row["id"], "geometry": row["geometry"],
          "properties": {key: value for key, value in row.items() if key != "geometry"}}
@@ -315,14 +317,15 @@ async def area_uuid_by_slug(session: AsyncSession, slug: str) -> uuid.UUID | Non
     return await session.scalar(select(AnalysisArea.uuid).where(AnalysisArea.slug == slug))
 
 
-async def areas_geojson(session: AsyncSession) -> dict:
+async def areas_geojson(session: AsyncSession, *, limit: int | None = None) -> dict:
+    effective_limit = min(limit or get_settings().public_polygon_response_limit, get_settings().public_polygon_response_limit)
     version = await cache_version(session, "analysis-areas")
-    key = build_cache_key("analysis-area:geojson", {}, version=version)
+    key = build_cache_key("analysis-area:geojson", {"limit": effective_limit}, version=version)
     data, _status = await cache_service.get_or_compute(
         key,
         ttl=get_settings().analysis_area_cache_ttl,
         resource="analysis-area-geojson",
-        compute=lambda: _areas_geojson_uncached(session),
+        compute=lambda: _areas_geojson_uncached(session, limit=effective_limit),
     )
     return data
 

--- a/backend/app/services/polygons.py
+++ b/backend/app/services/polygons.py
@@ -81,20 +81,32 @@ async def list_polygons(session: AsyncSession) -> list[PolygonRead]:
     return [serialize_polygon(row) for row in rows]
 
 
-async def list_public_polygons(session: AsyncSession) -> list[PublicPolygonRead]:
-    rows = await session.scalars(select(UserPolygon).order_by(UserPolygon.created_at.desc()))
+def _bounded_public_limit(limit: int | None) -> int:
+    server_limit = get_settings().public_polygon_response_limit
+    requested = server_limit if limit is None else limit
+    return min(requested, server_limit)
+
+
+async def list_public_polygons(session: AsyncSession, *, limit: int | None = None) -> list[PublicPolygonRead]:
+    effective_limit = _bounded_public_limit(limit)
+    rows = await session.scalars(
+        select(UserPolygon).order_by(UserPolygon.created_at.desc()).limit(effective_limit)
+    )
     return [serialize_public_polygon(row) for row in rows]
 
 
 async def list_polygon_overview(
     session: AsyncSession,
     filters: PolygonFilterParams | None = None,
+    *,
+    limit: int | None = None,
 ) -> list[PolygonOverviewRead]:
     statement = (
         select(UserPolygon)
         .where(*polygon_filter_clauses(filters or PolygonFilterParams()))
         .order_by(UserPolygon.created_at.desc())
     )
+    statement = statement.limit(_bounded_public_limit(limit))
     rows = await session.scalars(statement)
     return [
         PolygonOverviewRead(
@@ -543,8 +555,8 @@ async def delete_polygon(
     )
 
 
-async def _polygons_geojson_uncached(session: AsyncSession) -> FeatureCollection:
-    polygons = await list_public_polygons(session)
+async def _polygons_geojson_uncached(session: AsyncSession, *, limit: int | None = None) -> FeatureCollection:
+    polygons = await list_public_polygons(session, limit=limit)
     return FeatureCollection(
         type="FeatureCollection",
         features=[
@@ -565,12 +577,13 @@ async def _polygons_geojson_uncached(session: AsyncSession) -> FeatureCollection
     )
 
 
-async def polygons_geojson(session: AsyncSession) -> FeatureCollection:
+async def polygons_geojson(session: AsyncSession, *, limit: int | None = None) -> FeatureCollection:
     version = await cache_version(session, "polygons")
-    key = build_cache_key("polygons:geojson", {"scope": "public"}, version=version)
+    key = build_cache_key("polygons:geojson", {"scope": "public", "limit": _bounded_public_limit(limit)}, version=version)
+    effective_limit = _bounded_public_limit(limit)
 
     async def compute() -> dict:
-        result = await _polygons_geojson_uncached(session)
+        result = await _polygons_geojson_uncached(session, limit=effective_limit)
         return result.model_dump(mode="json")
 
     data, _status = await cache_service.get_or_compute(

--- a/backend/tests/test_analysis_area_public_api.py
+++ b/backend/tests/test_analysis_area_public_api.py
@@ -30,6 +30,18 @@ def test_openapi_documents_public_area_routes_and_unique_operations() -> None:
     assert paths["/api/v1/polygons"]["post"]["security"] == [{"AccessCookie": []}]
 
 
+def test_public_polygon_and_geojson_routes_expose_a_cap_limit() -> None:
+    schema = app.openapi()
+    for path in (
+        "/api/v1/polygons",
+        "/api/v1/polygons/overview",
+        "/api/v1/polygons/geojson",
+        "/api/v1/analysis-areas/geojson",
+    ):
+        params = schema["paths"][path]["get"]["parameters"]
+        assert any(parameter["name"] == "limit" for parameter in params)
+
+
 def test_public_area_dtos_exclude_confidential_management_fields() -> None:
     now = datetime.now(UTC)
     detail = AnalysisAreaDetail(

--- a/frontend/app/composables/usePolygonApi.ts
+++ b/frontend/app/composables/usePolygonApi.ts
@@ -27,7 +27,9 @@ export const usePolygonApi = () => {
       return polygons.map((polygon) => polygonSchema.parse(polygon))
     },
     async overview(query = '', signal?: AbortSignal) {
-      const polygons = await request<unknown[]>(`/polygons/overview${query ? `?${query}` : ''}`, { signal })
+      const limit = 1000
+      const suffix = query ? `${query}&limit=${limit}` : `?limit=${limit}`
+      const polygons = await request<unknown[]>(`/polygons/overview${suffix}`, { signal })
       return polygons.map(polygon => polygonOverviewSchema.parse(polygon)) as PolygonOverview[]
     },
     async create(payload: PolygonPayload) {
@@ -91,7 +93,7 @@ export const usePolygonApi = () => {
       return polygon
     },
     async geojson() {
-      return await request('/polygons/geojson')
+      return await request('/polygons/geojson?limit=1000')
     }
   }
 }

--- a/frontend/app/composables/usePolygonApi.ts
+++ b/frontend/app/composables/usePolygonApi.ts
@@ -28,7 +28,7 @@ export const usePolygonApi = () => {
     },
     async overview(query = '', signal?: AbortSignal) {
       const limit = 1000
-      const suffix = query ? `${query}&limit=${limit}` : `?limit=${limit}`
+      const suffix = query ? `?${query}&limit=${limit}` : `?limit=${limit}`
       const polygons = await request<unknown[]>(`/polygons/overview${suffix}`, { signal })
       return polygons.map(polygon => polygonOverviewSchema.parse(polygon)) as PolygonOverview[]
     },

--- a/frontend/app/stores/analysisAreas.ts
+++ b/frontend/app/stores/analysisAreas.ts
@@ -37,7 +37,7 @@ export const useAnalysisAreasStore = defineStore('analysisAreas', {
         const api = useApi()
         const [areas, featureCollection] = await Promise.all([
           api.request<AnalysisArea[]>('/analysis-areas'),
-          api.request<AnalysisAreaFeatureCollection>('/analysis-areas/geojson')
+          api.request<AnalysisAreaFeatureCollection>('/analysis-areas/geojson?limit=1000')
         ])
         this.areas = markRaw(areas)
         this.featureCollection = markRaw(featureCollection)

--- a/frontend/e2e/gis-multiselect.spec.ts
+++ b/frontend/e2e/gis-multiselect.spec.ts
@@ -98,7 +98,7 @@ async function mockGis(page: Page) {
     } })
   })
   await page.route('**/api/v1/analysis-areas', route => route.fulfill({ json: [] }))
-  await page.route('**/api/v1/analysis-areas/geojson', route => route.fulfill({ json: { type: 'FeatureCollection', features: [] } }))
+  await page.route(/\/api\/v1\/analysis-areas\/geojson(?:\?.*)?$/, route => route.fulfill({ json: { type: 'FeatureCollection', features: [] } }))
 }
 
 function group(page: Page, title: string) {

--- a/frontend/e2e/header-create-cta.spec.ts
+++ b/frontend/e2e/header-create-cta.spec.ts
@@ -31,7 +31,7 @@ async function mockOverview(page: Page) {
     prime_rents: { unit: 'EUR_PER_SQM', period: null, rows: [] }
   } }))
   await page.route('**/api/v1/analysis-areas', route => route.fulfill({ json: [] }))
-  await page.route('**/api/v1/analysis-areas/geojson', route => route.fulfill({ json: { type: 'FeatureCollection', features: [] } }))
+  await page.route(/\/api\/v1\/analysis-areas\/geojson(?:\?.*)?$/, route => route.fulfill({ json: { type: 'FeatureCollection', features: [] } }))
   await page.route('**/api/v1/osm/features?**', route => route.fulfill({ json: {
     type: 'FeatureCollection', features: [], meta: { count: 0, summary: {}, canonical_summary: {}, canonical_facets: {}, business_count: 0, context_count: 0, deduplicated_linked_count: 0, truncated: false, zoom: 17, osm_data_updated_at: null }
   } }))


### PR DESCRIPTION
## Why
Public polygon and GeoJSON endpoints were returning unbounded result sets, so database work, cache size, response size, and browser rendering cost grew with the number of stored polygons. This change adds a clear cap so map and public list requests stay predictable as the dataset grows.

## What changed
- Added a server-side `public_polygon_response_limit` setting and enforced it on the public polygon and GeoJSON endpoints.
- Applied the cap to `/polygons`, `/polygons/overview`, `/polygons/geojson`, and `/analysis-areas/geojson`.
- Updated the frontend overview and GeoJSON requests to pass the bounded limit explicitly instead of loading the complete public dataset by default.
- Added an API test covering the exposed `limit` parameter on the affected public routes.

## Notes
- The change is intentionally limited to payload bounds. Detail and editor responses remain unchanged, so full geometry fidelity is preserved where it is needed most.

Fixes: #12