### PR TITLE
security: add backend dependency audit and SAST gates

### DIFF
--- a/.github/security-exceptions.yml
+++ b/.github/security-exceptions.yml
@@ -1,0 +1,30 @@
+version: 1
+exceptions:
+  - id: generic-api-key@f0f6a914704eaf570513fee5873d0bbda7295e03:deploy/ansible/vault.example.yml:105
+    scanner: secret-scan
+    reason: Empty OPENAI_API_KEY and GROQ_API_KEY example variables match the generic assignment rule.
+    owner: security-maintainers
+    expires: '2027-02-23'
+    mitigation: The example contains no value and production values remain in Ansible Vault.
+    review_date: '2026-11-23'
+  - id: generic-api-key@394824ab92f21c4a230c7db5ad89a8cda9cfe42b:backend/app/services/assistant_knowledge.py:147
+    scanner: secret-scan
+    reason: A historical metric identifier matched the generic API key heuristic.
+    owner: security-maintainers
+    expires: '2027-02-23'
+    mitigation: The matched value is a public source-code identifier and not credential material.
+    review_date: '2026-11-23'
+  - id: generic-api-key@fa7e9476fc369a0b7fe3e461099f25b7406b6945:backend/tests/test_auth_restart.py:36
+    scanner: secret-scan
+    reason: A deterministic JWT signing value is required to test key rotation behavior.
+    owner: security-maintainers
+    expires: '2027-02-23'
+    mitigation: The value is test-only, synthetic, and cannot authenticate against any environment.
+    review_date: '2026-11-23'
+  - id: generic-api-key@c9f6c2f1f5b37c0f17731af485f7149b99fc872d:backend/tests/test_oauth_routes.py:74
+    scanner: secret-scan
+    reason: A deterministic test-only encryption key matches the generic API key heuristic.
+    owner: security-maintainers
+    expires: '2027-02-23'
+    mitigation: The value is synthetic and is never used outside the isolated unit test.
+    review_date: '2026-11-23'

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  packages: read
+  security-events: write
   id-token: write
   attestations: write
 
@@ -34,8 +36,7 @@ jobs:
     name: Security gate
     uses: ./.github/workflows/security.yml
     with:
-      dependency_review: true
-      frontend_audit: true
+      dependency_review: ${{ github.event_name == 'pull_request' }}
       base_ref: ${{ github.event.pull_request.base.sha || github.event.before || github.sha }}
       head_ref: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,14 +83,7 @@ jobs:
       - name: Audit frozen production dependencies
         run: backend/.venv/bin/python scripts/security/audit_backend.py
       - name: Prove the audit blocks a vulnerable dependency fixture
-        working-directory: backend
-        run: |
-          if uv run --frozen --extra security pip-audit \
-            --requirement ../tests/security/fixtures/vulnerable-requirements.txt \
-            --no-deps --disable-pip --progress-spinner off; then
-            echo "pip-audit accepted the intentionally vulnerable fixture." >&2
-            exit 1
-          fi
+        run: backend/.venv/bin/python scripts/security/test_backend_audit_gate.py
 
   frontend-audit:
     name: Frontend production dependency audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,12 +7,7 @@ on:
   workflow_call:
     inputs:
       dependency_review:
-        description: Whether to run the dependency review gate.
-        required: false
-        type: boolean
-        default: false
-      frontend_audit:
-        description: Whether to run the frontend dependency audit.
+        description: Whether to run the dependency review diff gate.
         required: false
         type: boolean
         default: false
@@ -35,9 +30,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  security-policy-validation:
+    name: Security policy validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: .python-version
+      - name: Install pinned security policy dependencies
+        working-directory: backend
+        run: |
+          python -m pip install 'uv==0.12.5'
+          uv sync --frozen --extra security --no-editable
+      - name: Validate time-bounded exceptions
+        run: backend/.venv/bin/python scripts/security/validate_security_exceptions.py
+      - name: Run security gate policy tests
+        run: backend/.venv/bin/python -m unittest scripts.security.tests.test_security_gates
+
   dependency-review:
     name: Dependency review
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || inputs.dependency_review
+    if: github.event_name == 'pull_request' || inputs.dependency_review
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -47,16 +61,52 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
-          base-ref: ${{ inputs.base_ref || github.event.pull_request.base.sha || github.event.before || github.event.repository.default_branch }}
+          base-ref: ${{ inputs.base_ref || github.event.pull_request.base.sha }}
           head-ref: ${{ inputs.head_ref || github.event.pull_request.head.sha || github.sha }}
+          fail-on-severity: high
 
-  frontend-audit:
-    name: Scheduled frontend dependency audit
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || inputs.frontend_audit
+  backend-audit:
+    name: Backend production dependency audit
+    needs: security-policy-validation
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: .python-version
+      - name: Install the locked Python audit environment
+        working-directory: backend
+        run: |
+          python -m pip install 'uv==0.12.5'
+          uv sync --frozen --extra security --no-editable
+      - name: Audit frozen production dependencies
+        run: backend/.venv/bin/python scripts/security/audit_backend.py
+      - name: Prove the audit blocks a vulnerable dependency fixture
+        working-directory: backend
+        run: |
+          if uv run --frozen --extra security pip-audit \
+            --requirement ../tests/security/fixtures/vulnerable-requirements.txt \
+            --no-deps --disable-pip --progress-spinner off; then
+            echo "pip-audit accepted the intentionally vulnerable fixture." >&2
+            exit 1
+          fi
+
+  frontend-audit:
+    name: Frontend production dependency audit
+    needs: security-policy-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: .python-version
+      - name: Install locked security policy dependencies
+        working-directory: backend
+        run: |
+          python -m pip install 'uv==0.12.5'
+          uv sync --frozen --extra security --no-editable
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.2
         with:
           version: 11.22.0
@@ -69,5 +119,92 @@ jobs:
         working-directory: frontend
         run: pnpm install --frozen-lockfile
       - name: Check production dependencies
-        working-directory: frontend
-        run: pnpm audit --prod --audit-level high
+        run: backend/.venv/bin/python scripts/security/audit_frontend.py
+
+  sast:
+    name: CodeQL SAST (${{ matrix.language }})
+    needs: security-policy-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: .python-version
+      - name: Install locked security policy dependencies
+        working-directory: backend
+        run: |
+          python -m pip install 'uv==0.12.5'
+          uv sync --frozen --extra security --no-editable
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+      - name: Analyze and upload SARIF
+        id: codeql-analyze
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          category: /language:${{ matrix.language }}
+          output: codeql-results
+          upload: always
+      - name: Enforce High/Critical CodeQL policy
+        env:
+          SARIF_DIRECTORY: ${{ steps.codeql-analyze.outputs.sarif-output }}
+        run: |
+          mapfile -d '' sarif_files < <(find "${SARIF_DIRECTORY}" -type f -name '*.sarif' -print0)
+          if (( ${#sarif_files[@]} == 0 )); then
+            echo "CodeQL did not produce a SARIF report." >&2
+            exit 1
+          fi
+          backend/.venv/bin/python scripts/security/enforce_sarif.py \
+            --scanner codeql "${sarif_files[@]}"
+
+  secret-scan:
+    name: Repository secret scan
+    needs: security-policy-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: .python-version
+      - name: Install locked security policy dependencies
+        working-directory: backend
+        run: |
+          python -m pip install 'uv==0.12.5'
+          uv sync --frozen --extra security --no-editable
+      - name: Install checksum-verified Gitleaks
+        run: |
+          scripts/security/install_gitleaks.sh "${RUNNER_TEMP}/gitleaks-bin"
+          echo "${RUNNER_TEMP}/gitleaks-bin" >> "${GITHUB_PATH}"
+      - name: Scan complete repository history with redacted output
+        run: |
+          gitleaks git --no-banner --redact=100 --exit-code 0 \
+            --config .gitleaks.toml --report-format sarif \
+            --report-path gitleaks.sarif .
+      - name: Upload secret findings to Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+      - name: Enforce High/Critical secret policy
+        run: backend/.venv/bin/python scripts/security/enforce_sarif.py --scanner secret-scan gitleaks.sarif
+      - name: Prove secret detection and inline test allowlisting
+        run: scripts/security/test_gitleaks_gate.sh

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+title = "Open City Planner secret scanning"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "ocm-artificial-test-secret"
+description = "Synthetic credential used only by the secret-gate regression test"
+regex = '''OCM_TEST_SECRET_[A-Z0-9]{20}'''
+keywords = ["OCM_TEST_SECRET_"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,66 @@ Sicherheitskorrekturen werden für den aktuellen Stand des Branches `main` berei
 
 Bitte veröffentlichen Sie Sicherheitslücken nicht in einem öffentlichen Issue. Nutzen Sie die [Kontaktseite des Stadtplaners](https://stadtplaner.oklabflensburg.de/kontakt) und übermitteln Sie zunächst nur die technischen Angaben, die zur Reproduktion und Bewertung des Problems erforderlich sind. Geben Sie den Verantwortlichen ausreichend Zeit, das Problem zu untersuchen und eine Korrektur bereitzustellen, bevor Sie es veröffentlichen. Greifen Sie bei Sicherheitsuntersuchungen nicht auf Daten anderer Personen zu und speichern Sie solche Daten nicht.
 
+## Automatisierte Sicherheitsprüfungen
+
+Der zentrale Security-Workflow läuft für Pull Requests, jeden Push, manuelle
+Aufrufe und montags zeitgesteuert. Das Release Gate ruft denselben Workflow
+verpflichtend auf. Er umfasst:
+
+- GitHub Dependency Review als Diff-Prüfung für Pull Requests;
+- `pip-audit 2.10.1` gegen den mit `uv export --frozen` aus
+  `backend/uv.lock` abgeleiteten Produktionssatz;
+- `pnpm audit --prod` gegen das unveränderte `frontend/pnpm-lock.yaml`;
+- CodeQL `4.37.8` mit `security-extended` für Python und
+  JavaScript/TypeScript;
+- Gitleaks `8.30.1` gegen die vollständige Git-Historie, mit vollständig
+  redigierter Konsolenausgabe;
+- Validierung aller zeitlich begrenzten Ausnahmen und negative Gate-Tests.
+
+CodeQL- und Gitleaks-Ergebnisse werden als SARIF in GitHub Code Scanning
+veröffentlicht. Pull Requests aus Forks laufen im normalen `pull_request`-
+Kontext und erhalten keine Produktionsgeheimnisse oder privilegierten
+Maintainer-Token.
+
+## Schweregrade und Blockierregeln
+
+Critical und High blockieren einen Release. Medium wird innerhalb der regulären
+Security-Triage bewertet; Low ist zunächst informativ. Die Werkzeuge werden
+folgendermaßen auf diese gemeinsame Policy abgebildet:
+
+- Dependency Review und pnpm: `critical` und `high` blockieren.
+- CodeQL: Security Score ab 9,0 ist Critical, ab 7,0 High. SARIF-`error`
+  ohne numerischen Score wird vorsorglich als High behandelt.
+- Gitleaks: Jeder nicht ausgenommene Fund gilt als High.
+- `pip-audit`: Da die Advisory-Quellen nicht durchgängig einen stabilen,
+  normalisierten Schweregrad liefern, blockiert vorsorglich jede bekannte
+  Schwachstelle.
+
+Critical-Funde werden innerhalb von 24 Stunden triagiert und unverzüglich
+behoben oder mitigiert. High-Funde werden innerhalb von drei Werktagen triagiert
+und innerhalb von 14 Kalendertagen behoben oder mitigiert. Medium und Low werden
+im regulären Wartungszyklus bewertet.
+
+## Befristete Ausnahmen
+
+Ausnahmen stehen ausschließlich in
+`.github/security-exceptions.yml`. Ein Eintrag benötigt Finding-/CVE-/Rule-ID,
+Scanner, Begründung, verantwortliches Team, Ablaufdatum, Mitigation und
+Review-Datum. Er darf nur nach Review durch eine für Security verantwortliche
+Maintainerin oder einen verantwortlichen Maintainer gemergt werden. Globale oder
+unbefristete Ignore-Regeln sind unzulässig.
+
+Vor Ablauf wird der Fund erneut bewertet, behoben oder über einen neuen Pull
+Request mit aktualisierter Begründung befristet verlängert. Fehlende,
+doppelte, ungültige oder abgelaufene Einträge lassen den Security-Workflow und
+damit das Release Gate fehlschlagen. Der Validator kann lokal ausgeführt werden:
+
+```bash
+cd backend
+uv sync --frozen --extra security --no-editable
+uv run --frozen --extra security python ../scripts/security/validate_security_exceptions.py
+```
+
 ## Sicherheitsarchitektur
 
 - Zugriffs- und Aktualisierungstokens werden in `HttpOnly`-Cookies gespeichert. Kurzlebige Zugriffs-JWTs sind an einen Aussteller, eine Zielgruppe und einen festgelegten Algorithmus gebunden. Aktualisierungstokens werden regelmäßig ersetzt; serverseitige Sitzungsfamilien erkennen eine Wiederverwendung.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,6 +41,10 @@ dev = [
   "pytest-asyncio>=1.1.0",
   "ruff>=0.12.8"
 ]
+security = [
+  "pip-audit==2.10.1",
+  "pyyaml==6.0.3"
+]
 
 [tool.ruff]
 line-length = 100

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -113,6 +113,33 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
+]
+
+[[package]]
 name = "cbor2"
 version = "6.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -158,6 +185,47 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
     { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
     { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
 ]
 
 [[package]]
@@ -219,6 +287,31 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/40/6509e6cfd7f2f3255501690f46375fdd224949e21fd1e96f4f4c8a9041b1/cyclonedx_python_lib-11.12.0.tar.gz", hash = "sha256:16767c4039de90c04e9f03348f8f0ed4b8ff842eaa7eefcad3a95685f970dacf", size = 1445378, upload-time = "2026-08-13T07:52:18.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/f0/b2cb999244f2f4194df63ecff6939228178fa63a33be809c412684ca8db7/cyclonedx_python_lib-11.12.0-py3-none-any.whl", hash = "sha256:0e807521a921a5c3cb8ce1153f8a61d29eedfe76a46aac2796b7c6b573391a54", size = 529453, upload-time = "2026-08-13T07:52:16.836Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -254,6 +347,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/64/a02e6765de08964ed371eca577870593245afc9dfac16d037de7c10d18e6/filelock-3.32.3.tar.gz", hash = "sha256:0ffa185a3540854c95caa7fa76b76cb219d907415e2c5dc9af25fd970563487f", size = 218135, upload-time = "2026-08-13T16:00:05.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl", hash = "sha256:7f0ca4bcc0e181c60dbbd8aa9ab5b120ebb99e4e064e83636340056f833a1f09", size = 98901, upload-time = "2026-08-13T16:00:03.974Z" },
 ]
 
 [[package]]
@@ -382,6 +484,18 @@ wheels = [
 ]
 
 [[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -391,6 +505,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -410,6 +536,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
     { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
     { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
 ]
 
 [[package]]
@@ -466,6 +620,10 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+security = [
+    { name = "pip-audit" },
+    { name = "pyyaml" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -479,6 +637,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pillow", specifier = ">=11.3.0" },
+    { name = "pip-audit", marker = "extra == 'security'", specifier = "==2.10.1" },
     { name = "playwright", specifier = ">=1.55.0" },
     { name = "pwdlib", extras = ["argon2"], specifier = ">=0.2.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
@@ -488,6 +647,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "pyyaml", marker = "extra == 'security'", specifier = "==6.0.3" },
     { name = "redis", specifier = ">=5.2,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.8" },
     { name = "shapely", specifier = ">=2.1.1" },
@@ -495,7 +655,16 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.35.0" },
     { name = "webauthn", specifier = ">=3.0.0,<4" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "security"]
+
+[[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
 
 [[package]]
 name = "packaging"
@@ -521,6 +690,70 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
     { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
     { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
 ]
 
 [[package]]
@@ -563,6 +796,18 @@ wheels = [
 [package.optional-dependencies]
 argon2 = [
     { name = "argon2-cffi" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -707,6 +952,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -781,6 +1035,34 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.16.4"
 source = { registry = "https://pypi.org/simple" }
@@ -825,6 +1107,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -858,6 +1149,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -876,6 +1194,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -137,11 +137,13 @@ PATH="/tmp/ocm-gitleaks:${PATH}" scripts/security/test_gitleaks_gate.sh
 PATH="/tmp/ocm-gitleaks:${PATH}" gitleaks git --redact=100 --config .gitleaks.toml .
 ```
 
-Die verwundbare Dependency-Fixture unter
-`tests/security/fixtures/vulnerable-requirements.txt` wird niemals installiert;
-sie beweist ausschließlich, dass `pip-audit` non-zero liefert. Der
-SARIF-Policy-Test beweist dasselbe für einen künstlichen High-CodeQL-Fund, der
-Gitleaks-Test für ein zusammengesetztes synthetisches Secret.
+Die negative Backend-Dependency-Fixture wird von
+`scripts/security/test_backend_audit_gate.py` ausschließlich in einem
+temporären Verzeichnis erzeugt und niemals installiert oder als
+Produktionsmanifest eingecheckt. Sie beweist, dass `pip-audit` non-zero
+liefert. Der SARIF-Policy-Test beweist dasselbe für einen künstlichen
+High-CodeQL-Fund, der Gitleaks-Test für ein zusammengesetztes synthetisches
+Secret.
 
 Dependabot aktualisiert GitHub Actions, `backend/uv.lock` und
 `frontend/pnpm-lock.yaml` ausschließlich per Pull Request. Jeder dieser Pull

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 # Continuous Integration
 
-Die CI ist in fünf getrennte GitHub-Actions-Workflows gegliedert. Alle Workflows
+Die CI ist in getrennte GitHub-Actions-Workflows gegliedert. Alle Workflows
 lassen sich manuell starten. Backend, Frontend und E2E laufen zusätzlich bei jedem
 Push und Pull Request, ohne Pfadfilter. Dadurch verschwinden Required Checks auch
 bei reinen Dokumentationsänderungen nicht.
@@ -17,6 +17,11 @@ bei reinen Dokumentationsänderungen nicht.
 | Frontend CI | `frontend-build` | produktiver Nuxt-Build |
 | Frontend CI | `frontend-language-audit` | Audit der sichtbaren Sprache |
 | E2E Tests | `e2e` | vollständige Playwright-Suite mit echtem Frontend, Backend und frischer PostGIS-Datenbank |
+| Security | `security-policy-validation` | Format, Vollständigkeit und Ablauf befristeter Security-Ausnahmen sowie negative Policy-Tests |
+| Security | `backend-audit` | `pip-audit 2.10.1` gegen den eingefrorenen Python-Produktionssatz |
+| Security | `frontend-audit` | `pnpm audit --prod` gegen das eingefrorene Frontend-Lockfile |
+| Security | `sast` | CodeQL-SAST für Python und JavaScript/TypeScript mit SARIF-Upload und High/Critical-Gate |
+| Security | `secret-scan` | Gitleaks gegen die vollständige Historie mit redigierter Ausgabe und SARIF-Upload |
 | Supply Chain | `verify` | Lockfile-Konsistenz, SHA-/Digest-Pins und negative Policy-Regressionstests |
 | Supply Chain | `sbom` | transitive CycloneDX-SBOMs für Backend und Frontend |
 
@@ -90,11 +95,53 @@ bereinigt sind, prüft CI deshalb den eindeutigen Head und das vollständige Upg
 
 ## Security-Workflow
 
-Bei Pull Requests prüft GitHubs Dependency Review neu hinzugekommene
-Abhängigkeiten. Das netzabhängige `pnpm audit` läuft wöchentlich montagmorgens und
-bei manuellem Start. Es ist bewusst kein Required Check: Änderungen oder Ausfälle
-externer Advisory-Datenbanken sollen reproduzierbare Pull-Request-Prüfungen nicht
-zufällig blockieren, bleiben im eigenen Workflow aber sichtbar und fehlschlagend.
+Der Security-Workflow läuft vollständig bei Pull Requests, Pushes, manuellen
+Starts, montags um 04:23 UTC und bei jedem Aufruf durch das Release Gate.
+Backend- und Frontend-Audit, beide CodeQL-Sprachen, Secret Scan und
+Policy-Validierung laufen dabei immer. Dependency Review ist bewusst das
+zusätzliche PR-Diff-Gate; vollständige Audits übernehmen Push und Schedule.
+
+Alle Security-Jobs sind über den reusable Workflow Teil des verpflichtenden
+Release Gate. High/Critical-Funde blockieren, ebenso ungültige oder abgelaufene
+Ausnahmen. `pip-audit` blockiert vorsorglich alle bekannten Advisories, weil
+dessen Quellen nicht für jeden Fund einen vergleichbaren Schweregrad liefern.
+Die genaue Severity-, SLA- und Ausnahme-Policy steht in [SECURITY.md](../SECURITY.md).
+
+CodeQL und Gitleaks laden SARIF nach GitHub Security / Code Scanning hoch. Nur
+diese Jobs erhalten `security-events: write`; ansonsten gilt `contents: read`.
+CodeQL erhält zusätzlich `packages: read` für das offizielle Bundle. Es gibt
+kein `pull_request_target`, keine Produktions-Secrets und kein `write-all`.
+
+Lokale Security-Prüfung:
+
+```bash
+cd backend
+python3 -m pip install 'uv==0.12.5'
+uv sync --frozen --extra security --no-editable
+uv run --frozen --extra security python ../scripts/security/audit_backend.py
+uv run --frozen --extra security python ../scripts/security/validate_security_exceptions.py
+cd ..
+backend/.venv/bin/python -m unittest scripts.security.tests.test_security_gates
+
+cd frontend
+pnpm install --frozen-lockfile
+../backend/.venv/bin/python ../scripts/security/audit_frontend.py
+```
+
+Gitleaks wird in CI über `scripts/security/install_gitleaks.sh` als Version
+8.30.1 mit geprüftem SHA-256 installiert. Anschließend:
+
+```bash
+scripts/security/install_gitleaks.sh /tmp/ocm-gitleaks
+PATH="/tmp/ocm-gitleaks:${PATH}" scripts/security/test_gitleaks_gate.sh
+PATH="/tmp/ocm-gitleaks:${PATH}" gitleaks git --redact=100 --config .gitleaks.toml .
+```
+
+Die verwundbare Dependency-Fixture unter
+`tests/security/fixtures/vulnerable-requirements.txt` wird niemals installiert;
+sie beweist ausschließlich, dass `pip-audit` non-zero liefert. Der
+SARIF-Policy-Test beweist dasselbe für einen künstlichen High-CodeQL-Fund, der
+Gitleaks-Test für ein zusammengesetztes synthetisches Secret.
 
 Dependabot aktualisiert GitHub Actions, `backend/uv.lock` und
 `frontend/pnpm-lock.yaml` ausschließlich per Pull Request. Jeder dieser Pull
@@ -114,11 +161,16 @@ Checks aus:
 - `frontend-build`
 - `frontend-language-audit`
 - `e2e`
+- `security-policy-validation`
+- `backend-audit`
+- `frontend-audit`
+- `sast`
+- `secret-scan`
 - `verify`
 - `sbom`
 - `gate`
 
 Zusätzlich empfehlen sich mindestens eine Freigabe, „Require conversation
 resolution before merging“ und „Require branches to be up to date before merging“.
-Der geplante Security-Audit bleibt beobachtbar, aber absichtlich außerhalb der
-Required Checks.
+Der zusammenfassende `gate`-Job verlangt den erfolgreichen reusable
+Security-Workflow und blockiert dadurch auch Production Deployments.

--- a/docs/security/production-checklist.md
+++ b/docs/security/production-checklist.md
@@ -52,6 +52,7 @@ Die Anwendung setzt ihre eigenen Größenlimits auch dann durch, wenn `Content-L
 - [ ] Backend-Tests und Ruff sind erfolgreich.
 - [ ] Frontend-Tests, Typprüfung und Produktions-Build sind erfolgreich.
 - [ ] Die bestehenden Playwright-Tests sind in einer isolierten Umgebung erfolgreich.
-- [ ] `pnpm audit --prod` und eine Python-Abhängigkeitsprüfung wurden ausgewertet.
+- [ ] Release Gate, Backend-/Frontend-Dependency-Audits, CodeQL-SAST,
+      Gitleaks und Security-Exception-Validierung sind für den Release-Commit grün.
 - [ ] Anmeldung, OAuth mit MFA, Passwortzurücksetzung, Abmeldung nach Passwortänderung, Rotation der Aktualisierungstokens, Admin-MFA und verifizierte GIS-Schreibzugriffe wurden durch Funktionstests geprüft.
 - [ ] Die Sicherheitsheader wurden anhand der tatsächlich öffentlich ausgelieferten Frontend- und API-Antworten geprüft.

--- a/scripts/security/__init__.py
+++ b/scripts/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security gate helpers."""

--- a/scripts/security/audit_backend.py
+++ b/scripts/security/audit_backend.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Audit the frozen set of production Python dependencies."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from .security_exceptions import ExceptionPolicyError, active_ids
+except ImportError:  # Support direct script execution.
+    from security_exceptions import ExceptionPolicyError, active_ids
+
+
+def main() -> int:
+    repository = Path(__file__).resolve().parents[2]
+    backend = repository / "backend"
+    policy = repository / ".github/security-exceptions.yml"
+    try:
+        ignored = sorted(active_ids(policy, "backend-dependency"))
+    except ExceptionPolicyError as exc:
+        print(f"Security exception policy failed: {exc}", file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory() as directory:
+        requirements = Path(directory) / "production-requirements.txt"
+        exported = subprocess.run(
+            [
+                "uv", "export", "--frozen", "--no-dev", "--no-default-groups",
+                "--no-emit-project", "--format", "requirements.txt", "--output-file",
+                str(requirements),
+            ],
+            cwd=backend,
+            check=False,
+            stdout=subprocess.DEVNULL,
+        )
+        if exported.returncode:
+            return exported.returncode
+        command = [
+            "uv", "run", "--frozen", "--extra", "security", "pip-audit",
+            "--requirement", str(requirements), "--require-hashes", "--disable-pip",
+            "--progress-spinner", "off",
+        ]
+        for finding_id in ignored:
+            command.extend(("--ignore-vuln", finding_id))
+        return subprocess.run(command, cwd=backend, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security/audit_frontend.py
+++ b/scripts/security/audit_frontend.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Audit frozen frontend production dependencies with the shared severity policy."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from .security_exceptions import ExceptionPolicyError, active_ids
+except ImportError:  # Support direct script execution.
+    from security_exceptions import ExceptionPolicyError, active_ids
+
+
+BLOCKING_SEVERITIES = {"high", "critical"}
+ADVISORY_ID = re.compile(r"(?:GHSA-[\w-]+|CVE-\d{4}-\d+)", re.IGNORECASE)
+
+
+def identifiers(advisory: dict[str, Any]) -> set[str]:
+    values: list[Any] = [
+        advisory.get("github_advisory_id"),
+        advisory.get("id"),
+        advisory.get("url"),
+        *(advisory.get("cves") or []),
+    ]
+    found: set[str] = set()
+    for value in values:
+        if value is None:
+            continue
+        matches = ADVISORY_ID.findall(str(value))
+        if matches:
+            found.update(match.upper() for match in matches)
+        elif isinstance(value, int) or str(value).isdigit():
+            found.add(str(value))
+    return found
+
+
+def blocking_advisories(document: dict[str, Any], ignored: set[str]) -> list[tuple[str, str, str]]:
+    findings: list[tuple[str, str, str]] = []
+    advisories = document.get("advisories", {})
+    if not isinstance(advisories, dict):
+        raise TypeError("pnpm audit response does not contain an advisories mapping")
+    for key, advisory in advisories.items():
+        if not isinstance(advisory, dict):
+            continue
+        finding_severity = str(advisory.get("severity", "unknown")).lower()
+        if finding_severity not in BLOCKING_SEVERITIES:
+            continue
+        ids = identifiers(advisory) or {str(key)}
+        if ids & ignored:
+            continue
+        canonical_id = next(
+            (value for value in sorted(ids) if value.startswith(("GHSA-", "CVE-"))),
+            min(ids),
+        )
+        findings.append((canonical_id, str(advisory.get("module_name", "unknown")), finding_severity))
+    return findings
+
+
+def main() -> int:
+    repository = Path(__file__).resolve().parents[2]
+    try:
+        ignored = active_ids(
+            repository / ".github/security-exceptions.yml", "frontend-dependency"
+        )
+    except ExceptionPolicyError as exc:
+        print(f"Security exception policy failed: {exc}", file=sys.stderr)
+        return 1
+
+    audit = subprocess.run(
+        ["pnpm", "audit", "--prod", "--audit-level", "high", "--json"],
+        cwd=repository / "frontend",
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    try:
+        document = json.loads(audit.stdout)
+        findings = blocking_advisories(document, ignored)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"Frontend audit failed to produce a valid report: {exc}", file=sys.stderr)
+        if audit.stderr:
+            print(audit.stderr.strip(), file=sys.stderr)
+        return 1
+    if findings:
+        print("Blocking frontend dependency findings:", file=sys.stderr)
+        for finding_id, package, finding_severity in findings:
+            print(f"- {finding_id}: {package} ({finding_severity})", file=sys.stderr)
+        return 1
+    if audit.returncode not in (0, 1):
+        print("Frontend audit failed because the advisory service was unavailable.", file=sys.stderr)
+        return audit.returncode
+    print("Frontend production dependency audit passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security/enforce_sarif.py
+++ b/scripts/security/enforce_sarif.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -40,6 +41,11 @@ def _secret_finding_id(rule_id: str, result: dict[str, Any]) -> str:
     line = location.get("region", {}).get("startLine", 0)
     commit = result.get("partialFingerprints", {}).get("commitSha", "working-tree")
     return f"{rule_id}@{commit}:{uri}:{line}"
+
+
+def _redact_finding_id(finding_id: str) -> str:
+    digest = hashlib.sha256(finding_id.encode("utf-8")).hexdigest()
+    return f"id:{digest[:12]}"
 
 
 def blocking_findings(
@@ -81,7 +87,7 @@ def main() -> int:
     if findings:
         print("Blocking SARIF findings:", file=sys.stderr)
         for rule_id, finding_severity in sorted(set(findings)):
-            print(f"- {rule_id}: {finding_severity}", file=sys.stderr)
+            print(f"- {_redact_finding_id(rule_id)}: {finding_severity}", file=sys.stderr)
         return 1
     print(f"SARIF policy passed for {args.scanner}.")
     return 0

--- a/scripts/security/enforce_sarif.py
+++ b/scripts/security/enforce_sarif.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Block High/Critical SARIF findings unless a current exception exists."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from .security_exceptions import ExceptionPolicyError, active_ids
+except ImportError:  # Support direct script execution.
+    from security_exceptions import ExceptionPolicyError, active_ids
+
+
+def severity(rule: dict[str, Any], result: dict[str, Any]) -> tuple[str, bool]:
+    properties = rule.get("properties", {})
+    raw_score = properties.get("security-severity") or properties.get("security_severity")
+    try:
+        score = float(raw_score)
+    except (TypeError, ValueError):
+        score = None
+    if score is not None:
+        if score >= 9.0:
+            return "critical", True
+        if score >= 7.0:
+            return "high", True
+        if score >= 4.0:
+            return "medium", False
+        return "low", False
+    level = result.get("level") or rule.get("defaultConfiguration", {}).get("level")
+    return ("high", True) if level == "error" else (str(level or "unknown"), False)
+
+
+def _secret_finding_id(rule_id: str, result: dict[str, Any]) -> str:
+    location = result.get("locations", [{}])[0].get("physicalLocation", {})
+    uri = location.get("artifactLocation", {}).get("uri", "unknown-path")
+    line = location.get("region", {}).get("startLine", 0)
+    commit = result.get("partialFingerprints", {}).get("commitSha", "working-tree")
+    return f"{rule_id}@{commit}:{uri}:{line}"
+
+
+def blocking_findings(
+    paths: list[Path], ignored: set[str], *, scanner: str = "codeql"
+) -> list[tuple[str, str]]:
+    findings: list[tuple[str, str]] = []
+    for path in paths:
+        document = json.loads(path.read_text())
+        for run in document.get("runs", []):
+            rules = {
+                rule.get("id"): rule
+                for rule in run.get("tool", {}).get("driver", {}).get("rules", [])
+            }
+            for result in run.get("results", []):
+                rule_id = result.get("ruleId", "unknown-rule")
+                finding_id = (
+                    _secret_finding_id(rule_id, result) if scanner == "secret-scan" else rule_id
+                )
+                finding_severity, blocks = severity(rules.get(rule_id, {}), result)
+                if scanner == "secret-scan":
+                    finding_severity, blocks = "high", True
+                if blocks and finding_id not in ignored:
+                    findings.append((finding_id, finding_severity))
+    return findings
+
+
+def main() -> int:
+    repository = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scanner", required=True, choices=("codeql", "secret-scan"))
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args()
+    try:
+        ignored = active_ids(repository / ".github/security-exceptions.yml", args.scanner)
+        findings = blocking_findings(args.paths, ignored, scanner=args.scanner)
+    except (ExceptionPolicyError, OSError, json.JSONDecodeError) as exc:
+        print(f"SARIF policy evaluation failed: {exc}", file=sys.stderr)
+        return 1
+    if findings:
+        print("Blocking SARIF findings:", file=sys.stderr)
+        for rule_id, finding_severity in sorted(set(findings)):
+            print(f"- {rule_id}: {finding_severity}", file=sys.stderr)
+        return 1
+    print(f"SARIF policy passed for {args.scanner}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security/install_gitleaks.sh
+++ b/scripts/security/install_gitleaks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITLEAKS_VERSION="8.30.1"
+GITLEAKS_LINUX_X64_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+
+if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+  echo "The pinned Gitleaks installer currently supports Linux x86_64 only." >&2
+  exit 1
+fi
+
+install_directory="${1:?usage: install_gitleaks.sh INSTALL_DIRECTORY}"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "${temporary_directory}"' EXIT
+archive="${temporary_directory}/gitleaks.tar.gz"
+
+curl --fail --silent --show-error --location \
+  "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+  --output "${archive}"
+echo "${GITLEAKS_LINUX_X64_SHA256}  ${archive}" | sha256sum --check --status
+tar -xzf "${archive}" -C "${temporary_directory}" gitleaks
+install -d "${install_directory}"
+install -m 0755 "${temporary_directory}/gitleaks" "${install_directory}/gitleaks"
+"${install_directory}/gitleaks" version

--- a/scripts/security/security_exceptions.py
+++ b/scripts/security/security_exceptions.py
@@ -1,0 +1,75 @@
+"""Load and validate time-bounded security exceptions."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REQUIRED_FIELDS = ("id", "scanner", "reason", "owner", "expires", "mitigation", "review_date")
+SCANNERS = {"backend-dependency", "frontend-dependency", "codeql", "secret-scan"}
+
+
+class ExceptionPolicyError(ValueError):
+    """Raised when the security exception file violates policy."""
+
+
+def _parse_date(value: Any, field: str, finding_id: str) -> date:
+    if not isinstance(value, str):
+        raise ExceptionPolicyError(f"{finding_id}: {field} must be an ISO date string")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ExceptionPolicyError(f"{finding_id}: {field} must use YYYY-MM-DD") from exc
+
+
+def load_exceptions(path: Path, *, today: date | None = None) -> list[dict[str, Any]]:
+    current_date = today or datetime.now(UTC).date()
+    try:
+        document = yaml.safe_load(path.read_text())
+    except (OSError, yaml.YAMLError) as exc:
+        raise ExceptionPolicyError(f"cannot read valid YAML from {path}: {exc}") from exc
+
+    if not isinstance(document, dict) or document.get("version") != 1:
+        raise ExceptionPolicyError("security exception policy must be a mapping with version: 1")
+    entries = document.get("exceptions")
+    if not isinstance(entries, list):
+        raise ExceptionPolicyError("security exception policy must contain an exceptions list")
+
+    seen: set[str] = set()
+    for index, entry in enumerate(entries, 1):
+        if not isinstance(entry, dict):
+            raise ExceptionPolicyError(f"exception {index} must be a mapping")
+        missing = [field for field in REQUIRED_FIELDS if field not in entry]
+        if missing:
+            raise ExceptionPolicyError(f"exception {index} is missing: {', '.join(missing)}")
+        finding_id = entry["id"]
+        if not isinstance(finding_id, str) or not finding_id.strip():
+            raise ExceptionPolicyError(f"exception {index}: id must be a non-empty string")
+        if finding_id in seen:
+            raise ExceptionPolicyError(f"duplicate security exception id: {finding_id}")
+        seen.add(finding_id)
+
+        scanner = entry["scanner"]
+        if scanner not in SCANNERS:
+            raise ExceptionPolicyError(
+                f"{finding_id}: scanner must be one of {', '.join(sorted(SCANNERS))}"
+            )
+        for field in ("reason", "owner", "mitigation"):
+            if not isinstance(entry[field], str) or not entry[field].strip():
+                raise ExceptionPolicyError(f"{finding_id}: {field} must be a non-empty string")
+
+        expires = _parse_date(entry["expires"], "expires", finding_id)
+        review_date = _parse_date(entry["review_date"], "review_date", finding_id)
+        if expires < current_date:
+            raise ExceptionPolicyError(f"{finding_id}: exception expired on {expires.isoformat()}")
+        if review_date > expires:
+            raise ExceptionPolicyError(f"{finding_id}: review_date must not be after expires")
+
+    return entries
+
+
+def active_ids(path: Path, scanner: str) -> set[str]:
+    return {entry["id"] for entry in load_exceptions(path) if entry["scanner"] == scanner}

--- a/scripts/security/test_backend_audit_gate.py
+++ b/scripts/security/test_backend_audit_gate.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Prove that pip-audit rejects a dynamically generated vulnerable fixture."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> int:
+    repository = Path(__file__).resolve().parents[2]
+    package = "urllib" + "3"
+    version = "1.24." + "1"
+    with tempfile.TemporaryDirectory() as directory:
+        fixture = Path(directory) / "audit-negative-fixture.txt"
+        fixture.write_text(f"{package}=={version}\n")
+        audit = subprocess.run(
+            [
+                "uv", "run", "--frozen", "--extra", "security", "pip-audit",
+                "--requirement", str(fixture), "--no-deps", "--disable-pip",
+                "--progress-spinner", "off",
+            ],
+            cwd=repository / "backend",
+            check=False,
+        )
+    if audit.returncode == 1:
+        print("Backend audit negative fixture was blocked.")
+        return 0
+    if audit.returncode == 0:
+        print("pip-audit accepted the intentionally vulnerable fixture.", file=sys.stderr)
+    else:
+        print(f"pip-audit failed unexpectedly with exit code {audit.returncode}.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security/test_gitleaks_gate.sh
+++ b/scripts/security/test_gitleaks_gate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "${temporary_directory}"' EXIT
+
+prefix="OCM_TEST_SECRET_"
+suffix="ABCDEFGHIJKLMNOPQRST"
+printf '%s%s\n' "${prefix}" "${suffix}" > "${temporary_directory}/must-block.txt"
+printf '%s%s # gitleaks:allow\n' "${prefix}" "${suffix}" > "${temporary_directory}/allowed.txt"
+
+if gitleaks dir --no-banner --redact=100 --config "${repository}/.gitleaks.toml" \
+  "${temporary_directory}/must-block.txt" >/dev/null 2>&1; then
+  echo "Gitleaks failed to block the synthetic test secret." >&2
+  exit 1
+fi
+
+gitleaks dir --no-banner --redact=100 --config "${repository}/.gitleaks.toml" \
+  "${temporary_directory}/allowed.txt" >/dev/null
+echo "Gitleaks negative and allowlist fixtures passed."

--- a/scripts/security/tests/__init__.py
+++ b/scripts/security/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Security helper regression tests."""

--- a/scripts/security/tests/test_security_gates.py
+++ b/scripts/security/tests/test_security_gates.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from scripts.security.audit_frontend import blocking_advisories
+from scripts.security.enforce_sarif import blocking_findings
+from scripts.security.security_exceptions import ExceptionPolicyError, load_exceptions
+
+
+class SecurityExceptionTests(unittest.TestCase):
+    def write_policy(self, content: str) -> Path:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as temporary:
+            temporary.write(content)
+        path = Path(temporary.name)
+        self.addCleanup(path.unlink, missing_ok=True)
+        return path
+
+    def test_empty_policy_is_valid(self) -> None:
+        path = self.write_policy("version: 1\nexceptions: []\n")
+        self.assertEqual(load_exceptions(path, today=date(2026, 8, 23)), [])
+
+    def test_expired_exception_is_rejected(self) -> None:
+        path = self.write_policy(
+            """version: 1
+exceptions:
+  - id: CVE-2099-0001
+    scanner: backend-dependency
+    reason: Temporary compatibility constraint
+    owner: security-team
+    expires: '2026-08-22'
+    mitigation: Network access is restricted
+    review_date: '2026-08-20'
+"""
+        )
+        with self.assertRaisesRegex(ExceptionPolicyError, "expired"):
+            load_exceptions(path, today=date(2026, 8, 23))
+
+    def test_duplicate_ids_are_rejected(self) -> None:
+        entry = """  - id: TEST-1
+    scanner: codeql
+    reason: Temporary false positive
+    owner: security-team
+    expires: '2026-09-30'
+    mitigation: Input is validated before this path
+    review_date: '2026-09-01'
+"""
+        path = self.write_policy("version: 1\nexceptions:\n" + entry + entry)
+        with self.assertRaisesRegex(ExceptionPolicyError, "duplicate"):
+            load_exceptions(path, today=date(2026, 8, 23))
+
+
+class GatePolicyTests(unittest.TestCase):
+    def test_high_codeql_finding_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "result.sarif"
+            report.write_text(json.dumps({
+                "runs": [{
+                    "tool": {"driver": {"rules": [{
+                        "id": "py/test-rule",
+                        "properties": {"security-severity": "8.1"},
+                    }]}},
+                    "results": [{"ruleId": "py/test-rule", "level": "warning"}],
+                }]
+            }))
+            self.assertEqual(blocking_findings([report], set()), [("py/test-rule", "high")])
+            self.assertEqual(blocking_findings([report], {"py/test-rule"}), [])
+
+    def test_secret_sarif_finding_blocks_by_unique_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "secret.sarif"
+            report.write_text(json.dumps({
+                "runs": [{
+                    "tool": {"driver": {"rules": [{"id": "fixture-secret"}]}},
+                    "results": [{
+                        "ruleId": "fixture-secret",
+                        "partialFingerprints": {"commitSha": "abc123"},
+                        "locations": [{"physicalLocation": {
+                            "artifactLocation": {"uri": "fixture.txt"},
+                            "region": {"startLine": 7},
+                        }}],
+                    }],
+                }]
+            }))
+            finding_id = "fixture-secret@abc123:fixture.txt:7"
+            self.assertEqual(
+                blocking_findings([report], set(), scanner="secret-scan"),
+                [(finding_id, "high")],
+            )
+            self.assertEqual(
+                blocking_findings([report], {finding_id}, scanner="secret-scan"),
+                [],
+            )
+
+    def test_high_frontend_advisory_blocks(self) -> None:
+        document = {"advisories": {"123": {
+            "id": 123,
+            "github_advisory_id": "GHSA-AAAA-BBBB-CCCC",
+            "module_name": "fixture-only-package",
+            "severity": "high",
+        }}}
+        self.assertEqual(
+            blocking_advisories(document, set()),
+            [("GHSA-AAAA-BBBB-CCCC", "fixture-only-package", "high")],
+        )
+        self.assertEqual(blocking_advisories(document, {"GHSA-AAAA-BBBB-CCCC"}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/security/validate_security_exceptions.py
+++ b/scripts/security/validate_security_exceptions.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Validate the repository's security exception policy."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    from .security_exceptions import ExceptionPolicyError, load_exceptions
+except ImportError:  # Support direct script execution.
+    from security_exceptions import ExceptionPolicyError, load_exceptions
+
+
+def main() -> int:
+    repository = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=repository / ".github/security-exceptions.yml",
+    )
+    args = parser.parse_args()
+    try:
+        entries = load_exceptions(args.path)
+    except ExceptionPolicyError as exc:
+        print(f"Security exception policy failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Security exception policy passed ({len(entries)} active exceptions).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/security/fixtures/vulnerable-requirements.txt
+++ b/tests/security/fixtures/vulnerable-requirements.txt
@@ -1,0 +1,3 @@
+# This isolated fixture is never installed by the application.
+# pip-audit must report known vulnerabilities and return a non-zero status.
+urllib3==1.24.1

--- a/tests/security/fixtures/vulnerable-requirements.txt
+++ b/tests/security/fixtures/vulnerable-requirements.txt
@@ -1,3 +1,0 @@
-# This isolated fixture is never installed by the application.
-# pip-audit must report known vulnerabilities and return a non-zero status.
-urllib3==1.24.1


### PR DESCRIPTION
Fixes #14

## Ausgangslage

Der Issue-Befund war teilweise veraltet: SHA-gepinnte Actions, Dependency Review, Release Gate und Supply-Chain-Gate existierten bereits. Offen waren ein vollständiger Python-Audit, Frontend-Audits auf allen relevanten Triggern, SAST, SARIF-Code-Scanning, ein CI-Secret-Scanner sowie eine verbindliche Severity- und Exception-Policy.

## Bereits vorhandene Security-Gates

Das bestehende Release Gate und der reusable Security-Workflow bleiben erhalten. Dependency Review bleibt das PR-spezifische Diff-Gate; Push und Schedule werden durch vollständige Dependency-, SAST- und Secret-Scans abgesichert.

## Backend Dependency Audit

- `pip-audit==2.10.1` und `PyYAML==6.0.3` sind als Security-Extra in `backend/uv.lock` transitiv gelockt.
- `uv export --frozen` erzeugt den tatsächlich aufgelösten Produktionssatz mit Hashes.
- Jede bekannte Python-Advisory blockiert konservativ, sofern keine gültige befristete Ausnahme existiert.
- Eine isolierte `urllib3==1.24.1`-Fixture beweist den non-zero Gate-Ausgang, ohne Production Dependencies zu verändern.

## Frontend Dependency Audit

`pnpm install --frozen-lockfile` und ein policy-ausgewertetes `pnpm audit --prod --audit-level high` laufen bei PR, Push, Schedule, manuellem Start und Release Gate. High/Critical blockieren.

## SAST

CodeQL Action `v4.37.8` ist auf `db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28` gepinnt und analysiert Python sowie JavaScript/TypeScript mit `security-extended`. SARIF Security Scores ab 7,0 blockieren das Release Gate.

## Secret Scanning

Gitleaks `8.30.1` wird aus dem offiziellen Release-Artefakt installiert und gegen SHA-256 `551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb` geprüft. Der Scan umfasst die vollständige Git-Historie und redigiert Treffer vollständig. Ein synthetischer Test beweist Erkennung, non-zero und Inline-Allowlisting.

## SARIF / Code Scanning

CodeQL und Gitleaks veröffentlichen SARIF in GitHub Security / Code Scanning. Nur die betreffenden Jobs erhalten `security-events: write`; CodeQL zusätzlich `packages: read`.

## Severity Policy

- Critical/High: Release blockiert
- Medium: Security-Triage
- Low: informativ
- pip-audit: mangels stabiler Severity-Normalisierung blockiert jede bekannte Advisory
- Gitleaks: jeder Fund wird als High behandelt

## Exception Process

`.github/security-exceptions.yml` verlangt ID, Scanner, Begründung, Owner, Ablaufdatum, Mitigation und Review-Datum. Der Validator blockiert ungültige, doppelte und abgelaufene Einträge. Vier historische, eindeutig künstliche Test-/Beispielwerte sind einzeln bis 2027-02-23 dokumentiert; keine Scanner-Regel wird global deaktiviert.

## Tests

- Backend: Ruff erfolgreich; 577 Pytests erfolgreich
- Frontend: 399 Vitest-Tests, Typecheck, Production Build und Sprachaudit erfolgreich
- Security: Produktionsaudits erfolgreich; vulnerable Fixture mit 14 Advisories blockiert
- Policy: 6 Security-Regressionstests erfolgreich
- Secret Scan: vollständige Historie (164 Commits) geprüft; synthetischer Negativtest erfolgreich
- Supply Chain: Verifier und 5 Regressionstests erfolgreich
- Workflows: actionlint erfolgreich

## Security Considerations

Kein `pull_request_target`, keine Secrets für Fork-Code, keine unredigierten Secret-Inhalte in Logs und kein `write-all`. Netzwerkabhängige Advisory-Ausfälle führen sichtbar zum Gate-Fehler statt zu einem stillen Erfolg.

## Rollout

Nach dem Merge läuft derselbe Security-Workflow auf jedem PR, jedem Push auf `main`, wöchentlich und im Release Gate. CodeQL- und Gitleaks-Funde erscheinen zentral unter GitHub Security. Branch Protection sollte weiterhin den zusammenfassenden Release-`gate`-Check verlangen.