### PR TITLE
feat: add production observability stack

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'deploy/ansible/**'
       - 'deploy/nginx/**'
+      - 'deploy/observability/**'
       - 'deploy/systemd/**'
       - '.github/workflows/ansible.yml'
   push:
@@ -12,6 +13,7 @@ on:
     paths:
       - 'deploy/ansible/**'
       - 'deploy/nginx/**'
+      - 'deploy/observability/**'
       - 'deploy/systemd/**'
       - '.github/workflows/ansible.yml'
 
@@ -36,4 +38,6 @@ jobs:
           ansible-playbook --syntax-check playbooks/bootstrap.yml
           ansible-playbook --syntax-check playbooks/deploy.yml
           ansible-playbook --syntax-check playbooks/certificates.yml
+          ansible-playbook --syntax-check playbooks/monitoring.yml
+          ansible-playbook --syntax-check playbooks/monitoring-certificates.yml
           ansible-playbook --syntax-check playbooks/osm-initial-import.yml

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run pytest
         working-directory: backend
         run: uv run pytest
+      - name: Verify observability contracts explicitly
+        working-directory: backend
+        run: uv run pytest tests/test_observability.py
 
   backend-migrations:
     name: Backend migrations

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 .nuxt/
 .output/
 dist/
+build/
 coverage/
 playwright-report/
 test-results/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Die vollständigen CI-Jobs und stabilen Check-Namen stehen in [docs/ci.md](docs/
 - Das öffentliche Benutzerhandbuch ist in der Anwendung unter `/dokumentation` erreichbar und wird aus `frontend/app/config/documentation.ts` erzeugt.
 - [Technische Dokumentation](docs/README.md)
 - [Deployment und Betrieb](docs/deployment.md)
+- [Production Observability](docs/observability.md)
 - [Reproduzierbare Supply Chain](docs/supply-chain.md)
 - [Ansible-Deployment](deploy/ansible/README.md)
 - [Nginx-Hardening und Rate Limits](deploy/nginx/README.md)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,15 @@
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/open_city_map
 CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 LOG_LEVEL=INFO
+LOG_FORMAT=json
 APP_ENVIRONMENT=development
+METRICS_ENABLED=true
+METRICS_PATH=/metrics
+OBSERVABILITY_TEXTFILE_DIR=
+OTEL_ENABLED=false
+OTEL_SERVICE_NAME=stadtplaner-api
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 APP_BASE_URL=http://localhost:3000
 API_BASE_URL=http://localhost:8000
 

--- a/backend/app/cache/redis.py
+++ b/backend/app/cache/redis.py
@@ -1,8 +1,10 @@
 import logging
+import time
 
 from redis.asyncio import Redis
 
 from app.core.config import get_settings
+from app.observability.metrics import REDIS_AVAILABLE, REDIS_ERRORS, observe_redis
 
 logger = logging.getLogger(__name__)
 _client: Redis | None = None
@@ -28,14 +30,20 @@ async def initialize_redis() -> None:
         health_check_interval=30,
     )
     try:
+        started = time.perf_counter()
         await client.ping()
     except Exception as exc:
+        REDIS_AVAILABLE.set(0)
+        REDIS_ERRORS.labels("connect").inc()
+        observe_redis("connect", started, result="error")
         await client.aclose()
         logger.warning("Redis unavailable, database fallback remains active: %s", type(exc).__name__)
         if settings.redis_required:
             raise RuntimeError("Redis is required but unavailable") from exc
         return
     _client = client
+    REDIS_AVAILABLE.set(1)
+    observe_redis("connect", started, result="success")
     logger.info("Redis cache connected")
 
 
@@ -51,8 +59,16 @@ async def redis_health() -> str:
         return "disabled"
     client = _client
     if client is None:
+        REDIS_AVAILABLE.set(0)
         return "degraded"
+    started = time.perf_counter()
     try:
-        return "ok" if await client.ping() else "degraded"
+        available = bool(await client.ping())
+        REDIS_AVAILABLE.set(1 if available else 0)
+        observe_redis("ping", started, result="success" if available else "error")
+        return "ok" if available else "degraded"
     except Exception:  # noqa: BLE001 - health must not affect readiness
+        REDIS_AVAILABLE.set(0)
+        REDIS_ERRORS.labels("ping").inc()
+        observe_redis("ping", started, result="error")
         return "degraded"

--- a/backend/app/cache/service.py
+++ b/backend/app/cache/service.py
@@ -9,6 +9,12 @@ from typing import Any, TypeVar
 
 from app.cache.redis import get_redis
 from app.core.config import get_settings
+from app.observability.metrics import (
+    REDIS_ERRORS,
+    REDIS_HITS,
+    REDIS_MISSES,
+    observe_redis,
+)
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
@@ -27,9 +33,18 @@ class CacheService:
         client = get_redis()
         if client is None:
             return None
+        started = time.perf_counter()
         try:
-            return await client.get(key)
+            value = await client.get(key)
+            if value is None:
+                REDIS_MISSES.inc()
+            else:
+                REDIS_HITS.inc()
+            observe_redis("get", started, result="hit" if value is not None else "miss", payload=value)
+            return value
         except Exception as exc:  # noqa: BLE001
+            REDIS_ERRORS.labels("get").inc()
+            observe_redis("get", started, result="error")
             logger.warning("cache_error operation=get error=%s", type(exc).__name__)
             return None
 
@@ -37,10 +52,14 @@ class CacheService:
         client = get_redis()
         if client is None:
             return False
+        started = time.perf_counter()
         try:
             await client.set(key, value, ex=ttl)
+            observe_redis("set", started, result="success", payload=value)
             return True
         except Exception as exc:  # noqa: BLE001
+            REDIS_ERRORS.labels("set").inc()
+            observe_redis("set", started, result="error")
             logger.warning("cache_error operation=set error=%s", type(exc).__name__)
             return False
 
@@ -48,9 +67,14 @@ class CacheService:
         client = get_redis()
         if client is None or not keys:
             return 0
+        started = time.perf_counter()
         try:
-            return int(await client.delete(*keys))
+            deleted = int(await client.delete(*keys))
+            observe_redis("delete", started, result="success")
+            return deleted
         except Exception as exc:  # noqa: BLE001
+            REDIS_ERRORS.labels("delete").inc()
+            observe_redis("delete", started, result="error")
             logger.warning("cache_error operation=delete error=%s", type(exc).__name__)
             return 0
 
@@ -76,9 +100,16 @@ class CacheService:
         client = get_redis()
         if client is None or not keys:
             return [None] * len(keys)
+        started = time.perf_counter()
         try:
-            return list(await client.mget(list(keys)))
+            values = list(await client.mget(list(keys)))
+            REDIS_HITS.inc(sum(value is not None for value in values))
+            REDIS_MISSES.inc(sum(value is None for value in values))
+            observe_redis("mget", started, result="success")
+            return values
         except Exception as exc:  # noqa: BLE001
+            REDIS_ERRORS.labels("mget").inc()
+            observe_redis("mget", started, result="error")
             logger.warning("cache_error operation=mget error=%s", type(exc).__name__)
             return [None] * len(keys)
 

--- a/backend/app/cli/import_flensburg_statistics.py
+++ b/backend/app/cli/import_flensburg_statistics.py
@@ -3,10 +3,12 @@ import asyncio
 import json
 
 from app.db.session import AsyncSessionLocal
+from app.observability.jobs import observed_job
 from app.services.flensburg_statistics_import import import_flensburg_statistics
 from app.services.flensburg_superset import FlensburgSupersetClient
 
 
+@observed_job("flensburg_statistics_sync")
 async def run(discover_only: bool) -> None:
     client = FlensburgSupersetClient()
     if discover_only:

--- a/backend/app/cli/postprocess_osm.py
+++ b/backend/app/cli/postprocess_osm.py
@@ -7,6 +7,8 @@ from time import monotonic
 from sqlalchemy import text
 
 from app.db.session import AsyncSessionLocal
+from app.observability.jobs import observed_job
+from app.observability.metrics import OSM_REPLICATION_LAG
 from app.services.analysis_areas import sync_osm_analysis_areas
 from app.services.cache_versions import bump_cache_versions
 from app.services.wikidata_enrichment import WikidataEnrichmentService
@@ -111,6 +113,7 @@ def progress(enabled: bool, started_at: float, phase: str, **values: object) -> 
     )
 
 
+@observed_job("osm_replication")
 async def run(
     sequence: int | None,
     osm_timestamp: datetime,
@@ -119,6 +122,7 @@ async def run(
     verbose: bool = False,
 ) -> None:
     started_at = monotonic()
+    OSM_REPLICATION_LAG.set(max(0.0, (datetime.now(UTC) - osm_timestamp).total_seconds()))
     progress(verbose, started_at, "start", sequence=sequence, timestamp=osm_timestamp.isoformat())
     async with AsyncSessionLocal() as session:
         progress(verbose, started_at, "validate_region")

--- a/backend/app/cli/process_email_outbox.py
+++ b/backend/app/cli/process_email_outbox.py
@@ -1,15 +1,16 @@
 import argparse
 import asyncio
-import json
 
 from app.db.session import AsyncSessionLocal
+from app.observability.jobs import observed_job
 from app.services.email_outbox import process_due_email_outbox
 
 
+@observed_job("email_outbox")
 async def run(limit: int) -> None:
     async with AsyncSessionLocal() as session:
         result = await process_due_email_outbox(session, limit=limit)
-    print(json.dumps(result, ensure_ascii=False))
+    return result
 
 
 def main() -> None:

--- a/backend/app/cli/process_polygon_outbox.py
+++ b/backend/app/cli/process_polygon_outbox.py
@@ -1,17 +1,16 @@
 import argparse
 import asyncio
-import logging
 
-from app.db.base import AsyncSessionLocal
+from app.db.session import AsyncSessionLocal
+from app.observability.jobs import observed_job
 from app.services.polygon_outbox import process_due_polygon_outbox
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
+@observed_job("polygon_outbox")
 async def async_main(limit: int) -> None:
     async with AsyncSessionLocal() as session:
         result = await process_due_polygon_outbox(session, limit=limit)
-        logger.info("Polygon outbox processing complete. processed=%d failed=%d dead_letter=%d", result["processed"], result["failed"], result["dead_letter"])
+        return result
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fällige Polygon-Ereignisse aus der Outbox verarbeiten")

--- a/backend/app/cli/publish_social_outbox.py
+++ b/backend/app/cli/publish_social_outbox.py
@@ -1,15 +1,16 @@
 import argparse
 import asyncio
-import json
 
 from app.db.session import AsyncSessionLocal
+from app.observability.jobs import observed_job
 from app.services.social_publishing import publish_due_events
 
 
+@observed_job("social_publisher")
 async def run(limit: int) -> None:
     async with AsyncSessionLocal() as session:
         result = await publish_due_events(session, limit=limit)
-    print(json.dumps(result, ensure_ascii=False))
+    return result
 
 
 def main() -> None:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 from cryptography.fernet import Fernet
-from pydantic import Field, SecretStr
+from pydantic import AliasChoices, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 BACKEND_ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
@@ -21,7 +21,18 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:3000,http://localhost:3001"
     cors_origin_regex: str | None = None
     log_level: str = "INFO"
+    log_format: str = "json"
     app_environment: str = "development"
+    release_sha: str = Field(
+        default="dev", validation_alias=AliasChoices("STADTPLANER_RELEASE_SHA", "release_sha")
+    )
+    metrics_enabled: bool = True
+    metrics_path: str = "/metrics"
+    observability_textfile_dir: str = ""
+    otel_enabled: bool = False
+    otel_service_name: str = "stadtplaner-api"
+    otel_exporter_otlp_endpoint: str | None = None
+    otel_exporter_otlp_protocol: str = "grpc"
     app_base_url: str = "http://localhost:3000"
     api_base_url: str = "http://localhost:8000"
     jwt_secret_key: str = DEVELOPMENT_JWT_SECRET
@@ -207,6 +218,12 @@ class Settings(BaseSettings):
         return [value.strip() for value in self.trusted_proxies.split(",") if value.strip()]
 
     def validate_security(self) -> None:
+        if not self.metrics_path.startswith("/") or "?" in self.metrics_path:
+            raise RuntimeError("METRICS_PATH must be an absolute path without a query")
+        if self.log_format not in {"json", "text"}:
+            raise RuntimeError("LOG_FORMAT must be json or text")
+        if self.otel_exporter_otlp_protocol != "grpc":
+            raise RuntimeError("Only the grpc OTLP protocol is currently supported")
         if self.production and (
             self.jwt_secret_key == DEVELOPMENT_JWT_SECRET
             or len(self.jwt_secret_key.strip()) < MINIMUM_JWT_SECRET_LENGTH

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,11 +1,20 @@
 import asyncio
 from collections.abc import AsyncGenerator
 
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import get_settings
+from app.observability.metrics import (
+    DB_CONNECTION_ERRORS,
+    DB_POOL_AVAILABLE,
+    DB_POOL_CAPACITY,
+    DB_POOL_CHECKED_OUT,
+    DB_POOL_OVERFLOW,
+    DB_POOL_SIZE,
+    DB_POOL_WAIT,
+)
 
 settings = get_settings()
 engine = create_async_engine(
@@ -18,14 +27,49 @@ engine = create_async_engine(
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 
+def update_pool_metrics() -> None:
+    pool = engine.sync_engine.pool
+    for metric, getter in (
+        (DB_POOL_SIZE, pool.size),
+        (DB_POOL_CHECKED_OUT, pool.checkedout),
+        (DB_POOL_AVAILABLE, pool.checkedin),
+        (DB_POOL_OVERFLOW, pool.overflow),
+    ):
+        try:
+            metric.set(max(0, getter()))
+        except (AttributeError, TypeError):
+            metric.set(0)
+
+
+@event.listens_for(engine.sync_engine.pool, "checkout")
+@event.listens_for(engine.sync_engine.pool, "checkin")
+def _pool_connection_changed(*_args) -> None:
+    update_pool_metrics()
+
+
+@event.listens_for(engine.sync_engine.pool, "invalidate")
+def _pool_connection_invalidated(*_args) -> None:
+    DB_CONNECTION_ERRORS.inc()
+    update_pool_metrics()
+
+
+update_pool_metrics()
+DB_POOL_CAPACITY.set(settings.database_pool_size + settings.database_max_overflow)
+
+
 async def database_health() -> str:
+    started = asyncio.get_running_loop().time()
     try:
         async with asyncio.timeout(settings.database_health_timeout_seconds):
             async with engine.connect() as connection:
                 await connection.execute(text("SELECT 1"))
         return "ok"
     except (TimeoutError, OSError, SQLAlchemyError):
+        DB_CONNECTION_ERRORS.inc()
         return "down"
+    finally:
+        DB_POOL_WAIT.observe(asyncio.get_running_loop().time() - started)
+        update_pool_metrics()
 
 
 async def close_session(session: AsyncSession | None) -> None:

--- a/backend/app/integrations/mastodon/client.py
+++ b/backend/app/integrations/mastodon/client.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 
 import httpx
 
+from app.observability.external import instrumented_httpx_request
+
 
 @dataclass(frozen=True)
 class MastodonStatus:
@@ -101,7 +103,15 @@ class MastodonClient:
             headers["Authorization"] = f"Bearer {self.access_token}"
         try:
             async with httpx.AsyncClient(timeout=self.timeout, transport=self.transport) as client:
-                response = await client.request(method, f"{self.base_url}{path}", headers=headers, **kwargs)
+                response = await instrumented_httpx_request(
+                    client,
+                    method,
+                    f"{self.base_url}{path}",
+                    provider="mastodon",
+                    operation=path,
+                    headers=headers,
+                    **kwargs,
+                )
         except (httpx.TimeoutException, httpx.NetworkError) as exc:
             raise MastodonError("Mastodon ist vorübergehend nicht erreichbar.", retryable=True) from exc
         if response.is_success:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,17 +8,34 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.responses import Response as FastAPIResponse
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from app.api.router import api_router
 from app.cache.redis import close_redis, initialize_redis, redis_health
 from app.core.config import get_settings
-from app.db.session import database_health
+from app.db.session import database_health, engine
+from app.observability.logging import configure_logging
+from app.observability.metrics import REDIS_AVAILABLE, REGISTRY, set_build_info
+from app.observability.middleware import ObservabilityMiddleware
+from app.observability.tracing import configure_tracing
 from app.security.request_limits import RequestBodyLimitMiddleware
 from app.services.assistant_provider import close_assistant_provider
 
 settings = get_settings()
-logging.basicConfig(level=settings.log_level)
+configure_logging(
+    level=settings.log_level,
+    service="stadtplaner-api",
+    environment=settings.app_environment,
+    release_sha=settings.release_sha,
+    json_logs=settings.log_format == "json",
+)
 logger = logging.getLogger(__name__)
+set_build_info(
+    release_sha=settings.release_sha,
+    version=settings.api_version,
+    environment=settings.app_environment,
+)
 
 if settings.configured_oauth_providers:
     logger.info("Enabled OAuth providers: %s", ", ".join(settings.configured_oauth_providers))
@@ -34,6 +51,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     finally:
         await close_assistant_provider()
         await close_redis()
+        tracing_runtime.shutdown()
 
 
 OPENAPI_TAGS = [
@@ -88,6 +106,11 @@ app = FastAPI(
 
 app.add_middleware(GZipMiddleware, minimum_size=1_000, compresslevel=5)
 app.add_middleware(RequestBodyLimitMiddleware)
+app.add_middleware(
+    ObservabilityMiddleware,
+    metrics_enabled=settings.metrics_enabled,
+    metrics_path=settings.metrics_path,
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -95,7 +118,8 @@ app.add_middleware(
     allow_origin_regex=settings.cors_origin_regex,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "X-CSRF-Token"],
+    allow_headers=["Authorization", "Content-Type", "X-CSRF-Token", "X-Request-ID"],
+    expose_headers=["X-Request-ID"],
 )
 
 app.include_router(api_router)
@@ -158,6 +182,7 @@ async def security_headers(request: Request, call_next) -> Response:
 async def health_status() -> tuple[bool, dict[str, str]]:
     database = await database_health()
     redis = await redis_health()
+    REDIS_AVAILABLE.set(1 if redis == "ok" else 0)
 
     database_ok = database == "ok"
     redis_ok = True
@@ -189,3 +214,22 @@ async def health_ready() -> Response:
 @app.get("/health", tags=["health"])
 async def health() -> Response:
     return await health_ready()
+
+
+@app.get("/health/info", tags=["health"])
+async def health_info() -> dict[str, str]:
+    return {
+        "version": settings.api_version,
+        "release_sha": settings.release_sha,
+        "environment": settings.app_environment,
+    }
+
+
+if settings.metrics_enabled:
+
+    @app.get(settings.metrics_path, include_in_schema=False)
+    async def metrics() -> FastAPIResponse:
+        return FastAPIResponse(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
+
+
+tracing_runtime = configure_tracing(app, engine, settings)

--- a/backend/app/observability/__init__.py
+++ b/backend/app/observability/__init__.py
@@ -1,0 +1,2 @@
+"""Shared, vendor-neutral production observability primitives."""
+

--- a/backend/app/observability/context.py
+++ b/backend/app/observability/context.py
@@ -1,0 +1,18 @@
+from contextvars import ContextVar, Token
+
+request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+route_var: ContextVar[str | None] = ContextVar("route", default=None)
+
+
+def bind_request_context(request_id: str) -> tuple[Token[str | None], Token[str | None]]:
+    return request_id_var.set(request_id), route_var.set(None)
+
+
+def clear_request_context(tokens: tuple[Token[str | None], Token[str | None]]) -> None:
+    request_id_var.reset(tokens[0])
+    route_var.reset(tokens[1])
+
+
+def request_id() -> str | None:
+    return request_id_var.get()
+

--- a/backend/app/observability/external.py
+++ b/backend/app/observability/external.py
@@ -1,0 +1,36 @@
+import time
+from typing import Any
+
+import httpx
+
+from app.observability.metrics import EXTERNAL_DURATION, EXTERNAL_ERRORS, EXTERNAL_REQUESTS
+
+
+async def instrumented_httpx_request(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    provider: str,
+    operation: str,
+    **kwargs: Any,
+) -> httpx.Response:
+    started = time.perf_counter()
+    try:
+        request_method = getattr(client, method.lower(), None)
+        if request_method is None:
+            response = await client.request(method, url, **kwargs)
+        else:
+            response = await request_method(url, **kwargs)
+    except Exception as exc:
+        EXTERNAL_REQUESTS.labels(provider, operation, "error").inc()
+        EXTERNAL_ERRORS.labels(provider, operation, type(exc).__name__).inc()
+        raise
+    finally:
+        EXTERNAL_DURATION.labels(provider, operation).observe(time.perf_counter() - started)
+    status_code = int(getattr(response, "status_code", 200))
+    result = "success" if status_code < 400 else "error"
+    EXTERNAL_REQUESTS.labels(provider, operation, result).inc()
+    if status_code >= 400:
+        EXTERNAL_ERRORS.labels(provider, operation, f"HTTP_{status_code}").inc()
+    return response

--- a/backend/app/observability/jobs.py
+++ b/backend/app/observability/jobs.py
@@ -1,0 +1,165 @@
+import json
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from pathlib import Path
+from typing import Any, ParamSpec, TypeVar
+
+from app.core.config import get_settings
+from app.observability.logging import configure_logging, log_event
+from app.observability.metrics import (
+    JOB_DURATION,
+    JOB_FAILURES,
+    JOB_LAST_SUCCESS,
+    JOB_RUNS,
+    OSM_REPLICATION_LAG,
+    OUTBOX_OLDEST_AGE,
+    OUTBOX_PENDING,
+)
+
+P = ParamSpec("P")
+T = TypeVar("T")
+logger = logging.getLogger(__name__)
+
+
+def _metric_state_path(job_name: str) -> Path | None:
+    directory = get_settings().observability_textfile_dir
+    if not directory:
+        return None
+    return Path(directory) / f"stadtplaner-{job_name}.json"
+
+
+def _persist_job_state(
+    job_name: str, *, success: bool, duration: float, result: Any = None
+) -> None:
+    path = _metric_state_path(job_name)
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        state: dict[str, Any] = {}
+        if path.exists():
+            state = json.loads(path.read_text(encoding="utf-8"))
+        state["runs"] = int(state.get("runs", 0)) + 1
+        state["failures"] = int(state.get("failures", 0)) + (0 if success else 1)
+        state["duration_seconds"] = duration
+        state["duration_total_seconds"] = float(state.get("duration_total_seconds", 0)) + duration
+        if success:
+            state["last_success_timestamp_seconds"] = time.time()
+        prom_path = path.with_suffix(".prom")
+        prom_temporary = prom_path.with_suffix(f".{os.getpid()}.tmp")
+        labels = f'job_name="{job_name}"'
+        lines = [
+            "# TYPE job_runs_total counter",
+            f"job_runs_total{{{labels}}} {state['runs']}",
+            "# TYPE job_failures_total counter",
+            f"job_failures_total{{{labels}}} {state['failures']}",
+            "# TYPE job_duration_seconds histogram",
+            f'job_duration_seconds_bucket{{{labels},le="+Inf"}} {state["runs"]}',
+            f"job_duration_seconds_count{{{labels}}} {state['runs']}",
+            f"job_duration_seconds_sum{{{labels}}} {state['duration_total_seconds']}",
+            "# TYPE job_last_success_timestamp_seconds gauge",
+            (
+                f"job_last_success_timestamp_seconds{{{labels}}} "
+                f"{float(state.get('last_success_timestamp_seconds', 0))}"
+            ),
+        ]
+        outbox_type = {
+            "email_outbox": "email",
+            "polygon_outbox": "polygon",
+            "social_publisher": "social",
+        }.get(job_name)
+        if outbox_type and isinstance(result, dict):
+            processed = int(
+                result.get("sent", 0)
+                or result.get("published", 0) + result.get("dry_run", 0)
+                or result.get("processed", 0)
+            )
+            failed = int(result.get("dead_letter", result.get("failed", 0)))
+            retried = int(result.get("retried", 0))
+            state["outbox_processed"] = int(state.get("outbox_processed", 0)) + processed
+            state["outbox_failed"] = int(state.get("outbox_failed", 0)) + failed
+            state["outbox_retry"] = int(state.get("outbox_retry", 0)) + retried
+            outbox_labels = f'outbox_type="{outbox_type}"'
+            lines.extend(
+                (
+                    "# TYPE outbox_pending gauge",
+                    (
+                        f"outbox_pending{{{outbox_labels}}} "
+                        f"{OUTBOX_PENDING.labels(outbox_type)._value.get()}"
+                    ),
+                    "# TYPE outbox_oldest_age_seconds gauge",
+                    (
+                        f"outbox_oldest_age_seconds{{{outbox_labels}}} "
+                        f"{OUTBOX_OLDEST_AGE.labels(outbox_type)._value.get()}"
+                    ),
+                    "# TYPE outbox_processed_total counter",
+                    f"outbox_processed_total{{{outbox_labels}}} {state['outbox_processed']}",
+                    "# TYPE outbox_failed_total counter",
+                    f"outbox_failed_total{{{outbox_labels}}} {state['outbox_failed']}",
+                    "# TYPE outbox_retry_total counter",
+                    f"outbox_retry_total{{{outbox_labels}}} {state['outbox_retry']}",
+                )
+            )
+        if job_name == "osm_replication":
+            lines.extend(
+                (
+                    "# TYPE osm_replication_lag_seconds gauge",
+                    f"osm_replication_lag_seconds {OSM_REPLICATION_LAG._value.get()}",
+                )
+            )
+        temporary = path.with_suffix(f".{os.getpid()}.tmp")
+        temporary.write_text(json.dumps(state, separators=(",", ":")), encoding="utf-8")
+        os.replace(temporary, path)
+        lines.append("")
+        prom_temporary.write_text(
+            "\n".join(lines),
+            encoding="utf-8",
+        )
+        os.replace(prom_temporary, prom_path)
+    except (OSError, ValueError, TypeError):
+        logger.exception("job_metric_state_write_failed", extra={"job_name": job_name})
+
+
+def observed_job(job_name: str) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+    def decorator(function: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+        @wraps(function)
+        async def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
+            settings = get_settings()
+            configure_logging(
+                level=settings.log_level,
+                service=f"stadtplaner-job-{job_name}",
+                environment=settings.app_environment,
+                release_sha=settings.release_sha,
+                json_logs=settings.log_format == "json",
+            )
+            started = time.perf_counter()
+            JOB_RUNS.labels(job_name).inc()
+            try:
+                result = await function(*args, **kwargs)
+            except BaseException:
+                duration = time.perf_counter() - started
+                JOB_FAILURES.labels(job_name).inc()
+                JOB_DURATION.labels(job_name).observe(duration)
+                _persist_job_state(job_name, success=False, duration=duration)
+                log_event(logger, logging.ERROR, "job_failed", job_name=job_name, duration_seconds=duration)
+                raise
+            duration = time.perf_counter() - started
+            JOB_DURATION.labels(job_name).observe(duration)
+            JOB_LAST_SUCCESS.labels(job_name).set_to_current_time()
+            _persist_job_state(job_name, success=True, duration=duration, result=result)
+            log_event(
+                logger,
+                logging.INFO,
+                "job_completed",
+                job_name=job_name,
+                duration_seconds=duration,
+                result=result,
+            )
+            return result
+
+        return wrapped
+
+    return decorator

--- a/backend/app/observability/logging.py
+++ b/backend/app/observability/logging.py
@@ -1,0 +1,76 @@
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+from opentelemetry import trace
+
+from app.observability.context import request_id_var, route_var
+from app.observability.redaction import redact, redact_text
+
+STANDARD_RECORD_FIELDS = set(logging.makeLogRecord({}).__dict__) | {"message", "asctime"}
+
+
+def trace_context() -> tuple[str | None, str | None]:
+    context = trace.get_current_span().get_span_context()
+    if not context.is_valid:
+        return None, None
+    return f"{context.trace_id:032x}", f"{context.span_id:016x}"
+
+
+class JsonFormatter(logging.Formatter):
+    def __init__(self, *, service: str, environment: str, release_sha: str) -> None:
+        super().__init__()
+        self.service = service
+        self.environment = environment
+        self.release_sha = release_sha
+
+    def format(self, record: logging.LogRecord) -> str:
+        trace_id, span_id = trace_context()
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, UTC).isoformat(),
+            "level": record.levelname.lower(),
+            "service": self.service,
+            "environment": self.environment,
+            "release_sha": self.release_sha,
+            "logger": record.name,
+            "message": redact_text(record.getMessage()),
+        }
+        context_values = {
+            "request_id": request_id_var.get(),
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "route": route_var.get(),
+        }
+        payload.update({key: value for key, value in context_values.items() if value})
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in STANDARD_RECORD_FIELDS and not key.startswith("_")
+        }
+        payload.update(redact(extras))
+        if record.exc_info:
+            payload["error_type"] = record.exc_info[0].__name__ if record.exc_info[0] else "Error"
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), default=str)
+
+
+def configure_logging(
+    *, level: str, service: str, environment: str, release_sha: str, json_logs: bool
+) -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    if json_logs:
+        handler.setFormatter(
+            JsonFormatter(service=service, environment=environment, release_sha=release_sha)
+        )
+    else:
+        handler.setFormatter(logging.Formatter("%(levelname)s %(name)s %(message)s"))
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(level.upper())
+
+
+def log_event(logger: logging.Logger, level: int, event: str, **fields: Any) -> None:
+    logger.log(level, event, extra={"event": event, **redact(fields)})
+

--- a/backend/app/observability/metrics.py
+++ b/backend/app/observability/metrics.py
@@ -1,0 +1,108 @@
+import time
+from contextlib import contextmanager
+from typing import Any
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, Info
+
+REGISTRY = CollectorRegistry(auto_describe=True)
+
+HTTP_REQUESTS = Counter(
+    "http_requests_total", "Completed HTTP requests", ("method", "route", "status_class"), registry=REGISTRY
+)
+HTTP_DURATION = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency",
+    ("method", "route"),
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+    registry=REGISTRY,
+)
+HTTP_IN_PROGRESS = Gauge(
+    "http_requests_in_progress", "Requests currently running", ("method", "route"), registry=REGISTRY
+)
+
+DB_POOL_SIZE = Gauge("db_pool_size", "Configured SQLAlchemy pool size", registry=REGISTRY)
+DB_POOL_CAPACITY = Gauge(
+    "db_pool_capacity", "Configured SQLAlchemy pool plus maximum overflow", registry=REGISTRY
+)
+DB_POOL_CHECKED_OUT = Gauge("db_pool_checked_out", "Checked out DB connections", registry=REGISTRY)
+DB_POOL_AVAILABLE = Gauge("db_pool_checked_in", "Connections available in the DB pool", registry=REGISTRY)
+DB_POOL_OVERFLOW = Gauge("db_pool_overflow", "Current DB pool overflow", registry=REGISTRY)
+DB_POOL_WAIT = Histogram(
+    "db_pool_wait_seconds", "Time waiting to acquire a database connection", registry=REGISTRY
+)
+DB_CONNECTION_ERRORS = Counter(
+    "db_connection_errors_total", "Database connection failures", registry=REGISTRY
+)
+
+REDIS_OPERATIONS = Counter(
+    "redis_operations_total", "Redis operations", ("operation", "result"), registry=REGISTRY
+)
+REDIS_DURATION = Histogram(
+    "redis_operation_duration_seconds", "Redis operation latency", ("operation",), registry=REGISTRY
+)
+REDIS_ERRORS = Counter("redis_errors_total", "Redis errors", ("operation",), registry=REGISTRY)
+REDIS_HITS = Counter("redis_cache_hits_total", "Redis cache hits", registry=REGISTRY)
+REDIS_MISSES = Counter("redis_cache_misses_total", "Redis cache misses", registry=REGISTRY)
+REDIS_PAYLOAD = Histogram(
+    "redis_payload_bytes", "Redis payload size", ("operation",), buckets=(64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304), registry=REGISTRY
+)
+REDIS_AVAILABLE = Gauge("redis_available", "Redis health status (1=available)", registry=REGISTRY)
+
+EXTERNAL_REQUESTS = Counter(
+    "external_requests_total", "External provider requests", ("provider", "operation", "result"), registry=REGISTRY
+)
+EXTERNAL_DURATION = Histogram(
+    "external_request_duration_seconds", "External provider latency", ("provider", "operation"), registry=REGISTRY
+)
+EXTERNAL_ERRORS = Counter(
+    "external_request_errors_total", "External provider errors", ("provider", "operation", "error_type"), registry=REGISTRY
+)
+
+OUTBOX_PENDING = Gauge("outbox_pending", "Pending outbox entries", ("outbox_type",), registry=REGISTRY)
+OUTBOX_OLDEST_AGE = Gauge(
+    "outbox_oldest_age_seconds", "Age of oldest pending outbox entry", ("outbox_type",), registry=REGISTRY
+)
+OUTBOX_PROCESSED = Counter(
+    "outbox_processed_total", "Processed outbox entries", ("outbox_type",), registry=REGISTRY
+)
+OUTBOX_FAILED = Counter("outbox_failed_total", "Failed outbox entries", ("outbox_type",), registry=REGISTRY)
+OUTBOX_RETRY = Counter("outbox_retry_total", "Retried outbox entries", ("outbox_type",), registry=REGISTRY)
+
+JOB_RUNS = Counter("job_runs_total", "Background job runs", ("job_name",), registry=REGISTRY)
+JOB_FAILURES = Counter("job_failures_total", "Background job failures", ("job_name",), registry=REGISTRY)
+JOB_DURATION = Histogram(
+    "job_duration_seconds", "Background job duration", ("job_name",), registry=REGISTRY
+)
+JOB_LAST_SUCCESS = Gauge(
+    "job_last_success_timestamp_seconds", "Last successful job completion", ("job_name",), registry=REGISTRY
+)
+OSM_REPLICATION_LAG = Gauge(
+    "osm_replication_lag_seconds", "Age of the newest locally imported OSM feature", registry=REGISTRY
+)
+BUILD = Info("build", "Running Stadtplaner release", registry=REGISTRY)
+
+
+def set_build_info(*, release_sha: str, version: str, environment: str) -> None:
+    BUILD.info({"release_sha": release_sha, "version": version, "environment": environment})
+
+
+@contextmanager
+def external_request(provider: str, operation: str):
+    started = time.perf_counter()
+    try:
+        yield
+    except Exception as exc:
+        EXTERNAL_REQUESTS.labels(provider, operation, "error").inc()
+        EXTERNAL_ERRORS.labels(provider, operation, type(exc).__name__).inc()
+        raise
+    else:
+        EXTERNAL_REQUESTS.labels(provider, operation, "success").inc()
+    finally:
+        EXTERNAL_DURATION.labels(provider, operation).observe(time.perf_counter() - started)
+
+
+def observe_redis(operation: str, started: float, *, result: str, payload: Any = None) -> None:
+    REDIS_OPERATIONS.labels(operation, result).inc()
+    REDIS_DURATION.labels(operation).observe(time.perf_counter() - started)
+    if isinstance(payload, (bytes, bytearray, str)):
+        REDIS_PAYLOAD.labels(operation).observe(len(payload))

--- a/backend/app/observability/middleware.py
+++ b/backend/app/observability/middleware.py
@@ -1,0 +1,93 @@
+import logging
+import re
+import time
+import uuid
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.routing import Match
+
+from app.observability.context import bind_request_context, clear_request_context, route_var
+from app.observability.logging import log_event, trace_context
+from app.observability.metrics import HTTP_DURATION, HTTP_IN_PROGRESS, HTTP_REQUESTS
+
+logger = logging.getLogger(__name__)
+REQUEST_ID_HEADER = "X-Request-ID"
+REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
+
+
+def valid_request_id(value: str | None) -> bool:
+    return bool(value and REQUEST_ID_RE.fullmatch(value))
+
+
+def request_id_for(value: str | None) -> str:
+    return value if valid_request_id(value) else str(uuid.uuid4())
+
+
+def route_template(request: Request) -> str:
+    cache_key = "_observability_route_patterns"
+    patterns = getattr(request.app.state, cache_key, None)
+    if patterns is None:
+        patterns = []
+        for template, operations in request.app.openapi().get("paths", {}).items():
+            expression = re.sub(r"\\\{[^/]+\\\}", "[^/]+", re.escape(template))
+            methods = frozenset(method.upper() for method in operations)
+            patterns.append((re.compile(f"^{expression}$"), template, methods))
+        setattr(request.app.state, cache_key, patterns)
+    for expression, template, methods in patterns:
+        if request.method in methods and expression.fullmatch(request.url.path):
+            return template
+    for route in request.app.routes:
+        match, _ = route.matches(request.scope)
+        if match is Match.FULL:
+            path = getattr(route, "path", None)
+            if path:
+                return path
+    return "unmatched"
+
+
+class ObservabilityMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, *, metrics_enabled: bool, metrics_path: str) -> None:
+        super().__init__(app)
+        self.metrics_enabled = metrics_enabled
+        self.metrics_path = metrics_path
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        request_id = request_id_for(request.headers.get(REQUEST_ID_HEADER))
+        tokens = bind_request_context(request_id)
+        route = route_template(request)
+        route_var.set(route)
+        request.state.request_id = request_id
+        started = time.perf_counter()
+        status_code = 500
+        measure = self.metrics_enabled and request.url.path != self.metrics_path
+        if measure:
+            HTTP_IN_PROGRESS.labels(request.method, route).inc()
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            response.headers[REQUEST_ID_HEADER] = request_id
+            return response
+        finally:
+            duration = time.perf_counter() - started
+            if measure:
+                HTTP_IN_PROGRESS.labels(request.method, route).dec()
+                HTTP_REQUESTS.labels(request.method, route, f"{status_code // 100}xx").inc()
+                HTTP_DURATION.labels(request.method, route).observe(duration)
+            trace_id, span_id = trace_context()
+            fields = {
+                "method": request.method,
+                "route": route,
+                "status_code": status_code,
+                "duration_ms": round(duration * 1000, 3),
+                "request_id": request_id,
+                "trace_id": trace_id,
+                "span_id": span_id,
+            }
+            log_event(
+                logger,
+                logging.ERROR if status_code >= 500 else logging.INFO,
+                "http_request_completed",
+                **fields,
+            )
+            clear_request_context(tokens)

--- a/backend/app/observability/outbox.py
+++ b/backend/app/observability/outbox.py
@@ -1,0 +1,38 @@
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select
+
+from app.observability.metrics import OUTBOX_OLDEST_AGE, OUTBOX_PENDING
+
+logger = logging.getLogger(__name__)
+
+
+async def update_outbox_gauges(
+    session,
+    model,
+    *,
+    outbox_type: str,
+    pending_statuses: tuple[str, ...],
+) -> None:
+    try:
+        count, oldest = (
+            await session.execute(
+                select(func.count(model.id), func.min(model.created_at)).where(
+                    model.status.in_(pending_statuses)
+                )
+            )
+        ).one()
+    except Exception as exc:  # noqa: BLE001 - metrics must not break outbox processing
+        logger.warning(
+            "outbox_metrics_collection_failed",
+            extra={"outbox_type": outbox_type, "error_type": type(exc).__name__},
+        )
+        return
+    OUTBOX_PENDING.labels(outbox_type).set(int(count or 0))
+    age = 0.0
+    if oldest is not None:
+        if oldest.tzinfo is None:
+            oldest = oldest.replace(tzinfo=UTC)
+        age = max(0.0, (datetime.now(UTC) - oldest).total_seconds())
+    OUTBOX_OLDEST_AGE.labels(outbox_type).set(age)

--- a/backend/app/observability/redaction.py
+++ b/backend/app/observability/redaction.py
@@ -1,0 +1,50 @@
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+REDACTED = "[REDACTED]"
+SENSITIVE_KEY_PARTS = (
+    "password",
+    "token",
+    "secret",
+    "authorization",
+    "cookie",
+    "api_key",
+    "apikey",
+    "access_token",
+    "refresh_token",
+    "csrf",
+    "recovery_code",
+    "otp",
+    "totp",
+    "email",
+    "prompt",
+)
+EMAIL_RE = re.compile(r"(?<![\w.+-])([\w.+-]+)@([\w.-]+\.[A-Za-z]{2,})(?![\w.-])")
+BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")
+JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
+
+
+def _sensitive_key(key: object) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", str(key).lower())
+    return any(re.sub(r"[^a-z0-9]", "", part) in normalized for part in SENSITIVE_KEY_PARTS)
+
+
+def redact_text(value: str) -> str:
+    value = BEARER_RE.sub("Bearer [REDACTED]", value)
+    value = JWT_RE.sub(REDACTED, value)
+    return EMAIL_RE.sub(REDACTED, value)
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): REDACTED if _sensitive_key(key) else redact(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [redact(item) for item in value]
+    if isinstance(value, str):
+        return redact_text(value)
+    return value
+

--- a/backend/app/observability/tracing.py
+++ b/backend/app/observability/tracing.py
@@ -1,0 +1,54 @@
+import logging
+from dataclasses import dataclass
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TracingRuntime:
+    provider: TracerProvider | None = None
+
+    def shutdown(self) -> None:
+        if self.provider is not None:
+            self.provider.shutdown()
+
+
+def configure_tracing(app, engine, settings) -> TracingRuntime:
+    if not settings.otel_enabled or not settings.otel_exporter_otlp_endpoint:
+        return TracingRuntime()
+    try:
+        resource = Resource.create(
+            {
+                "service.name": settings.otel_service_name,
+                "service.version": settings.release_sha,
+                "deployment.environment.name": settings.app_environment,
+            }
+        )
+        provider = TracerProvider(resource=resource)
+        exporter = OTLPSpanExporter(
+            endpoint=settings.otel_exporter_otlp_endpoint,
+            insecure=settings.otel_exporter_otlp_endpoint.startswith("http://"),
+        )
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+        FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+        HTTPXClientInstrumentor().instrument(tracer_provider=provider)
+        SQLAlchemyInstrumentor().instrument(
+            engine=engine.sync_engine,
+            tracer_provider=provider,
+            enable_commenter=False,
+        )
+        logger.info("OpenTelemetry tracing enabled")
+        return TracingRuntime(provider)
+    except Exception:  # telemetry must never prevent application startup
+        logger.exception("OpenTelemetry setup failed; application continues without tracing")
+        return TracingRuntime()

--- a/backend/app/services/assistant_provider.py
+++ b/backend/app/services/assistant_provider.py
@@ -7,6 +7,7 @@ import httpx
 from pydantic import ValidationError
 
 from app.core.config import Settings, get_settings
+from app.observability.external import instrumented_httpx_request
 from app.schemas.assistant import AssistantContext, AssistantPlan
 
 ASSISTANT_PROMPT_VERSION = "3.0"
@@ -40,12 +41,25 @@ class AssistantProviderError(RuntimeError):
 class GroqProvider:
     name = "groq"
 
-    def __init__(self, settings: Settings, client: httpx.AsyncClient | None = None) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        client: httpx.AsyncClient | None = None,
+        *,
+        provider_name: str = "groq",
+    ) -> None:
         self.settings = settings
+        self.name = provider_name
         self.model = settings.ai_search_model or ""
+        self.api_key = settings.openai_api_key if provider_name == "openai" else settings.groq_api_key
+        base_url = (
+            "https://api.openai.com/v1"
+            if provider_name == "openai"
+            else settings.groq_base_url.rstrip("/")
+        )
         self._external_client = client is not None
         self._client = client or httpx.AsyncClient(
-            base_url=settings.groq_base_url.rstrip("/"),
+            base_url=base_url,
             timeout=httpx.Timeout(settings.groq_timeout_seconds),
             limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
         )
@@ -59,7 +73,7 @@ class GroqProvider:
         self, query: str, context: AssistantContext, tools: list[dict[str, Any]]
     ) -> AssistantPlan:
         self.usage = {}
-        if not self.settings.groq_api_key or not self.model:
+        if not self.api_key or not self.model:
             raise AssistantProviderError(
                 "ASSISTANT_DISABLED",
                 "Die intelligente Sprachinterpretation ist nicht vollständig konfiguriert.",
@@ -85,8 +99,9 @@ class GroqProvider:
                 return AssistantPlan.model_validate_json(content)
             except (ValidationError, ValueError) as exc:
                 logger.warning(
-                    "assistant_provider_invalid_plan provider=groq model=%r "
+                    "assistant_provider_invalid_plan provider=%s model=%r "
                     "repair=%s response=%s",
+                    self.name,
                     self.model,
                     bool(repair),
                     self._safe_log_value(content),
@@ -119,10 +134,14 @@ class GroqProvider:
         retries = self.settings.groq_max_retries
         for attempt in range(retries + 1):
             try:
-                response = await self._client.post(
+                response = await instrumented_httpx_request(
+                    self._client,
+                    "POST",
                     "/chat/completions",
+                    provider=self.name,
+                    operation="chat_completion",
                     headers={
-                        "Authorization": f"Bearer {self.settings.groq_api_key.get_secret_value()}",
+                        "Authorization": f"Bearer {self.api_key.get_secret_value()}",
                         "Content-Type": "application/json",
                     },
                     json=payload,
@@ -138,8 +157,9 @@ class GroqProvider:
                 ) from exc
             if response.status_code >= 400:
                 logger.warning(
-                    "assistant_provider_http_error provider=groq status=%d "
+                    "assistant_provider_http_error provider=%s status=%d "
                     "model=%r attempt=%d response=%s",
+                    self.name,
                     response.status_code,
                     self.model,
                     attempt + 1,
@@ -180,8 +200,9 @@ class GroqProvider:
                 return content
             except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
                 logger.warning(
-                    "assistant_provider_invalid_response provider=groq model=%r "
+                    "assistant_provider_invalid_response provider=%s model=%r "
                     "response=%s",
+                    self.name,
                     self.model,
                     self._safe_log_value(response.text),
                 )
@@ -192,9 +213,11 @@ class GroqProvider:
         raise AssertionError("unreachable")
 
     def _safe_log_value(self, value: str) -> str:
+        if not self.settings.assistant_query_logging:
+            return "[REDACTED]"
         secret = (
-            self.settings.groq_api_key.get_secret_value()
-            if self.settings.groq_api_key
+            self.api_key.get_secret_value()
+            if self.api_key
             else ""
         )
         redacted = value.replace(secret, "[REDACTED]") if secret else value
@@ -216,12 +239,17 @@ _provider: GroqProvider | None = None
 def get_assistant_provider() -> GroqProvider | None:
     global _provider
     settings = get_settings()
-    if not settings.ai_search_enabled or settings.ai_search_provider != "groq":
+    if not settings.ai_search_enabled:
         return None
-    if not settings.groq_api_key or not settings.ai_search_model:
+    api_key = (
+        settings.openai_api_key
+        if settings.ai_search_provider == "openai"
+        else settings.groq_api_key
+    )
+    if not api_key or not settings.ai_search_model:
         return None
     if _provider is None:
-        _provider = GroqProvider(settings)
+        _provider = GroqProvider(settings, provider_name=settings.ai_search_provider)
     return _provider
 
 

--- a/backend/app/services/contact_service.py
+++ b/backend/app/services/contact_service.py
@@ -10,6 +10,7 @@ import jwt
 from fastapi import HTTPException, Request, status
 
 from app.core.config import get_settings
+from app.observability.external import instrumented_httpx_request
 from app.schemas.contact import ContactMessageCreate
 
 logger = logging.getLogger(__name__)
@@ -137,8 +138,12 @@ async def verify_turnstile(token: str | None, remote_ip: str) -> None:
         )
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await client.post(
+            response = await instrumented_httpx_request(
+                client,
+                "POST",
                 "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+                provider="cloudflare_turnstile",
+                operation="verify",
                 data={
                     "secret": settings.turnstile_secret_key,
                     "response": token,

--- a/backend/app/services/email_outbox.py
+++ b/backend/app/services/email_outbox.py
@@ -13,6 +13,8 @@ from app.models.email_campaign import EmailCampaign, EmailCampaignDelivery
 from app.models.email_outbox import EmailOutbox
 from app.models.notification import Notification
 from app.models.user import User
+from app.observability.metrics import OUTBOX_FAILED, OUTBOX_PROCESSED
+from app.observability.outbox import update_outbox_gauges
 from app.services.email_service import (
     EmailTemplateContent,
     EmailTemplateValidationError,
@@ -389,4 +391,9 @@ async def process_due_email_outbox(session: AsyncSession, *, limit: int = 20) ->
             break
         result["processed"] += 1
         result["sent" if await _finish_event(session, event.id) else "failed"] += 1
+    OUTBOX_PROCESSED.labels("email").inc(result["sent"])
+    OUTBOX_FAILED.labels("email").inc(result["failed"])
+    await update_outbox_gauges(
+        session, EmailOutbox, outbox_type="email", pending_statuses=("PENDING", "PROCESSING")
+    )
     return result

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import get_settings
 from app.models.email_template import EmailTemplate
 from app.models.user import User
+from app.observability.metrics import external_request
 
 logger = logging.getLogger(__name__)
 TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates" / "email"
@@ -508,7 +509,9 @@ def send_email(
         message[name] = value
     message.set_content(text)
     message.add_alternative(html, subtype="html")
-    with smtplib.SMTP(settings.smtp_host, settings.smtp_port) as smtp:
+    with external_request("smtp", "send"), smtplib.SMTP(
+        settings.smtp_host, settings.smtp_port
+    ) as smtp:
         if settings.smtp_use_tls:
             smtp.starttls()
         if settings.smtp_username:

--- a/backend/app/services/flensburg_superset.py
+++ b/backend/app/services/flensburg_superset.py
@@ -179,7 +179,14 @@ class FlensburgSupersetClient:
                 transport=self.transport,
                 headers={"User-Agent": "Stadtplaner statistics importer/1.0"},
             ) as client:
-                response = await client.request(method, endpoint, **kwargs)
+                response = await instrumented_httpx_request(
+                    client,
+                    method,
+                    endpoint,
+                    provider="flensburg_superset",
+                    operation="dataset_export",
+                    **kwargs,
+                )
         except httpx.TimeoutException as exc:
             raise SupersetSourceError(f"Superset timeout for {endpoint}") from exc
         except httpx.HTTPError as exc:
@@ -193,3 +200,4 @@ class FlensburgSupersetClient:
                 f"Superset returned HTTP {response.status_code} for {endpoint}"
             )
         return response
+from app.observability.external import instrumented_httpx_request

--- a/backend/app/services/mastodon_sso.py
+++ b/backend/app/services/mastodon_sso.py
@@ -19,6 +19,7 @@ from app.auth.oauth import oauth_redirect_uri, safe_redirect_path
 from app.auth.tokens import generate_token, hash_token
 from app.core.config import Settings, get_settings
 from app.models.oauth_account import MastodonOAuthInstance, OAuthFlowGrant
+from app.observability.external import instrumented_httpx_request
 from app.schemas.oauth import OAuthIdentity
 
 Resolver = Callable[[str, int], Awaitable[set[ipaddress.IPv4Address | ipaddress.IPv6Address]]]
@@ -285,7 +286,14 @@ class MastodonSSOClient:
                 transport=self.transport,
                 follow_redirects=False,
             ) as client:
-                response = await client.request(method, url, **kwargs)
+                response = await instrumented_httpx_request(
+                    client,
+                    method,
+                    url,
+                    provider="mastodon_sso",
+                    operation=parsed.path,
+                    **kwargs,
+                )
         except (httpx.TimeoutException, httpx.NetworkError) as exc:
             raise mastodon_sso_error(
                 "MASTODON_INSTANCE_UNREACHABLE",

--- a/backend/app/services/nominatim.py
+++ b/backend/app/services/nominatim.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import httpx
 
 from app.core.config import get_settings
+from app.observability.external import instrumented_httpx_request
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,7 +49,9 @@ class NominatimService:
             limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
             headers={"User-Agent": settings.nominatim_user_agent},
         ) as client:
-            response = await client.get(endpoint, params=params)
+            response = await instrumented_httpx_request(
+                client, "GET", endpoint, provider="nominatim", operation="reverse", params=params
+            )
             response.raise_for_status()
             payload = response.json()
 

--- a/backend/app/services/osm_lookup.py
+++ b/backend/app/services/osm_lookup.py
@@ -378,7 +378,14 @@ class OsmLookupService:
                     "Accept": "application/json",
                 },
             ) as client:
-                response = await client.post(settings.overpass_api_url, data={"data": query})
+                response = await instrumented_httpx_request(
+                    client,
+                    "POST",
+                    settings.overpass_api_url,
+                    provider="overpass",
+                    operation="polygon_lookup",
+                    data={"data": query},
+                )
                 response.raise_for_status()
                 payload = response.json()
         except (httpx.HTTPError, ValueError) as exc:
@@ -426,3 +433,4 @@ class OsmLookupService:
         for key in list(_cache):
             if key[0] == polygon_id and key != keep:
                 _cache.pop(key, None)
+from app.observability.external import instrumented_httpx_request

--- a/backend/app/services/polygon_outbox.py
+++ b/backend/app/services/polygon_outbox.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.polygon_outbox import PolygonOutbox
 from app.models.user_polygon import UserPolygon
+from app.observability.metrics import OUTBOX_FAILED, OUTBOX_PROCESSED, OUTBOX_RETRY
+from app.observability.outbox import update_outbox_gauges
 from app.services.notification_policy import DomainEvent, NotificationEventType
 from app.services.notifications import (
     notify_users,
@@ -136,6 +138,12 @@ async def process_due_polygon_outbox(session: AsyncSession, *, limit: int = 50) 
     )
     events = result.all()
     if not events:
+        await update_outbox_gauges(
+            session,
+            PolygonOutbox,
+            outbox_type="polygon",
+            pending_statuses=("PENDING", "PROCESSING"),
+        )
         return {"processed": 0, "failed": 0, "dead_letter": 0}
 
     stats = {"processed": 0, "failed": 0, "dead_letter": 0}
@@ -174,4 +182,13 @@ async def process_due_polygon_outbox(session: AsyncSession, *, limit: int = 50) 
                 
         await session.commit()
         
+    OUTBOX_PROCESSED.labels("polygon").inc(stats["processed"])
+    OUTBOX_FAILED.labels("polygon").inc(stats["dead_letter"])
+    OUTBOX_RETRY.labels("polygon").inc(stats["failed"])
+    await update_outbox_gauges(
+        session,
+        PolygonOutbox,
+        outbox_type="polygon",
+        pending_statuses=("PENDING", "PROCESSING"),
+    )
     return stats

--- a/backend/app/services/social_publishing.py
+++ b/backend/app/services/social_publishing.py
@@ -13,6 +13,8 @@ from app.models.admin_audit_log import AdminAuditLog
 from app.models.analysis_area import AnalysisArea
 from app.models.social_publication import SocialPublication, SocialPublicationOutbox
 from app.models.user_polygon import UserPolygon
+from app.observability.metrics import OUTBOX_FAILED, OUTBOX_PROCESSED, OUTBOX_RETRY
+from app.observability.outbox import update_outbox_gauges
 from app.schemas.social import PublicAdoptedPolygonSnapshot
 from app.services.notification_policy import DomainEvent, NotificationEventType
 from app.services.notifications import notify_superusers, publish_notifications
@@ -700,6 +702,15 @@ async def publish_due_events(
                 notifications = []
             await session.commit()
             publish_notifications(notifications)
+    OUTBOX_PROCESSED.labels("social").inc(result["published"] + result["dry_run"])
+    OUTBOX_FAILED.labels("social").inc(result["failed"])
+    OUTBOX_RETRY.labels("social").inc(result["retried"])
+    await update_outbox_gauges(
+        session,
+        SocialPublicationOutbox,
+        outbox_type="social",
+        pending_statuses=("PENDING", "PENDING_APPROVAL", "PROCESSING"),
+    )
     return result
 
 

--- a/backend/app/services/wikidata_enrichment.py
+++ b/backend/app/services/wikidata_enrichment.py
@@ -75,7 +75,14 @@ class WikidataClient:
         for attempt in range(3):
             try:
                 async with httpx.AsyncClient(timeout=timeout, transport=self.transport, headers=headers) as client:
-                    response = await client.get(self.settings.wikidata_api_url, params={**params, "format": "json", "formatversion": 2})
+                    response = await instrumented_httpx_request(
+                        client,
+                        "GET",
+                        self.settings.wikidata_api_url,
+                        provider="wikidata",
+                        operation=str(params.get("action", "request")),
+                        params={**params, "format": "json", "formatversion": 2},
+                    )
                 if (response.status_code == 429 or response.status_code >= 500) and attempt < 2:
                     await asyncio.sleep(min(float(response.headers.get("Retry-After", attempt + 1)), 5.0))
                     continue
@@ -337,3 +344,4 @@ class WikidataEnrichmentService:
                  "label": entity.label, "description": entity.description})
         await bump_cache_versions(session, ("analysis-areas",))
         await session.commit()
+from app.observability.external import instrumented_httpx_request

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,8 +13,15 @@ dependencies = [
   "geoalchemy2>=0.17.1",
   "httpx>=0.28.1",
   "jinja2>=3.1.6",
+  "opentelemetry-api>=1.38.0,<2",
+  "opentelemetry-exporter-otlp-proto-grpc>=1.38.0,<2",
+  "opentelemetry-instrumentation-fastapi>=0.59b0,<1",
+  "opentelemetry-instrumentation-httpx>=0.59b0,<1",
+  "opentelemetry-instrumentation-sqlalchemy>=0.59b0,<1",
+  "opentelemetry-sdk>=1.38.0,<2",
   "pillow>=11.3.0",
   "playwright>=1.55.0",
+  "prometheus-client>=0.22.1,<1",
   "pwdlib[argon2]>=0.2.1",
   "pydantic-settings>=2.10.1",
   "pydantic>=2.11.7",
@@ -25,7 +32,7 @@ dependencies = [
   "shapely>=2.1.1",
   "sqlalchemy>=2.0.42",
   "uvicorn[standard]>=0.35.0",
-  "webauthn>=3.0.0,<4"
+  "webauthn>=3.0.0,<4",
 ]
 
 [build-system]

--- a/backend/tests/test_assistant_phase3.py
+++ b/backend/tests/test_assistant_phase3.py
@@ -310,7 +310,7 @@ async def test_provider_failure_is_visible_in_privacy_safe_telemetry(
 
 
 @pytest.mark.asyncio
-async def test_groq_provider_rejects_empty_and_malformed_output_after_one_repair(
+async def test_groq_provider_rejects_output_without_logging_raw_provider_content(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.WARNING, logger="app.services.assistant_provider")
@@ -330,8 +330,9 @@ async def test_groq_provider_rejects_empty_and_malformed_output_after_one_repair
     assert raised.value.code == "ASSISTANT_INVALID_PLAN"
     assert calls == 2
     assert "assistant_provider_invalid_plan" in caplog.text
-    assert "response={}" in caplog.text
-    assert "response=kein json" in caplog.text
+    assert "response=[REDACTED]" in caplog.text
+    assert "response={}" not in caplog.text
+    assert "response=kein json" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,273 @@
+import json
+import logging
+from io import StringIO
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import AsyncOpenTelemetryTransport
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from prometheus_client import generate_latest
+from starlette.requests import Request
+
+from app import main as main_module
+from app.cache.service import CacheService
+from app.observability.external import instrumented_httpx_request
+from app.observability.logging import JsonFormatter
+from app.observability.metrics import (
+    EXTERNAL_ERRORS,
+    EXTERNAL_REQUESTS,
+    REDIS_ERRORS,
+    REDIS_HITS,
+    REDIS_MISSES,
+    REGISTRY,
+)
+from app.observability.middleware import ObservabilityMiddleware, request_id_for, route_template
+from app.observability.redaction import REDACTED, redact
+
+
+def test_recursive_redaction_removes_secrets_and_pii() -> None:
+    source = {
+        "password": "secret",
+        "Authorization": "Bearer abc",
+        "nested": [{"email": "person@example.org", "totp_secret": "otp-value"}],
+        "message": "contact person@example.org using Bearer xyz",
+    }
+
+    rendered = json.dumps(redact(source))
+
+    for secret in ("Bearer abc", "person@example.org", "otp-value", "Bearer xyz"):
+        assert secret not in rendered
+    assert redact(source)["password"] == REDACTED
+    assert REDACTED in rendered
+
+
+def test_json_formatter_redacts_security_and_assistant_fields() -> None:
+    formatter = JsonFormatter(service="test", environment="test", release_sha="abc123")
+    record = logging.makeLogRecord(
+        {
+            "name": "privacy",
+            "levelno": logging.INFO,
+            "levelname": "INFO",
+            "msg": "request for person@example.org with Bearer abc",
+            "args": (),
+            "authorization": "Bearer jwt-value",
+            "cookie": "session=value",
+            "csrf_token": "csrf-value",
+            "password": "password-value",
+            "recovery_code": "recovery-value",
+            "totp_secret": "totp-value",
+            "assistant_prompt": "raw private prompt",
+            "smtp_password": "smtp-value",
+            "api_key": "key-value",
+        }
+    )
+
+    output = formatter.format(record)
+
+    for value in (
+        "person@example.org",
+        "Bearer abc",
+        "jwt-value",
+        "session=value",
+        "csrf-value",
+        "password-value",
+        "recovery-value",
+        "totp-value",
+        "raw private prompt",
+        "smtp-value",
+        "key-value",
+    ):
+        assert value not in output
+    assert json.loads(output)["release_sha"] == "abc123"
+
+
+@pytest.mark.parametrize(
+    ("incoming", "accepted"),
+    ((None, False), ("edge-123", True), ("bad value\n", False), ("x" * 97, False)),
+)
+def test_request_id_validation(incoming: str | None, accepted: bool) -> None:
+    generated = request_id_for(incoming)
+    assert (generated == incoming) is accepted
+    assert len(generated) <= 96
+
+
+def test_dynamic_paths_share_the_fastapi_route_template() -> None:
+    def request(path: str) -> Request:
+        return Request(
+            {
+                "type": "http",
+                "app": main_module.app,
+                "method": "GET",
+                "path": path,
+                "root_path": "",
+                "scheme": "https",
+                "query_string": b"",
+                "headers": [],
+                "server": ("api.example", 443),
+                "client": ("127.0.0.1", 1234),
+            }
+        )
+
+    first = route_template(request("/api/v1/polygons/by-slug/foo"))
+    second = route_template(request("/api/v1/polygons/by-slug/bar"))
+    assert first == second == "/api/v1/polygons/by-slug/{slug}"
+
+
+@pytest.mark.asyncio
+async def test_request_id_response_log_metrics_and_route_cardinality() -> None:
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(JsonFormatter(service="test", environment="test", release_sha="sha"))
+    middleware_logger = logging.getLogger("app.observability.middleware")
+    middleware_logger.addHandler(handler)
+    middleware_logger.propagate = False
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=main_module.app), base_url="https://api.example"
+        ) as client:
+            first = await client.get("/health/live", headers={"X-Request-ID": "edge-123"})
+            second = await client.get("/health/live", headers={"X-Request-ID": "bad value"})
+            metrics = await client.get(main_module.settings.metrics_path)
+    finally:
+        middleware_logger.removeHandler(handler)
+        middleware_logger.propagate = True
+
+    assert first.headers["X-Request-ID"] == "edge-123"
+    assert second.headers["X-Request-ID"] != "bad value"
+    records = [json.loads(line) for line in stream.getvalue().splitlines()]
+    first_log = next(item for item in records if item.get("request_id") == "edge-123")
+    assert first_log["event"] == "http_request_completed"
+    assert first_log["route"] == "/health/live"
+    assert first_log["status_code"] == 200
+    body = metrics.text
+    assert 'http_requests_total{method="GET",route="/health/live",status_class="2xx"}' in body
+    assert "http_request_duration_seconds_bucket" in body
+    assert "edge-123" not in body
+
+
+@pytest.mark.asyncio
+async def test_fastapi_trace_contains_child_span_and_trace_id_in_log() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    app = FastAPI()
+    app.add_middleware(ObservabilityMiddleware, metrics_enabled=False, metrics_path="/metrics")
+    @app.get("/trace")
+    async def traced() -> dict[str, bool]:
+        async with httpx.AsyncClient(
+            transport=AsyncOpenTelemetryTransport(
+                httpx.MockTransport(lambda _request: httpx.Response(200)),
+                tracer_provider=provider,
+            )
+        ) as provider_client:
+            response = await provider_client.get("https://provider.test/resource")
+        return {"ok": response.is_success}
+
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(JsonFormatter(service="test", environment="test", release_sha="sha"))
+    middleware_logger = logging.getLogger("app.observability.middleware")
+    middleware_logger.addHandler(handler)
+    middleware_logger.propagate = False
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="https://api.example"
+        ) as client:
+            assert (await client.get("/trace")).status_code == 200
+    finally:
+        middleware_logger.removeHandler(handler)
+        middleware_logger.propagate = True
+        FastAPIInstrumentor.uninstrument_app(app)
+        provider.shutdown()
+
+    spans = exporter.get_finished_spans()
+    names = {span.name for span in spans}
+    assert "GET" in names
+    assert any("/trace" in name for name in names)
+    request_log = json.loads(stream.getvalue().splitlines()[-1])
+    assert request_log["trace_id"] == f"{spans[0].context.trace_id:032x}"
+
+
+class FakeRedis:
+    async def get(self, key: str) -> bytes | None:
+        if key == "error":
+            raise ConnectionError(key)
+        return b"value" if key == "hit" else None
+
+
+@pytest.mark.asyncio
+async def test_redis_hit_miss_and_failure_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = CacheService()
+    monkeypatch.setattr("app.cache.service.get_redis", lambda: FakeRedis())
+    before = (REDIS_HITS._value.get(), REDIS_MISSES._value.get())
+    errors = REDIS_ERRORS.labels("get")._value.get()
+
+    assert await cache.get("hit") == b"value"
+    assert await cache.get("miss") is None
+    assert await cache.get("error") is None
+
+    assert REDIS_HITS._value.get() == before[0] + 1
+    assert REDIS_MISSES._value.get() == before[1] + 1
+    assert REDIS_ERRORS.labels("get")._value.get() == errors + 1
+
+
+@pytest.mark.asyncio
+async def test_external_provider_success_timeout_and_http_error_metrics() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/timeout":
+            raise httpx.ReadTimeout("slow", request=request)
+        return httpx.Response(500 if request.url.path == "/error" else 200)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        success_before = EXTERNAL_REQUESTS.labels("test", "lookup", "success")._value.get()
+        error_before = EXTERNAL_REQUESTS.labels("test", "lookup", "error")._value.get()
+        timeout_before = EXTERNAL_ERRORS.labels("test", "lookup", "ReadTimeout")._value.get()
+        assert (
+            await instrumented_httpx_request(
+                client, "GET", "https://provider.test/ok", provider="test", operation="lookup"
+            )
+        ).status_code == 200
+        assert (
+            await instrumented_httpx_request(
+                client,
+                "GET",
+                "https://provider.test/error",
+                provider="test",
+                operation="lookup",
+            )
+        ).status_code == 500
+        with pytest.raises(httpx.ReadTimeout):
+            await instrumented_httpx_request(
+                client,
+                "GET",
+                "https://provider.test/timeout",
+                provider="test",
+                operation="lookup",
+            )
+
+    assert EXTERNAL_REQUESTS.labels("test", "lookup", "success")._value.get() == success_before + 1
+    assert EXTERNAL_REQUESTS.labels("test", "lookup", "error")._value.get() == error_before + 2
+    assert EXTERNAL_ERRORS.labels("test", "lookup", "ReadTimeout")._value.get() == timeout_before + 1
+    assert b"password" not in generate_latest(REGISTRY)
+
+
+def test_db_pool_metrics_hooks_use_public_pool_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    pool = main_module.engine.sync_engine.pool
+    monkeypatch.setattr(pool, "size", lambda: 7)
+    monkeypatch.setattr(pool, "checkedout", lambda: 3)
+    monkeypatch.setattr(pool, "checkedin", lambda: 4)
+    monkeypatch.setattr(pool, "overflow", lambda: 1)
+    from app.db.session import update_pool_metrics
+
+    update_pool_metrics()
+    body = generate_latest(REGISTRY).decode()
+    assert "db_pool_size 7.0" in body
+    assert "db_pool_checked_out 3.0" in body
+    assert "db_pool_checked_in 4.0" in body
+    assert "db_pool_overflow 1.0" in body

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -84,6 +84,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -372,6 +381,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/74bcab964c9a7a61f2bb71e8179b0f13e6fa98f7ce00fd168aab291e4a2e/googleapis_common_protos-1.75.1.tar.gz", hash = "sha256:d3042c6c5a2d4e67113104d6b6818b59b6bd92a197f2a91508e801fe815cf071", size = 150967, upload-time = "2026-08-06T06:24:51.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl", hash = "sha256:28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79", size = 300626, upload-time = "2026-08-06T06:23:46.696Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -387,6 +408,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
     { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
     { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/2b/51e32514a4e9b715375c99721aadff0f24164cc2049b8269eda4de82a814/grpcio-1.83.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:28f6c35ac8fcf10e4594f138e468f194360089dde40d126a7033e863fc479930", size = 6303167, upload-time = "2026-07-23T15:19:33.78Z" },
+    { url = "https://files.pythonhosted.org/packages/39/33/b5b50fc2c6fbe350e04814047bb2d409feec7b36ef8b170254c050e06bc0/grpcio-1.83.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:33898e6a28e4ae598f1577cb1c4fec2a15c033d0ec52b9b45a09610dd045b9da", size = 12160538, upload-time = "2026-07-23T15:19:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5f/734e72e7b9f79bcf0b2c270b8d3bca0e4ebb97a27a50d06240b145f6d41e/grpcio-1.83.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fb8a1dd0c6f0f931e69e9d0dc6d1c406ed2a44fa963414eafba07b7fb685d16", size = 6869310, upload-time = "2026-07-23T15:19:38.607Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/a1735f215b2a5cd43c38b79eac072ad197e61be9829905b6b29550abd0db/grpcio-1.83.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2b5e75c34842cd9c1b95285ca395c6a569664b81e3ffa6b714125922942abaaf", size = 7613472, upload-time = "2026-07-23T15:19:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/78/c9e81f806ac704b6b145cb01628db398985b1f8dfdc10e23b55fb0902b3d/grpcio-1.83.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeb339838db07600481ef869507279b75326c75eac6d10f7afa62a0da1d2bcdd", size = 7040616, upload-time = "2026-07-23T15:19:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ba/94cd5af859876049d340480acbb61a959096c84b567f215534faa78d0424/grpcio-1.83.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f47d62808b4c0a97b78bff88a6d4ca283a2a492b9a04a87d814af95ca3b9c19c", size = 7570491, upload-time = "2026-07-23T15:19:44.357Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/15/108d30d5a5c964312ae8b9cb0e8cc5b3c1cc68d8f757cca52b3565534d26/grpcio-1.83.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62003babc444a606dcd1f009cd16391ce23669ae4ad6ec267a873da7937a69f5", size = 8605036, upload-time = "2026-07-23T15:19:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/23/3828ae13c3db8233d123ad612747665817b952d8a954f32390230b582336/grpcio-1.83.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1aa567f8c3f19850ffd5d2858c9a8ea7c80f0db6c01186b71eb31e923ec984f5", size = 7981587, upload-time = "2026-07-23T15:19:48.913Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5b/77af31228f55f55a2a5112bb0077ad0a1c4d23dbb0c2853a62475bbdcc14/grpcio-1.83.0-cp312-cp312-win32.whl", hash = "sha256:cb2906c61db4f9c64cc360054b5df70eeb81846228e9e56a4944bd415a63dadc", size = 4394004, upload-time = "2026-07-23T15:19:50.618Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/da/f706e39550e7a3732ce2b9c5926107a93d74a802775b19b642a6df27dc96/grpcio-1.83.0-cp312-cp312-win_amd64.whl", hash = "sha256:1c699bbb20f143c8f2bff219de578aa2dc1f919399d67dc702b038b986ee62df", size = 5158525, upload-time = "2026-07-23T15:19:52.246Z" },
 ]
 
 [[package]]
@@ -599,8 +641,15 @@ dependencies = [
     { name = "geoalchemy2" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-sdk" },
     { name = "pillow" },
     { name = "playwright" },
+    { name = "prometheus-client" },
     { name = "pwdlib", extra = ["argon2"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -636,9 +685,16 @@ requires-dist = [
     { name = "geoalchemy2", specifier = ">=0.17.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "opentelemetry-api", specifier = ">=1.38.0,<2" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.38.0,<2" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.59b0,<1" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.59b0,<1" },
+    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.59b0,<1" },
+    { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "pip-audit", marker = "extra == 'security'", specifier = "==2.10.1" },
     { name = "playwright", specifier = ">=1.55.0" },
+    { name = "prometheus-client", specifier = ">=0.22.1,<1" },
     { name = "pwdlib", extras = ["argon2"], specifier = ">=0.2.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
@@ -656,6 +712,175 @@ requires-dist = [
     { name = "webauthn", specifier = ">=3.0.0,<4" },
 ]
 provides-extras = ["dev", "security"]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/83/8e8e83b7ac285281687c7be2fd305213ccccbb8c0a2dd4fb45a8ccaf12c7/opentelemetry_instrumentation_asgi-0.65b0.tar.gz", hash = "sha256:892bca67c56522ffa85a8a83cf934d7b50b3be2132e45cbee705825f0a5ba426", size = 26140, upload-time = "2026-07-16T15:25:54.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/9c/376962840b619d2d55fe8ee2285f8c70971c090e5fff614516fc654a6f3a/opentelemetry_instrumentation_asgi-0.65b0-py3-none-any.whl", hash = "sha256:3a845a8ebd1c4ef0d8263401e6545f5b219b2feee612090d50f578a87e71fd65", size = 15903, upload-time = "2026-07-16T15:24:57.198Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/b057f8196d06efdc1b50e3ff11fbc499a7d96b35c87f217eb7885542f4ea/opentelemetry_instrumentation_fastapi-0.65b0.tar.gz", hash = "sha256:10a3a95486036230413a58fe4fdf4a83fa6bba46918407e527476994bd92bd97", size = 26236, upload-time = "2026-07-16T15:26:05.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b0/c9b0300d33349ecc3dfd2362516eaffc44877e90970e6a52178ff953fec3/opentelemetry_instrumentation_fastapi-0.65b0-py3-none-any.whl", hash = "sha256:cda2610a0ec1b22d19886f33e4d861e9f5dbb886aeaa3a1263b47aff82c36943", size = 13261, upload-time = "2026-07-16T15:25:12.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/03/a529140241addd4d0acc73bafbd6f74691651b92fc0ae9b4513cf80f07fa/opentelemetry_instrumentation_httpx-0.65b0.tar.gz", hash = "sha256:4627aa9c6bb99bf4462c8b565b0ef6aeb9ffad95c6c92868be1ef7895de112ee", size = 26309, upload-time = "2026-07-16T15:26:07.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/0f/c6144096b4914bbf44b43ba21c962e8f333ff045770b50a3e79ed8bd455f/opentelemetry_instrumentation_httpx-0.65b0-py3-none-any.whl", hash = "sha256:400f1b78afa4ee2332b5debe58e1ed1b317913d58812c952576be76660aeadb1", size = 17436, upload-time = "2026-07-16T15:25:15.772Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-sqlalchemy"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/9d/72af21527ce6f286ac78dc2c75ce44b76cc45343a28f0bcbb13f213421fc/opentelemetry_instrumentation_sqlalchemy-0.65b0.tar.gz", hash = "sha256:8ec2e79f1e00808c5dc639ab5b2cfcdf9dcdef55efd6442c6019707fe2894028", size = 18007, upload-time = "2026-07-16T15:26:19.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/94/3eb3195a60b894cc1852a5657a2b64764a998085c50d7fb3452148af8f18/opentelemetry_instrumentation_sqlalchemy-0.65b0-py3-none-any.whl", hash = "sha256:4d8a2e5afc7b505a48d05cb1fb6db5f8b31681814c1d7767bd6d4b5bdd3a3047", size = 14410, upload-time = "2026-07-16T15:25:32.04Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
+]
 
 [[package]]
 name = "packageurl-python"
@@ -782,6 +1007,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/e7/0553e21d25ca4d9f573135775348a372c3ec34a93a71d5f297c3bac38341/protobuf-7.36.0.tar.gz", hash = "sha256:e8e09cb0d794c6687926fa558a8a6e72aa10edb997d5ca61da0765f12a3e00ea", size = 510034, upload-time = "2026-08-20T16:34:01.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ae/58e3ca96cb2e118cc546b677359b3c6659f79a140935c08dec94c7998585/protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:9103532dffd80c6fab7e50c65a31007680a06eb57537d437bb1b35812c138a37", size = 453256, upload-time = "2026-08-20T16:33:53.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/15/5162230af4912697f0fe406f6800f80760945babcff0e2c2fe6c84ef2d5d/protobuf-7.36.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:bf94a5917c71058262de683669bc0a797a7669d3de71f0b36d058e3194f47b44", size = 341436, upload-time = "2026-08-20T16:33:55.134Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/09/1670b2bfc9a45e807e520c3e9be36524db9ccc7dc05ea17af7681cabdc61/protobuf-7.36.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:3297e60abdff301e5f74393d87f6cc59dacab5f024a89548a6e8de1d26576b16", size = 354440, upload-time = "2026-08-20T16:33:56.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b", size = 340439, upload-time = "2026-08-20T16:33:56.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/acd02338235a3e7d03168c4303478347b7624fc8189ff4e7f0d2654bbe86/protobuf-7.36.0-cp310-abi3-win32.whl", hash = "sha256:7326fd717bdc419162a735938d89d4032332bcc3408804012b24ff3a37086071", size = 440216, upload-time = "2026-08-20T16:33:57.99Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4e/12cb93270967a2affff5b3f720694700d4d87712a67afd05c8cb3f6fa52c/protobuf-7.36.0-cp310-abi3-win_amd64.whl", hash = "sha256:1781cc1de61249b750848029bca452c0a8b7e990080316b9bbc2518b2117b488", size = 453731, upload-time = "2026-08-20T16:33:58.951Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/629999e78d46c1115c11886d51c6bd68c17ce4a944f1ea3e153a91316a33/protobuf-7.36.0-py3-none-any.whl", hash = "sha256:53374d53fc29a67f7dbbf0ade47d7526a0f0137bf0f9c90e48d8a60790ef748c", size = 177024, upload-time = "2026-08-20T16:34:00.053Z" },
 ]
 
 [[package]]
@@ -1310,4 +1559,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/d8/c3a78cccc74a554780e9e76e323d5cde891048627025f0f82623e22dc3df/websockets-17.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:2b3f3020171202b135ca078e20434977c6b2b02af647130d6980c9e39b9462e3", size = 213348, upload-time = "2026-07-31T11:29:53.891Z" },
     { url = "https://files.pythonhosted.org/packages/7b/25/e1b8824bd632c8a5a62d504b61e9e35e470b67e4be0206f5c28f90c7f86d/websockets-17.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:41d6aa06b5ab832aee72fedf47a149535b121ac900b6bb4d3fe14712afac9a79", size = 213276, upload-time = "2026-07-31T11:29:55.299Z" },
     { url = "https://files.pythonhosted.org/packages/09/ce/3929538b2b9918f5eee623fbf3346893973191f6df93f19bbda097bd7bb7/websockets-17.0.1-py3-none-any.whl", hash = "sha256:c6be9cba65c65cc76dfa3d4619e359ff02a4476c74e179b215236c11a0b32345", size = 206718, upload-time = "2026-07-31T11:31:26.037Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b0/c1f5a970721f06b85c0cd5142e0ff8fe067708abd779b0c4f4be7d61d09f/wrapt-2.3.0.tar.gz", hash = "sha256:681a2d0eefd721998f90642762b8e75c2159ec531b20ad5e437245ea7b06a107", size = 131509, upload-time = "2026-07-28T06:06:14.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/4a/d17a0fad1bf1c5f2c887ff71fef75654141b0880bff71d157d955b5bec3a/wrapt-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a45ffae742ce91a16e11cb6c7cd71e7f9994f3cbd283b962ab093f5c6dcf525", size = 82139, upload-time = "2026-07-28T06:04:35.082Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/55/51b92daaf6defb57f4dc56bdcce985400f75c6984a03ca5e78ccac717028/wrapt-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69e477046f2237ef0bc6547544ee73008dc764ca26eff44f09e976d221b34d5d", size = 82723, upload-time = "2026-07-28T06:04:36.502Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7f/cfd9bc4b1f5e424eeea83d0493e43f3b1b02707ce8e50c47945873982bd5/wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d221a6e6ddd302b8397433184e96b59f259f50024b854db1c411a881586b6b8", size = 172381, upload-time = "2026-07-28T06:04:37.674Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/89/ff7814f6eb6856b479946117d1138a2fbb46cdb6b1f379db359056c69743/wrapt-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:392158c9a7f2ab1b8699418bfc0fe6f83548788c418b27d7bf2019ad3405cebb", size = 174120, upload-time = "2026-07-28T06:04:38.987Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1e/8eded8615d39e3ce81f626937a3a87b280a2a86239a2bf14a4b4bb345034/wrapt-2.3.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e5301c35cf75655eb33498f2bd6ae8703ca19940e3167dc9cdf740c712a39c60", size = 163035, upload-time = "2026-07-28T06:04:40.361Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ea/a0af2d9da62897af2a055484920de05dade30d2ba2c0d65cbdea875d3d8b/wrapt-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:418f54bb09d1762db02c7009b4051149893af3153a87f92d70356703c11eea02", size = 171887, upload-time = "2026-07-28T06:04:41.614Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/dd/63cd4c864c65ef4906df64bd2d378f4a62b54f28063f282dfb3bf93caead/wrapt-2.3.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1598becd30f8f2777d18564064eb4f4dbe1ab0e05a8f09786d0ef505ac782bf3", size = 161113, upload-time = "2026-07-28T06:04:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ee/82f1fc9e431b5c2c5a6d201aa865dbeae3984c311c6d11a185f0c8367cf6/wrapt-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3da470536bf9645143323dd41b32db55c6f4304ad382094c1a1da8a92061e10d", size = 170530, upload-time = "2026-07-28T06:04:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a5/5dc590e863a419930d988f8b7ca3e75a6befcfb10b6003b3a152f3d5f732/wrapt-2.3.0-cp312-cp312-win32.whl", hash = "sha256:fb8e2e6704a1e0b1b989546c69e2688371ef4a07fa5f61bde3eb6211186f5ac1", size = 78323, upload-time = "2026-07-28T06:04:45.484Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f9/4a6925a07951df56394f7e6ebe14f69f1c5ef9d87aa63e0839acf15aa63a/wrapt-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:cdc021cb0b62471d6aac7f2bd92f3b4658073775f9ee7fcd325c511129e7bcc8", size = 81180, upload-time = "2026-07-28T06:04:47.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/4f/8b5de0395b2a72216751d41c9861df6facaeb611b619d8810ed2b3b23eb2/wrapt-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:67bfe2485f50368c3fcd2275fc1fd100e350d601e0058921a7c82678a465aeab", size = 80155, upload-time = "2026-07-28T06:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/00/39/3daf9f47be208606586de4568ba6713db53ebc8fd7a575aea1fe57983b69/wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2", size = 61866, upload-time = "2026-07-28T06:06:12.9Z" },
 ]

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -2,6 +2,11 @@
 
 Dieses Verzeichnis automatisiert den produktiven Betrieb des Open City Planner auf dem bestehenden Shared Host. Es ersetzt bewusst nicht die globale Serververwaltung aller OK-Lab-Projekte. Nginx, PostgreSQL, Redis und Node können weitere Anwendungen bedienen; die Playbooks verändern deshalb überwiegend Stadtplaner-spezifische Dateien. Die ausdrücklich verwaltete NodeSource-22-Paketquelle und die gepinnten Corepack-/pnpm-Versionen bilden die gemeinsame JavaScript-Runtime-Ausnahme. `/etc/nginx/nginx.conf`, PostgreSQL und Redis werden nicht blind neu konfiguriert.
 
+Prometheus und Grafana werden nicht durch einen normalen Applikationsdeploy
+verändert. Dafür existiert das separate Opt-in-Playbook
+`playbooks/monitoring.yml`; die vollständige Betriebsanleitung steht unter
+[`docs/monitoring-deployment.md`](../../docs/monitoring-deployment.md).
+
 ## Warum Ansible?
 
 Für diesen Server ist ein idempotenter Deployment-Ablauf sicherer als wiederholte manuelle Änderungen: dieselben Pfade, Benutzer, systemd-Units, Builds, Migrationen, Nginx-Dateien und Smoke Tests werden bei jedem Lauf reproduzierbar angewendet. Ein normaler Deploy führt **keinen** OSM-Initialimport und **keine** Certbot-Ausstellung aus.

--- a/deploy/ansible/inventory/group_vars/all.yml
+++ b/deploy/ansible/inventory/group_vars/all.yml
@@ -65,3 +65,22 @@ stadtplaner_pre_migration_backup_command: ''
 # Certbot is opt-in and must never run on each normal deploy.
 stadtplaner_certbot_email: ''
 stadtplaner_manage_certificates: false
+
+# The monitoring playbook is separate and opt-in. All services bind to
+# loopback unless Grafana publication is explicitly enabled.
+monitoring_grafana_bind_address: 127.0.0.1
+monitoring_grafana_port: 3000
+monitoring_grafana_publish: false
+monitoring_grafana_host: ''
+monitoring_grafana_certificate_name: "{{ monitoring_grafana_host }}"
+monitoring_grafana_package_version: ''
+monitoring_prometheus_bind_address: 127.0.0.1
+monitoring_prometheus_port: 9090
+monitoring_prometheus_retention_time: 30d
+monitoring_prometheus_retention_size: 10GB
+monitoring_prometheus_api_scheme: http
+monitoring_prometheus_api_target: "127.0.0.1:{{ stadtplaner_backend_port }}"
+monitoring_readiness_url: "http://127.0.0.1:{{ stadtplaner_backend_port }}/health/ready"
+monitoring_alertmanager_targets: []
+monitoring_manage_certificates: false
+monitoring_certbot_email: ''

--- a/deploy/ansible/inventory/group_vars/all.yml
+++ b/deploy/ansible/inventory/group_vars/all.yml
@@ -11,6 +11,8 @@ stadtplaner_config_dir: /etc/stadtplaner
 stadtplaner_data_dir: /data/stadtplaner
 stadtplaner_social_dir: /data/stadtplaner-social
 stadtplaner_avatar_upload_dir: /data/uploads
+stadtplaner_observability_dir: /data/stadtplaner/observability
+stadtplaner_metrics_allowed_cidrs: []
 
 stadtplaner_backend_port: 8008
 stadtplaner_frontend_port: 3008

--- a/deploy/ansible/inventory/production.yml
+++ b/deploy/ansible/inventory/production.yml
@@ -5,3 +5,6 @@ all:
         stadtplaner-prod:
           ansible_host: stadtplaner.oklabflensburg.de
           ansible_become: true
+    monitoring:
+      hosts:
+        stadtplaner-prod:

--- a/deploy/ansible/playbooks/monitoring-certificates.yml
+++ b/deploy/ansible/playbooks/monitoring-certificates.yml
@@ -1,0 +1,140 @@
+---
+- name: Issue the optional Grafana TLS certificate
+  hosts: monitoring
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  tasks:
+    - name: Require explicit Grafana publication and certificate opt-in
+      ansible.builtin.assert:
+        that:
+          - monitoring_grafana_publish | bool
+          - monitoring_manage_certificates | bool
+          - monitoring_grafana_host | length > 3
+          - monitoring_certbot_email | length > 3
+        fail_msg: >-
+          Set monitoring_grafana_publish=true,
+          monitoring_manage_certificates=true, monitoring_grafana_host and
+          monitoring_certbot_email. DNS must already point at this host.
+
+    - name: Check whether the Grafana certificate exists
+      ansible.builtin.stat:
+        path: "/etc/letsencrypt/live/{{ monitoring_grafana_certificate_name }}/fullchain.pem"
+      register: monitoring_grafana_certificate
+
+    - name: Install certificate prerequisites
+      ansible.builtin.apt:
+        name:
+          - certbot
+          - nginx
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Create ACME webroot
+      ansible.builtin.file:
+        path: /var/www/letsencrypt
+        state: directory
+        owner: www-data
+        group: www-data
+        mode: '0755'
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Install temporary Grafana ACME vhost
+      ansible.builtin.copy:
+        dest: /etc/nginx/sites-available/stadtplaner-grafana-acme
+        owner: root
+        group: root
+        mode: '0644'
+        content: |
+          server {
+              listen 80;
+              listen [::]:80;
+              server_name {{ monitoring_grafana_host }};
+              location /.well-known/acme-challenge/ { root /var/www/letsencrypt; }
+              location / { return 404; }
+          }
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Enable temporary Grafana ACME vhost
+      ansible.builtin.file:
+        src: /etc/nginx/sites-available/stadtplaner-grafana-acme
+        dest: /etc/nginx/sites-enabled/stadtplaner-grafana-acme
+        state: link
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Validate Nginx before requesting the certificate
+      ansible.builtin.command: nginx -t
+      changed_when: false
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Reload Nginx for the ACME challenge
+      ansible.builtin.systemd_service:
+        name: nginx
+        state: reloaded
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Obtain the Grafana certificate
+      ansible.builtin.command:
+        argv:
+          - certbot
+          - certonly
+          - --webroot
+          - -w
+          - /var/www/letsencrypt
+          - -d
+          - "{{ monitoring_grafana_host }}"
+          - --non-interactive
+          - --agree-tos
+          - --email
+          - "{{ monitoring_certbot_email }}"
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Remove temporary Grafana ACME vhost
+      ansible.builtin.file:
+        path: /etc/nginx/sites-enabled/stadtplaner-grafana-acme
+        state: absent
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Remove temporary Grafana ACME vhost file
+      ansible.builtin.file:
+        path: /etc/nginx/sites-available/stadtplaner-grafana-acme
+        state: absent
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Create certificate renewal hook directory
+      ansible.builtin.file:
+        path: /etc/letsencrypt/renewal-hooks/deploy
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Install certificate renewal reload hook
+      ansible.builtin.copy:
+        dest: /etc/letsencrypt/renewal-hooks/deploy/reload-nginx
+        owner: root
+        group: root
+        mode: '0755'
+        content: |
+          #!/bin/sh
+          set -eu
+          /usr/bin/systemctl reload nginx
+
+    - name: Validate Nginx after removing the ACME vhost
+      ansible.builtin.command: nginx -t
+      changed_when: false
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Reload Nginx after removing the ACME vhost
+      ansible.builtin.systemd_service:
+        name: nginx
+        state: reloaded
+      when: not monitoring_grafana_certificate.stat.exists
+
+    - name: Explain the required follow-up
+      ansible.builtin.debug:
+        msg: >-
+          Certificate available. Run monitoring.yml with
+          monitoring_grafana_publish=true to install the HTTPS vhost.

--- a/deploy/ansible/playbooks/monitoring.yml
+++ b/deploy/ansible/playbooks/monitoring.yml
@@ -1,0 +1,8 @@
+---
+- name: Deploy Open City Planner monitoring
+  hosts: monitoring
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  roles:
+    - role: stadtplaner_monitoring

--- a/deploy/ansible/roles/stadtplaner/tasks/main.yml
+++ b/deploy/ansible/roles/stadtplaner/tasks/main.yml
@@ -12,6 +12,7 @@
     - { path: "{{ stadtplaner_social_dir }}", owner: "{{ stadtplaner_service_user }}", group: "{{ stadtplaner_service_group }}", mode: '0750' }
     - { path: "{{ stadtplaner_avatar_upload_dir }}", owner: "{{ stadtplaner_service_user }}", group: "{{ stadtplaner_service_group }}", mode: '0750' }
     - { path: "{{ stadtplaner_avatar_upload_dir }}/avatars", owner: "{{ stadtplaner_service_user }}", group: "{{ stadtplaner_service_group }}", mode: '0750' }
+    - { path: "{{ stadtplaner_observability_dir }}", owner: "{{ stadtplaner_service_user }}", group: "{{ stadtplaner_service_group }}", mode: '0750' }
 
 - name: Install backend environment from encrypted variable when supplied
   ansible.builtin.copy:
@@ -183,6 +184,7 @@
 
 - name: Resolve the target release path
   ansible.builtin.set_fact:
+    stadtplaner_release_sha: "{{ stadtplaner_git.after | default(stadtplaner_deploy_ref) }}"
     stadtplaner_release_path: >-
       {{ stadtplaner_releases_dir }}/{{ (stadtplaner_git.after | default(stadtplaner_deploy_ref)) | regex_replace('[^A-Za-z0-9._-]+', '-') }}
 
@@ -460,7 +462,7 @@
         working_directory: "{{ stadtplaner_current_path }}"
         environment_file: "{{ stadtplaner_osm_env_file }}"
         exec_start: "{{ stadtplaner_current_path }}/scripts/osm/update.sh"
-        read_write_paths: ["{{ stadtplaner_data_dir }}"]
+        read_write_paths: ["{{ stadtplaner_data_dir }}", "{{ stadtplaner_observability_dir }}"]
         timer_description: Run Stadtplaner OpenStreetMap synchronization hourly
         on_boot: 10m
         on_unit_active: 1h
@@ -473,7 +475,7 @@
         working_directory: "{{ stadtplaner_current_path }}/backend"
         environment_file: "{{ stadtplaner_backend_env_file }}"
         exec_start: "{{ stadtplaner_current_path }}/backend/.venv/bin/python -m app.cli.import_flensburg_statistics"
-        read_write_paths: ["{{ stadtplaner_current_path }}/backend/data"]
+        read_write_paths: ["{{ stadtplaner_current_path }}/backend/data", "{{ stadtplaner_observability_dir }}"]
         timer_description: Weekly check for updated Flensburg statistics
         on_boot: ''
         on_unit_active: ''
@@ -486,7 +488,7 @@
         working_directory: "{{ stadtplaner_current_path }}/backend"
         environment_file: "{{ stadtplaner_backend_env_file }}"
         exec_start: "{{ stadtplaner_current_path }}/backend/.venv/bin/python -m app.cli.process_email_outbox --limit 20"
-        read_write_paths: []
+        read_write_paths: ["{{ stadtplaner_observability_dir }}"]
         timer_description: Fällige Stadtplaner-E-Mails regelmäßig versenden
         on_boot: 1m
         on_unit_active: 1m
@@ -499,7 +501,7 @@
         working_directory: "{{ stadtplaner_current_path }}/backend"
         environment_file: "{{ stadtplaner_backend_env_file }}"
         exec_start: "{{ stadtplaner_current_path }}/backend/.venv/bin/python -m app.cli.publish_social_outbox --limit 20"
-        read_write_paths: ["{{ stadtplaner_social_dir }}"]
+        read_write_paths: ["{{ stadtplaner_social_dir }}", "{{ stadtplaner_observability_dir }}"]
         timer_description: Publish due Stadtplaner Mastodon outbox events
         on_boot: 2m
         on_unit_active: 1m

--- a/deploy/ansible/roles/stadtplaner/templates/oneshot.service.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/oneshot.service.j2
@@ -9,7 +9,8 @@ User={{ stadtplaner_service_user }}
 Group={{ stadtplaner_service_group }}
 WorkingDirectory={{ unit_working_directory }}
 {% if unit_environment_file %}EnvironmentFile={{ unit_environment_file }}
-{% endif %}ExecStart={{ unit_exec_start }}
+{% endif %}Environment=STADTPLANER_RELEASE_SHA={{ stadtplaner_release_sha }}
+ExecStart={{ unit_exec_start }}
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict

--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner-api.service.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner-api.service.j2
@@ -9,6 +9,7 @@ User={{ stadtplaner_service_user }}
 Group={{ stadtplaner_service_group }}
 WorkingDirectory={{ stadtplaner_current_path }}/backend
 EnvironmentFile={{ stadtplaner_backend_env_file }}
+Environment=STADTPLANER_RELEASE_SHA={{ stadtplaner_release_sha }}
 ExecStart={{ stadtplaner_current_path }}/backend/.venv/bin/uvicorn app.main:app --host 127.0.0.1 --port {{ stadtplaner_backend_port }} --proxy-headers --forwarded-allow-ips=127.0.0.1,::1
 Restart=on-failure
 RestartSec=3
@@ -17,7 +18,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths={{ stadtplaner_current_path }}/backend/data {{ stadtplaner_data_dir }} {{ stadtplaner_social_dir }} {{ stadtplaner_avatar_upload_dir }}
+ReadWritePaths={{ stadtplaner_current_path }}/backend/data {{ stadtplaner_data_dir }} {{ stadtplaner_social_dir }} {{ stadtplaner_avatar_upload_dir }} {{ stadtplaner_observability_dir }}
 UMask=0027
 
 [Install]

--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner-frontend.service.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner-frontend.service.j2
@@ -9,6 +9,8 @@ User={{ stadtplaner_service_user }}
 Group={{ stadtplaner_service_group }}
 WorkingDirectory={{ stadtplaner_current_path }}/frontend
 EnvironmentFile={{ stadtplaner_frontend_env_file }}
+Environment=STADTPLANER_RELEASE_SHA={{ stadtplaner_release_sha }}
+Environment=APP_ENVIRONMENT=production
 Environment=NODE_ENV=production
 Environment=HOST=127.0.0.1
 Environment=PORT={{ stadtplaner_frontend_port }}

--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner.nginx.conf.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner.nginx.conf.j2
@@ -8,10 +8,16 @@ upstream stadtplaner_api {
     keepalive 32;
 }
 
+log_format stadtplaner_json escape=json '{"timestamp":"$time_iso8601",'
+    '"request_id":"$request_id","method":"$request_method","uri":"$uri",'
+    '"status":$status,"request_time":$request_time,'
+    '"upstream_response_time":"$upstream_response_time"}';
+
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_name {{ stadtplaner_public_host }};
+    access_log /var/log/nginx/stadtplaner-access.json stadtplaner_json;
 
     location / {
         proxy_pass http://stadtplaner_frontend;
@@ -21,6 +27,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $stadtplaner_connection_upgrade;
         proxy_connect_timeout 5s;
@@ -39,6 +46,7 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_name {{ stadtplaner_developer_host }};
+    access_log /var/log/nginx/stadtplaner-developer-access.json stadtplaner_json;
 
     location / {
         proxy_pass http://stadtplaner_frontend;
@@ -48,6 +56,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $stadtplaner_connection_upgrade;
         proxy_connect_timeout 5s;
@@ -66,8 +75,8 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_name {{ stadtplaner_api_host }};
-
     client_max_body_size 10m;
+    access_log /var/log/nginx/stadtplaner-api-access.json stadtplaner_json;
     limit_req_dry_run {{ 'on' if stadtplaner_enable_rate_limit_dry_run else 'off' }};
 
     location = /health/live {
@@ -77,6 +86,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
     }
@@ -88,12 +98,28 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
     }
 
     location = /health {
         return 301 /health/ready;
+    }
+
+    location = /metrics {
+        allow 127.0.0.1;
+        allow ::1;
+{% for cidr in stadtplaner_metrics_allowed_cidrs %}
+        allow {{ cidr }};
+{% endfor %}
+        deny all;
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 10s;
     }
 
     location = /api/v1/assistant/query {
@@ -107,6 +133,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
         proxy_connect_timeout 5s;
         proxy_send_timeout 35s;
         proxy_read_timeout 35s;
@@ -123,6 +150,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
         proxy_connect_timeout 5s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
@@ -140,6 +168,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $stadtplaner_connection_upgrade;
         proxy_connect_timeout 5s;

--- a/deploy/ansible/roles/stadtplaner_monitoring/defaults/main.yml
+++ b/deploy/ansible/roles/stadtplaner_monitoring/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+monitoring_grafana_admin_user: admin
+monitoring_grafana_admin_password: ''
+monitoring_grafana_bind_address: 127.0.0.1
+monitoring_grafana_port: 3000
+monitoring_grafana_publish: false
+monitoring_grafana_host: ''
+monitoring_grafana_certificate_name: "{{ monitoring_grafana_host }}"
+monitoring_grafana_package_version: ''
+monitoring_grafana_apt_repository: >-
+  deb [signed-by=/etc/apt/keyrings/grafana.asc]
+  https://apt.grafana.com stable main
+monitoring_grafana_apt_key_url: https://apt.grafana.com/gpg-full.key
+monitoring_grafana_apt_key_checksum: ''
+monitoring_grafana_apt_key_fingerprint: B53A E77B ADB6 30A6 8304 6005 963F A277 1045 8545
+
+monitoring_prometheus_bind_address: 127.0.0.1
+monitoring_prometheus_port: 9090
+monitoring_prometheus_retention_time: 30d
+monitoring_prometheus_retention_size: 10GB
+monitoring_prometheus_scrape_interval: 30s
+monitoring_prometheus_evaluation_interval: 30s
+monitoring_prometheus_api_scheme: http
+monitoring_prometheus_api_target: "127.0.0.1:{{ stadtplaner_backend_port | default(8008) }}"
+monitoring_prometheus_api_metrics_path: /metrics
+monitoring_readiness_url: >-
+  http://127.0.0.1:{{ stadtplaner_backend_port | default(8008) }}/health/ready
+monitoring_external_labels:
+  environment: production
+  service: stadtplaner
+
+monitoring_node_exporter_bind_address: 127.0.0.1
+monitoring_node_exporter_port: 9100
+monitoring_node_textfile_dir: >-
+  {{ stadtplaner_observability_dir | default('/data/stadtplaner/observability') }}
+monitoring_node_textfile_writer_user: "{{ stadtplaner_service_user | default('root') }}"
+monitoring_blackbox_bind_address: 127.0.0.1
+monitoring_blackbox_port: 9115
+
+monitoring_alertmanager_targets: []
+monitoring_manage_certificates: false
+monitoring_certbot_email: ''

--- a/deploy/ansible/roles/stadtplaner_monitoring/handlers/main.yml
+++ b/deploy/ansible/roles/stadtplaner_monitoring/handlers/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Restart Prometheus
+  ansible.builtin.systemd_service:
+    name: prometheus
+    state: restarted
+
+- name: Restart node exporter
+  ansible.builtin.systemd_service:
+    name: prometheus-node-exporter
+    state: restarted
+
+- name: Restart blackbox exporter
+  ansible.builtin.systemd_service:
+    name: prometheus-blackbox-exporter
+    state: restarted
+
+- name: Restart Grafana
+  ansible.builtin.systemd_service:
+    name: grafana-server
+    state: restarted
+
+- name: Reload Nginx
+  ansible.builtin.systemd_service:
+    name: nginx
+    state: reloaded

--- a/deploy/ansible/roles/stadtplaner_monitoring/tasks/main.yml
+++ b/deploy/ansible/roles/stadtplaner_monitoring/tasks/main.yml
@@ -1,0 +1,366 @@
+---
+- name: Validate monitoring configuration
+  ansible.builtin.assert:
+    that:
+      - ansible_facts.os_family == 'Debian'
+      - monitoring_grafana_admin_user | length > 0
+      - monitoring_grafana_admin_password | length >= 12
+      - not monitoring_grafana_admin_password.startswith('REPLACE_')
+      - monitoring_prometheus_retention_time | length > 0
+      - monitoring_prometheus_retention_size | length > 0
+      - not monitoring_grafana_publish | bool or monitoring_grafana_host | length > 3
+      - monitoring_grafana_bind_address not in ['0.0.0.0', '::']
+      - monitoring_prometheus_bind_address not in ['0.0.0.0', '::']
+      - monitoring_node_exporter_bind_address not in ['0.0.0.0', '::']
+      - monitoring_blackbox_bind_address not in ['0.0.0.0', '::']
+    fail_msg: >-
+      Monitoring supports Debian-family hosts and requires a non-placeholder
+      Grafana admin password of at least 12 characters. Publishing Grafana also
+      requires monitoring_grafana_host. Wildcard monitoring listeners are
+      deliberately rejected.
+  no_log: true
+
+- name: Install Prometheus and exporter packages
+  ansible.builtin.apt:
+    name:
+      - acl
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - prometheus
+      - prometheus-blackbox-exporter
+      - prometheus-node-exporter
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+    policy_rc_d: 101
+
+- name: Create APT keyring directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Install Grafana repository signing key
+  ansible.builtin.get_url:
+    url: "{{ monitoring_grafana_apt_key_url }}"
+    dest: /etc/apt/keyrings/grafana.asc
+    owner: root
+    group: root
+    mode: '0644'
+    checksum: "{{ monitoring_grafana_apt_key_checksum | default(omit, true) }}"
+  register: monitoring_grafana_key
+
+- name: Read Grafana repository key fingerprint
+  ansible.builtin.command:
+    argv:
+      - gpg
+      - --batch
+      - --show-keys
+      - --with-colons
+      - /etc/apt/keyrings/grafana.asc
+  register: monitoring_grafana_key_details
+  changed_when: false
+
+- name: Verify Grafana repository key fingerprint
+  ansible.builtin.assert:
+    that:
+      - >-
+        ('fpr:::::::::' +
+        (monitoring_grafana_apt_key_fingerprint | replace(' ', '')) + ':')
+        in monitoring_grafana_key_details.stdout
+    fail_msg: >-
+      The downloaded Grafana repository key does not match the reviewed
+      fingerprint. Review an official key rotation before changing the value.
+
+- name: Configure official Grafana APT repository
+  ansible.builtin.apt_repository:
+    repo: "{{ monitoring_grafana_apt_repository }}"
+    filename: grafana
+    state: present
+    update_cache: true
+
+- name: Install Grafana OSS
+  ansible.builtin.apt:
+    name: >-
+      grafana{{ ('=' + monitoring_grafana_package_version)
+      if monitoring_grafana_package_version | length > 0 else '' }}
+    state: present
+    update_cache: "{{ monitoring_grafana_key.changed }}"
+    policy_rc_d: 101
+
+- name: Create monitoring configuration directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: /etc/prometheus/rules, owner: root, group: prometheus, mode: '0750' }
+    - { path: /etc/grafana/provisioning/datasources, owner: root, group: grafana, mode: '0750' }
+    - { path: /etc/grafana/provisioning/dashboards, owner: root, group: grafana, mode: '0750' }
+    - { path: /var/lib/grafana/dashboards, owner: grafana, group: grafana, mode: '0750' }
+    - path: "{{ monitoring_node_textfile_dir }}"
+      owner: "{{ monitoring_node_textfile_writer_user }}"
+      group: root
+      mode: '0750'
+
+- name: Read textfile collector directory ACL
+  ansible.builtin.command:
+    argv: [getfacl, --absolute-names, "{{ monitoring_node_textfile_dir }}"]
+  register: monitoring_textfile_acl
+  changed_when: false
+
+- name: Grant node exporter read access to job metrics
+  ansible.builtin.command:
+    argv:
+      - setfacl
+      - -m
+      - u:prometheus:rx,d:u:prometheus:rx
+      - "{{ monitoring_node_textfile_dir }}"
+  when: "'user:prometheus:r-x' not in monitoring_textfile_acl.stdout"
+
+- name: Install Prometheus alert rules
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../observability/prometheus/alerts.yml"
+    dest: /etc/prometheus/rules/stadtplaner-alerts.yml
+    owner: root
+    group: prometheus
+    mode: '0640'
+  notify: Restart Prometheus
+
+- name: Configure Prometheus
+  ansible.builtin.template:
+    src: prometheus.yml.j2
+    dest: /etc/prometheus/prometheus.yml
+    owner: root
+    group: prometheus
+    mode: '0640'
+  notify: Restart Prometheus
+
+- name: Configure Prometheus service arguments
+  ansible.builtin.template:
+    src: prometheus.default.j2
+    dest: /etc/default/prometheus
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart Prometheus
+
+- name: Configure node exporter service arguments
+  ansible.builtin.template:
+    src: node-exporter.default.j2
+    dest: /etc/default/prometheus-node-exporter
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart node exporter
+
+- name: Configure blackbox exporter
+  ansible.builtin.template:
+    src: blackbox.yml.j2
+    dest: /etc/prometheus/blackbox.yml
+    owner: root
+    group: prometheus
+    mode: '0640'
+  notify: Restart blackbox exporter
+
+- name: Configure blackbox exporter service arguments
+  ansible.builtin.template:
+    src: blackbox-exporter.default.j2
+    dest: /etc/default/prometheus-blackbox-exporter
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart blackbox exporter
+
+- name: Install Grafana configuration
+  ansible.builtin.template:
+    src: grafana.ini.j2
+    dest: /etc/grafana/grafana.ini
+    owner: root
+    group: grafana
+    mode: '0640'
+  notify: Restart Grafana
+
+- name: Install protected Grafana bootstrap environment
+  ansible.builtin.template:
+    src: grafana.env.j2
+    dest: /etc/grafana/stadtplaner.env
+    owner: root
+    group: grafana
+    mode: '0640'
+  no_log: true
+  notify: Restart Grafana
+
+- name: Create Grafana systemd override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/grafana-server.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Load Grafana bootstrap environment from systemd
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/grafana-server.service.d/stadtplaner.conf
+    owner: root
+    group: root
+    mode: '0644'
+    content: |
+      [Service]
+      EnvironmentFile=/etc/grafana/stadtplaner.env
+  notify: Restart Grafana
+
+- name: Provision Prometheus datasource
+  ansible.builtin.template:
+    src: grafana-datasource.yml.j2
+    dest: /etc/grafana/provisioning/datasources/stadtplaner-prometheus.yml
+    owner: root
+    group: grafana
+    mode: '0640'
+  notify: Restart Grafana
+
+- name: Provision dashboard provider
+  ansible.builtin.template:
+    src: grafana-dashboard-provider.yml.j2
+    dest: /etc/grafana/provisioning/dashboards/stadtplaner.yml
+    owner: root
+    group: grafana
+    mode: '0640'
+  notify: Restart Grafana
+
+- name: Install Stadtplaner Grafana dashboard
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../observability/grafana/stadtplaner-overview.json"
+    dest: /var/lib/grafana/dashboards/stadtplaner-overview.json
+    owner: grafana
+    group: grafana
+    mode: '0640'
+  notify: Restart Grafana
+
+- name: Check optional Grafana TLS certificate
+  ansible.builtin.stat:
+    path: "/etc/letsencrypt/live/{{ monitoring_grafana_certificate_name }}/fullchain.pem"
+  register: monitoring_grafana_certificate
+  when: monitoring_grafana_publish | bool
+
+- name: Require certificate before publishing Grafana
+  ansible.builtin.assert:
+    that:
+      - monitoring_grafana_certificate.stat.exists
+    fail_msg: >-
+      The Grafana certificate is missing. Run monitoring-certificates.yml
+      before enabling monitoring_grafana_publish.
+  when: monitoring_grafana_publish | bool
+
+- name: Install optional Grafana HTTPS vhost
+  ansible.builtin.template:
+    src: grafana.nginx.conf.j2
+    dest: /etc/nginx/sites-available/stadtplaner-grafana
+    owner: root
+    group: root
+    mode: '0644'
+  when: monitoring_grafana_publish | bool
+  notify: Reload Nginx
+
+- name: Enable optional Grafana HTTPS vhost
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/stadtplaner-grafana
+    dest: /etc/nginx/sites-enabled/stadtplaner-grafana
+    state: link
+  when: monitoring_grafana_publish | bool
+  notify: Reload Nginx
+
+- name: Remove Grafana HTTPS vhost when publication is disabled
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/nginx/sites-enabled/stadtplaner-grafana
+    - /etc/nginx/sites-available/stadtplaner-grafana
+  when: not monitoring_grafana_publish | bool
+  notify: Reload Nginx
+
+- name: Validate Prometheus configuration
+  ansible.builtin.command: promtool check config /etc/prometheus/prometheus.yml
+  changed_when: false
+
+- name: Validate Prometheus alert rules
+  ansible.builtin.command: promtool check rules /etc/prometheus/rules/stadtplaner-alerts.yml
+  changed_when: false
+
+- name: Validate optional Nginx configuration
+  ansible.builtin.command: nginx -t
+  changed_when: false
+  when: monitoring_grafana_publish | bool
+
+- name: Reload systemd configuration
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
+- name: Apply pending monitoring restarts
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start monitoring services
+  ansible.builtin.systemd_service:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+  loop:
+    - prometheus
+    - prometheus-node-exporter
+    - prometheus-blackbox-exporter
+    - grafana-server
+
+- name: Wait for Prometheus health
+  ansible.builtin.uri:
+    url: "http://{{ monitoring_prometheus_bind_address }}:{{ monitoring_prometheus_port }}/-/ready"
+    status_code: 200
+  register: monitoring_prometheus_health
+  retries: 12
+  delay: 2
+  until: monitoring_prometheus_health.status == 200
+
+- name: Wait for Grafana health
+  ansible.builtin.uri:
+    url: "http://{{ monitoring_grafana_bind_address }}:{{ monitoring_grafana_port }}/api/health"
+    status_code: 200
+  register: monitoring_grafana_health
+  retries: 12
+  delay: 2
+  until: monitoring_grafana_health.status == 200
+
+- name: Wait for the Stadtplaner API scrape target
+  ansible.builtin.uri:
+    url: >-
+      http://{{ monitoring_prometheus_bind_address }}:{{ monitoring_prometheus_port
+      }}/api/v1/query?query=up%7Bjob%3D%22stadtplaner-api%22%7D
+    return_content: true
+    status_code: 200
+  register: monitoring_api_target
+  retries: 12
+  delay: 5
+  until: >-
+    monitoring_api_target.json is defined and
+    monitoring_api_target.json.data.result | length > 0 and
+    monitoring_api_target.json.data.result[0].value[1] == '1'
+
+- name: Wait for the Stadtplaner readiness probe
+  ansible.builtin.uri:
+    url: >-
+      http://{{ monitoring_prometheus_bind_address }}:{{ monitoring_prometheus_port
+      }}/api/v1/query?query=probe_success%7Bjob%3D%22stadtplaner-readiness%22%7D
+    return_content: true
+    status_code: 200
+  register: monitoring_readiness_target
+  retries: 12
+  delay: 5
+  until: >-
+    monitoring_readiness_target.json is defined and
+    monitoring_readiness_target.json.data.result | length > 0 and
+    monitoring_readiness_target.json.data.result[0].value[1] == '1'

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/blackbox-exporter.default.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/blackbox-exporter.default.j2
@@ -1,0 +1,1 @@
+ARGS="--config.file=/etc/prometheus/blackbox.yml --web.listen-address={{ monitoring_blackbox_bind_address }}:{{ monitoring_blackbox_port }}"

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/blackbox.yml.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/blackbox.yml.j2
@@ -1,0 +1,8 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 10s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      follow_redirects: true

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana-dashboard-provider.yml.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana-dashboard-provider.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: Stadtplaner
+    orgId: 1
+    folder: Stadtplaner
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana-datasource.yml.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana-datasource.yml.j2
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Stadtplaner Prometheus
+    orgId: 1
+
+datasources:
+  - name: Stadtplaner Prometheus
+    uid: stadtplaner-prometheus
+    type: prometheus
+    access: proxy
+    url: http://{{ monitoring_prometheus_bind_address }}:{{ monitoring_prometheus_port }}
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: {{ monitoring_prometheus_scrape_interval }}

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana.env.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana.env.j2
@@ -1,0 +1,2 @@
+GF_SECURITY_ADMIN_USER={{ monitoring_grafana_admin_user | to_json }}
+GF_SECURITY_ADMIN_PASSWORD={{ monitoring_grafana_admin_password | to_json }}

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana.ini.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana.ini.j2
@@ -1,0 +1,31 @@
+[paths]
+data = /var/lib/grafana
+logs = /var/log/grafana
+plugins = /var/lib/grafana/plugins
+provisioning = /etc/grafana/provisioning
+
+[server]
+protocol = http
+http_addr = {{ monitoring_grafana_bind_address }}
+http_port = {{ monitoring_grafana_port }}
+domain = {{ monitoring_grafana_host if monitoring_grafana_publish else 'localhost' }}
+enforce_domain = false
+root_url = {{ ('https://' ~ monitoring_grafana_host ~ '/') if monitoring_grafana_publish else ('http://' ~ monitoring_grafana_bind_address ~ ':' ~ monitoring_grafana_port ~ '/') }}
+
+[security]
+disable_gravatar = true
+cookie_secure = {{ 'true' if monitoring_grafana_publish else 'false' }}
+cookie_samesite = strict
+
+[users]
+allow_sign_up = false
+
+[auth.anonymous]
+enabled = false
+
+[analytics]
+reporting_enabled = false
+check_for_updates = false
+
+[log]
+mode = console

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana.nginx.conf.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/grafana.nginx.conf.j2
@@ -1,0 +1,39 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{ monitoring_grafana_host }};
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/letsencrypt;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name {{ monitoring_grafana_host }};
+
+    ssl_certificate /etc/letsencrypt/live/{{ monitoring_grafana_certificate_name }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ monitoring_grafana_certificate_name }}/privkey.pem;
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy no-referrer always;
+    add_header X-Frame-Options DENY always;
+
+    location / {
+        proxy_pass http://{{ monitoring_grafana_bind_address }}:{{ monitoring_grafana_port }};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 60s;
+    }
+}

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/node-exporter.default.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/node-exporter.default.j2
@@ -1,0 +1,1 @@
+ARGS="--web.listen-address={{ monitoring_node_exporter_bind_address }}:{{ monitoring_node_exporter_port }} --collector.textfile.directory={{ monitoring_node_textfile_dir }}"

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/prometheus.default.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/prometheus.default.j2
@@ -1,0 +1,1 @@
+ARGS="--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus/metrics2 --storage.tsdb.retention.time={{ monitoring_prometheus_retention_time }} --storage.tsdb.retention.size={{ monitoring_prometheus_retention_size }} --web.listen-address={{ monitoring_prometheus_bind_address }}:{{ monitoring_prometheus_port }}"

--- a/deploy/ansible/roles/stadtplaner_monitoring/templates/prometheus.yml.j2
+++ b/deploy/ansible/roles/stadtplaner_monitoring/templates/prometheus.yml.j2
@@ -1,0 +1,48 @@
+global:
+  scrape_interval: {{ monitoring_prometheus_scrape_interval }}
+  evaluation_interval: {{ monitoring_prometheus_evaluation_interval }}
+  external_labels:
+{% for key, value in monitoring_external_labels.items() %}
+    {{ key }}: {{ value | to_json }}
+{% endfor %}
+
+rule_files:
+  - /etc/prometheus/rules/stadtplaner-alerts.yml
+
+{% if monitoring_alertmanager_targets | length > 0 %}
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+{% for target in monitoring_alertmanager_targets %}
+            - {{ target | to_json }}
+{% endfor %}
+{% endif %}
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: [{{ (monitoring_prometheus_bind_address ~ ':' ~ monitoring_prometheus_port) | to_json }}]
+
+  - job_name: stadtplaner-api
+    scheme: {{ monitoring_prometheus_api_scheme }}
+    metrics_path: {{ monitoring_prometheus_api_metrics_path }}
+    static_configs:
+      - targets: [{{ monitoring_prometheus_api_target | to_json }}]
+
+  - job_name: stadtplaner-node
+    static_configs:
+      - targets: [{{ (monitoring_node_exporter_bind_address ~ ':' ~ monitoring_node_exporter_port) | to_json }}]
+
+  - job_name: stadtplaner-readiness
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets: [{{ monitoring_readiness_url | trim | to_json }}]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: {{ monitoring_blackbox_bind_address }}:{{ monitoring_blackbox_port }}

--- a/deploy/ansible/tests/test_monitoring_deployment.py
+++ b/deploy/ansible/tests/test_monitoring_deployment.py
@@ -1,0 +1,57 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+ANSIBLE = ROOT / "deploy/ansible"
+ROLE = ANSIBLE / "roles/stadtplaner_monitoring"
+
+
+class MonitoringDeploymentTest(unittest.TestCase):
+    def test_secure_loopback_defaults_and_bounded_retention(self) -> None:
+        defaults = yaml.safe_load((ROLE / "defaults/main.yml").read_text(encoding="utf-8"))
+
+        self.assertEqual(defaults["monitoring_grafana_bind_address"], "127.0.0.1")
+        self.assertEqual(defaults["monitoring_prometheus_bind_address"], "127.0.0.1")
+        self.assertEqual(defaults["monitoring_node_exporter_bind_address"], "127.0.0.1")
+        self.assertEqual(defaults["monitoring_blackbox_bind_address"], "127.0.0.1")
+        self.assertFalse(defaults["monitoring_grafana_publish"])
+        self.assertEqual(defaults["monitoring_prometheus_retention_time"], "30d")
+        self.assertEqual(defaults["monitoring_prometheus_retention_size"], "10GB")
+        self.assertEqual(defaults["monitoring_grafana_admin_password"], "")
+        tasks = (ROLE / "tasks/main.yml").read_text(encoding="utf-8")
+        self.assertNotIn("0.0.0.0:{{ monitoring_prometheus_port }}", tasks)
+        self.assertIn("Wildcard monitoring listeners are", tasks)
+
+    def test_monitoring_assets_are_provisioned_from_canonical_files(self) -> None:
+        tasks = (ROLE / "tasks/main.yml").read_text(encoding="utf-8")
+        prometheus = (ROLE / "templates/prometheus.yml.j2").read_text(encoding="utf-8")
+        datasource = (ROLE / "templates/grafana-datasource.yml.j2").read_text(encoding="utf-8")
+
+        self.assertIn("observability/prometheus/alerts.yml", tasks)
+        self.assertIn("observability/grafana/stadtplaner-overview.json", tasks)
+        self.assertIn("promtool check config", tasks)
+        self.assertIn("promtool check rules", tasks)
+        self.assertIn("job_name: stadtplaner-api", prometheus)
+        self.assertIn("job_name: stadtplaner-readiness", prometheus)
+        self.assertIn("job_name: stadtplaner-node", prometheus)
+        self.assertIn("uid: stadtplaner-prometheus", datasource)
+
+    def test_monitoring_is_opt_in_and_documented(self) -> None:
+        deploy = yaml.safe_load((ANSIBLE / "playbooks/deploy.yml").read_text(encoding="utf-8"))
+        monitoring = yaml.safe_load((ANSIBLE / "playbooks/monitoring.yml").read_text(encoding="utf-8"))
+        docs = (ROOT / "docs/monitoring-deployment.md").read_text(encoding="utf-8")
+
+        normal_roles = deploy[0]["roles"]
+        self.assertNotIn("stadtplaner_monitoring", str(normal_roles))
+        self.assertEqual(monitoring[0]["hosts"], "monitoring")
+        self.assertIn("stadtplaner_monitoring", str(monitoring[0]["roles"]))
+        self.assertIn("Zugriff ohne Subdomain", docs)
+        self.assertIn("Optionale Grafana-Subdomain", docs)
+        self.assertIn("Separater Monitoring-Server", docs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/ansible/vault.example.yml
+++ b/deploy/ansible/vault.example.yml
@@ -303,3 +303,37 @@ stadtplaner_database_backup_retention: 3
 stadtplaner_pre_migration_backup_command: ''
 stadtplaner_certbot_email: ''
 stadtplaner_manage_certificates: false
+
+# Separate, opt-in Prometheus/Grafana deployment. Store the real admin
+# password only in the encrypted external Vault, never in this repository.
+monitoring_grafana_admin_user: admin
+monitoring_grafana_admin_password: REPLACE_WITH_LONG_RANDOM_GRAFANA_PASSWORD
+monitoring_grafana_bind_address: 127.0.0.1
+monitoring_grafana_port: 3000
+monitoring_grafana_publish: false
+monitoring_grafana_host: ''
+monitoring_grafana_certificate_name: "{{ monitoring_grafana_host }}"
+monitoring_grafana_package_version: ''
+monitoring_grafana_apt_key_checksum: ''
+monitoring_grafana_apt_key_fingerprint: B53A E77B ADB6 30A6 8304 6005 963F A277 1045 8545
+monitoring_prometheus_bind_address: 127.0.0.1
+monitoring_prometheus_port: 9090
+monitoring_prometheus_retention_time: 30d
+monitoring_prometheus_retention_size: 10GB
+monitoring_prometheus_scrape_interval: 30s
+monitoring_prometheus_evaluation_interval: 30s
+monitoring_prometheus_api_scheme: http
+monitoring_prometheus_api_target: "127.0.0.1:{{ stadtplaner_backend_port }}"
+monitoring_prometheus_api_metrics_path: /metrics
+monitoring_readiness_url: "http://127.0.0.1:{{ stadtplaner_backend_port }}/health/ready"
+monitoring_external_labels:
+  environment: production
+  service: stadtplaner
+monitoring_node_exporter_bind_address: 127.0.0.1
+monitoring_node_exporter_port: 9100
+monitoring_node_textfile_dir: "{{ stadtplaner_observability_dir }}"
+monitoring_blackbox_bind_address: 127.0.0.1
+monitoring_blackbox_port: 9115
+monitoring_alertmanager_targets: []
+monitoring_manage_certificates: false
+monitoring_certbot_email: ''

--- a/deploy/ansible/vault.example.yml
+++ b/deploy/ansible/vault.example.yml
@@ -15,6 +15,14 @@ stadtplaner_backend_env_content: |
   DATABASE_URL=REPLACE_WITH_PRODUCTION_DATABASE_URL
   CORS_ORIGINS=https://stadtplaner.oklabflensburg.de
   LOG_LEVEL=INFO
+  LOG_FORMAT=json
+  METRICS_ENABLED=true
+  METRICS_PATH=/metrics
+  OBSERVABILITY_TEXTFILE_DIR=/data/stadtplaner/observability
+  OTEL_ENABLED=false
+  OTEL_SERVICE_NAME=stadtplaner-api
+  OTEL_EXPORTER_OTLP_ENDPOINT=
+  OTEL_EXPORTER_OTLP_PROTOCOL=grpc
   APP_ENVIRONMENT=production
   APP_BASE_URL=https://stadtplaner.oklabflensburg.de
   API_BASE_URL=https://api.stadtplaner.oklabflensburg.de
@@ -108,7 +116,7 @@ stadtplaner_backend_env_content: |
   GROQ_TIMEOUT_SECONDS=8
   GROQ_MAX_RETRIES=1
   GROQ_TEMPERATURE=0.1
-  ASSISTANT_QUERY_LOGGING=true
+  ASSISTANT_QUERY_LOGGING=false
 
   AVATAR_OUTPUT_SIZE=512
   AVATAR_WEBP_QUALITY=85
@@ -255,6 +263,8 @@ stadtplaner_config_dir: /etc/stadtplaner
 stadtplaner_data_dir: /data/stadtplaner
 stadtplaner_social_dir: /data/stadtplaner-social
 stadtplaner_avatar_upload_dir: /data/uploads
+stadtplaner_observability_dir: /data/stadtplaner/observability
+stadtplaner_metrics_allowed_cidrs: []
 stadtplaner_backend_port: 8008
 stadtplaner_frontend_port: 3008
 stadtplaner_backend_env_file: /etc/stadtplaner/backend.env

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -29,6 +29,12 @@ Nginx soll für den Stadtplaner **keine zweite CORS-Implementierung** besitzen. 
 
 Die produktive Backend-Konfiguration muss `CORS_ORIGINS` bzw. die im Backend verwendeten Origin-Settings korrekt setzen.
 
+## Request-ID, JSON-Logs und Metrics
+
+Der VHost erzeugt am Edge über `$request_id` eine `X-Request-ID` für Nuxt und FastAPI. Das `stadtplaner_json`-Access-Log enthält nur Zeitpunkt, Request-ID, Methode, normalisierten `$uri` ohne Query-String, Status und Laufzeiten; Authorization, Cookies und Request Bodies werden nicht protokolliert.
+
+`/metrics` erlaubt zunächst ausschließlich Loopback. Ergänzen Sie gezielt eine `allow <monitoring-cidr>;`-Zeile und behalten Sie `deny all`; Zugangsdaten gehören nicht in die Vorlage. Die Ansible-Variante nutzt dafür `stadtplaner_metrics_allowed_cidrs`.
+
 ## Rate-Limiting-Philosophie
 
 Nginx ist nur der äußere Überlastungsschutz. Fachliche, benutzerbezogene oder sicherheitsrelevante Limits gehören weiterhin in FastAPI/Redis.

--- a/deploy/nginx/sites-available/stadtplaner.conf
+++ b/deploy/nginx/sites-available/stadtplaner.conf
@@ -17,6 +17,11 @@ upstream stadtplaner_api {
     keepalive 32;
 }
 
+log_format stadtplaner_json escape=json '{"timestamp":"$time_iso8601",'
+    '"request_id":"$request_id","method":"$request_method","uri":"$uri",'
+    '"status":$status,"request_time":$request_time,'
+    '"upstream_response_time":"$upstream_response_time"}';
+
 # -----------------------------------------------------------------------------
 # Public frontend
 # -----------------------------------------------------------------------------
@@ -25,6 +30,7 @@ server {
     listen [::]:443 ssl http2;
 
     server_name stadtplaner.oklabflensburg.de;
+    access_log /var/log/nginx/stadtplaner-access.json stadtplaner_json;
 
     client_max_body_size 10m;
 
@@ -37,6 +43,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
 
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $stadtplaner_connection_upgrade;
@@ -60,6 +67,7 @@ server {
     listen [::]:443 ssl http2;
 
     server_name developer.stadtplaner.oklabflensburg.de;
+    access_log /var/log/nginx/stadtplaner-developer-access.json stadtplaner_json;
 
     location / {
         proxy_pass http://stadtplaner_frontend;
@@ -70,6 +78,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
 
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $stadtplaner_connection_upgrade;
@@ -93,6 +102,7 @@ server {
     listen [::]:443 ssl http2;
 
     server_name api.stadtplaner.oklabflensburg.de;
+    access_log /var/log/nginx/stadtplaner-api-access.json stadtplaner_json;
 
     # The application already owns CORS through FastAPI CORSMiddleware.
     # Do not duplicate Access-Control-* handling in nginx.
@@ -105,6 +115,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
     }
@@ -116,12 +127,26 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-ID $request_id;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
     }
 
     location = /health {
         return 301 /health/ready;
+    }
+
+    # Add the monitoring host/network explicitly. Never expose metrics globally.
+    location = /metrics {
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+        proxy_pass http://stadtplaner_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Request-ID $request_id;
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 10s;
     }
 
     # Assistant: expensive path, separate outer limit. A legitimate user can
@@ -138,6 +163,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
         proxy_connect_timeout 5s;
         proxy_send_timeout 35s;
         proxy_read_timeout 35s;
@@ -157,6 +183,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
         proxy_connect_timeout 5s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
@@ -178,6 +205,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Request-ID $request_id;
 
         # Keep upgrade support for realtime endpoints without forcing it for
         # ordinary HTTP requests.

--- a/deploy/observability/grafana/stadtplaner-overview.json
+++ b/deploy/observability/grafana/stadtplaner-overview.json
@@ -1,0 +1,30 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {"id": 1, "title": "Request Rate", "type": "timeseries", "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0}, "targets": [{"expr": "sum(rate(http_requests_total[5m]))", "legendFormat": "requests/s"}]},
+    {"id": 2, "title": "5xx Rate", "type": "timeseries", "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0}, "targets": [{"expr": "sum(rate(http_requests_total{status_class=\"5xx\"}[5m])) / clamp_min(sum(rate(http_requests_total[5m])), 0.001)", "legendFormat": "5xx ratio"}]},
+    {"id": 3, "title": "API Latency p50/p95/p99", "type": "timeseries", "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0}, "targets": [{"expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))", "legendFormat": "p50"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))", "legendFormat": "p95"}, {"expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))", "legendFormat": "p99"}]},
+    {"id": 4, "title": "Requests in Flight", "type": "timeseries", "gridPos": {"h": 8, "w": 8, "x": 0, "y": 8}, "targets": [{"expr": "sum(http_requests_in_progress)", "legendFormat": "requests"}]},
+    {"id": 5, "title": "DB Pool Usage", "type": "timeseries", "gridPos": {"h": 8, "w": 8, "x": 8, "y": 8}, "targets": [{"expr": "db_pool_checked_out", "legendFormat": "checked out"}, {"expr": "db_pool_capacity", "legendFormat": "capacity"}, {"expr": "db_pool_checked_in", "legendFormat": "available"}]},
+    {"id": 6, "title": "Redis Availability", "type": "stat", "gridPos": {"h": 8, "w": 8, "x": 16, "y": 8}, "targets": [{"expr": "redis_available", "legendFormat": "available"}]},
+    {"id": 7, "title": "External Provider Latency p95", "type": "timeseries", "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16}, "targets": [{"expr": "histogram_quantile(0.95, sum by (provider, le) (rate(external_request_duration_seconds_bucket[10m])))", "legendFormat": "{{provider}}"}]},
+    {"id": 8, "title": "Outbox Pending", "type": "timeseries", "gridPos": {"h": 8, "w": 6, "x": 12, "y": 16}, "targets": [{"expr": "outbox_pending", "legendFormat": "{{outbox_type}}"}]},
+    {"id": 9, "title": "Outbox Oldest Age", "type": "timeseries", "gridPos": {"h": 8, "w": 6, "x": 18, "y": 16}, "targets": [{"expr": "outbox_oldest_age_seconds", "legendFormat": "{{outbox_type}}"}]},
+    {"id": 10, "title": "Background Job Failures", "type": "timeseries", "gridPos": {"h": 8, "w": 8, "x": 0, "y": 24}, "targets": [{"expr": "increase(job_failures_total[1h])", "legendFormat": "{{job_name}}"}]},
+    {"id": 11, "title": "OSM Replication Lag", "type": "timeseries", "gridPos": {"h": 8, "w": 8, "x": 8, "y": 24}, "targets": [{"expr": "osm_replication_lag_seconds", "legendFormat": "lag"}]},
+    {"id": 12, "title": "Release SHA", "type": "table", "gridPos": {"h": 8, "w": 8, "x": 16, "y": 24}, "targets": [{"expr": "build_info", "format": "table", "instant": true}]},
+    {"id": 13, "title": "Redis Cache Hit Ratio", "type": "timeseries", "gridPos": {"h": 8, "w": 12, "x": 0, "y": 32}, "targets": [{"expr": "rate(redis_cache_hits_total[5m]) / clamp_min(rate(redis_cache_hits_total[5m]) + rate(redis_cache_misses_total[5m]), 0.001)", "legendFormat": "hit ratio"}]},
+    {"id": 14, "title": "External Provider Errors", "type": "timeseries", "gridPos": {"h": 8, "w": 12, "x": 12, "y": 32}, "targets": [{"expr": "sum by (provider) (rate(external_request_errors_total[5m]))", "legendFormat": "{{provider}}"}]}
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["stadtplaner", "observability"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "browser",
+  "title": "Stadtplaner Production Overview",
+  "uid": "stadtplaner-overview",
+  "version": 1
+}

--- a/deploy/observability/prometheus/alerts.yml
+++ b/deploy/observability/prometheus/alerts.yml
@@ -1,0 +1,81 @@
+groups:
+  - name: stadtplaner-production
+    rules:
+      - alert: StadtplanerReadinessDown
+        expr: probe_success{job="stadtplaner-readiness"} == 0
+        for: 10m
+        labels: { severity: critical }
+        annotations:
+          summary: Stadtplaner readiness has failed for ten minutes
+          runbook_url: docs/runbooks/readiness-down.md
+
+      - alert: StadtplanerHigh5xxRate
+        expr: >-
+          sum(rate(http_requests_total{status_class="5xx"}[10m]))
+          / clamp_min(sum(rate(http_requests_total[10m])), 0.001) > 0.05
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: More than 5% of API requests return 5xx
+          runbook_url: docs/runbooks/high-5xx-rate.md
+
+      - alert: StadtplanerCritical5xxRate
+        expr: >-
+          sum(rate(http_requests_total{status_class="5xx"}[5m]))
+          / clamp_min(sum(rate(http_requests_total[5m])), 0.001) > 0.15
+        for: 5m
+        labels: { severity: critical }
+        annotations:
+          summary: More than 15% of API requests return 5xx
+          runbook_url: docs/runbooks/high-5xx-rate.md
+
+      - alert: StadtplanerHighLatency
+        expr: >-
+          histogram_quantile(0.95,
+          sum by (le) (rate(http_request_duration_seconds_bucket[10m]))) > 2
+        for: 15m
+        labels: { severity: warning }
+        annotations:
+          summary: API p95 latency is above two seconds
+          runbook_url: docs/runbooks/high-5xx-rate.md
+
+      - alert: StadtplanerDatabasePoolSaturated
+        expr: db_pool_checked_out / clamp_min(db_pool_capacity, 1) > 0.9
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: More than 90% of database connection capacity is in use
+          runbook_url: docs/runbooks/db-pool-saturation.md
+
+      - alert: StadtplanerRedisDown
+        expr: redis_available == 0
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: Redis has been unavailable for ten minutes
+          runbook_url: docs/runbooks/redis-down.md
+
+      - alert: StadtplanerOutboxBacklog
+        expr: outbox_pending > 100 or outbox_oldest_age_seconds > 3600
+        for: 15m
+        labels: { severity: warning }
+        annotations:
+          summary: A Stadtplaner outbox is large or more than one hour old
+          runbook_url: docs/runbooks/outbox-backlog.md
+
+      - alert: StadtplanerBackgroundJobFailures
+        expr: increase(job_failures_total[15m]) > 0
+        for: 5m
+        labels: { severity: warning }
+        annotations:
+          summary: A Stadtplaner background job failed
+          runbook_url: docs/runbooks/background-job-failure.md
+
+      - alert: StadtplanerOsmReplicationStale
+        expr: osm_replication_lag_seconds > 7200
+        for: 15m
+        labels: { severity: warning }
+        annotations:
+          summary: Local OpenStreetMap data is more than two hours behind
+          runbook_url: docs/runbooks/osm-replication-stale.md
+

--- a/deploy/observability/prometheus/prometheus.example.yml
+++ b/deploy/observability/prometheus/prometheus.example.yml
@@ -1,0 +1,28 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+rule_files:
+  - alerts.yml
+
+scrape_configs:
+  - job_name: stadtplaner-api
+    scheme: https
+    metrics_path: /metrics
+    static_configs:
+      - targets: [api.stadtplaner.oklabflensburg.de:443]
+
+  # Requires the Prometheus blackbox exporter.
+  - job_name: stadtplaner-readiness
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets: [https://api.stadtplaner.oklabflensburg.de/health/ready]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9115

--- a/deploy/systemd/stadtplaner-email-outbox.service
+++ b/deploy/systemd/stadtplaner-email-outbox.service
@@ -13,3 +13,4 @@ ExecStart=/opt/git/open-city-planner/backend/.venv/bin/python -m app.cli.process
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
+ReadWritePaths=/data/stadtplaner/observability

--- a/deploy/systemd/stadtplaner-flensburg-statistics-sync.service
+++ b/deploy/systemd/stadtplaner-flensburg-statistics-sync.service
@@ -13,4 +13,4 @@ ExecStart=/opt/stadtplaner/backend/.venv/bin/python -m app.cli.import_flensburg_
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ReadWritePaths=/opt/stadtplaner/backend/data
+ReadWritePaths=/opt/stadtplaner/backend/data /data/stadtplaner/observability

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 
 - [Deployment und Betrieb](deployment.md)
 - [Production Observability, SLOs und Runbooks](observability.md)
+- [Prometheus und Grafana mit Ansible betreiben](monitoring-deployment.md)
 - [Wiederholbares Ansible-Deployment](../deploy/ansible/README.md)
 - [Nginx-Hardening und Rate Limits](../deploy/nginx/README.md)
 - [Social Publishing mit Mastodon](social-publishing.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 ## Betrieb und Integrationen
 
 - [Deployment und Betrieb](deployment.md)
+- [Production Observability, SLOs und Runbooks](observability.md)
 - [Wiederholbares Ansible-Deployment](../deploy/ansible/README.md)
 - [Nginx-Hardening und Rate Limits](../deploy/nginx/README.md)
 - [Social Publishing mit Mastodon](social-publishing.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -222,6 +222,30 @@ Typische Prüfungen:
 - Assistant fällt zurück: `AI_SEARCH_ENABLED`, Modell, Backend-Key und bereinigte Provider-Warnings prüfen.
 - E-Mail oder Mastodon bleibt liegen: Timer, Outboxstatus und letzte Worker-Logs prüfen.
 
+## Observability anbinden
+
+Ansible injiziert den exakt ausgecheckten Git-SHA als `STADTPLANER_RELEASE_SHA` in API, Frontend und One-shot-Jobs. Behalten Sie `LOG_FORMAT=json`, `METRICS_ENABLED=true` und `ASSISTANT_QUERY_LOGGING=false` in Produktion. Ein OTLP-Collector ist optional; setzen Sie dessen Adresse ausschließlich über `OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+Der Nginx-vHost erzeugt `X-Request-ID`, schreibt datensparsame JSON-Access-Logs und schützt `/metrics` mit `allow`/`deny`. Tragen Sie das Netz des Monitoring-Hosts in `stadtplaner_metrics_allowed_cidrs` ein; veröffentlichen Sie keine Basic-Auth-Credentials in Templates. Der Prometheus-Scraper verwendet HTTPS und benötigt eine erlaubte Quelladresse.
+
+```yaml
+stadtplaner_metrics_allowed_cidrs:
+  - 10.20.0.15/32
+```
+
+Die Beispielkonfiguration liegt unter `deploy/observability/prometheus/`. Importieren Sie anschließend `deploy/observability/grafana/stadtplaner-overview.json`. Für timerbasierte Jobs konfigurieren Sie node_exporter mit `--collector.textfile.directory=/data/stadtplaner/observability`; die atomisch aktualisierten `.prom`-Dateien enthalten keine Empfänger oder Payloads.
+
+Nach einem Deployment prüfen Sie:
+
+```bash
+curl -i https://<api-origin>/health/info
+curl -i -H 'X-Request-ID: deploy-smoke' https://<api-origin>/health/live
+curl --fail http://127.0.0.1:<backend-port>/metrics | grep build_info
+journalctl -u stadtplaner-api -o cat | jq 'select(.request_id == "deploy-smoke")'
+```
+
+Prometheus-, Grafana- und Collector-Ausfälle dürfen weder Readiness noch Requests beeinflussen. Architektur, Datenschutz, SLOs, Alerts und Runbooks sind in [observability.md](observability.md) beschrieben.
+
 ## Sicherheitscheckliste
 
 - [ ] Keine Produktions-Secrets oder `.env`-Dateien sind im Repository.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -235,6 +235,13 @@ stadtplaner_metrics_allowed_cidrs:
 
 Die Beispielkonfiguration liegt unter `deploy/observability/prometheus/`. Importieren Sie anschließend `deploy/observability/grafana/stadtplaner-overview.json`. Für timerbasierte Jobs konfigurieren Sie node_exporter mit `--collector.textfile.directory=/data/stadtplaner/observability`; die atomisch aktualisierten `.prom`-Dateien enthalten keine Empfänger oder Payloads.
 
+Alternativ installiert und provisioniert das separate, ausdrücklich opt-in
+auszuführende Ansible-Playbook `playbooks/monitoring.yml` den vollständigen
+lokalen Stack. Es ist nicht Bestandteil eines normalen Applikationsdeployments.
+Die Anleitung einschließlich SSH-Tunnel, optionaler Grafana-Subdomain,
+Retention, Backups und Fehlerdiagnose steht unter
+[Prometheus und Grafana mit Ansible betreiben](monitoring-deployment.md).
+
 Nach einem Deployment prüfen Sie:
 
 ```bash

--- a/docs/monitoring-deployment.md
+++ b/docs/monitoring-deployment.md
@@ -1,0 +1,327 @@
+# Prometheus und Grafana mit Ansible betreiben
+
+Das separate Playbook `deploy/ansible/playbooks/monitoring.yml` installiert und
+konfiguriert einen self-hostbaren Monitoring-Stack für den Stadtplaner:
+
+- Prometheus sammelt API-, Host- und Job-Metriken und wertet die versionierten Alert-Regeln aus;
+- Grafana erhält Prometheus als vorinstallierte Datenquelle und lädt das Stadtplaner-Dashboard automatisch;
+- der Blackbox Exporter prüft `/health/ready` aus Sicht des Monitoring-Hosts;
+- der Node Exporter liefert Host-Metriken und liest die `.prom`-Dateien der timerbasierten Jobs.
+
+Das normale `deploy.yml` installiert den Monitoring-Stack bewusst nicht. So
+bleiben bestehende Shared Hosts unverändert, bis der Operator `monitoring.yml`
+ausdrücklich ausführt.
+
+## Brauche ich Subdomains?
+
+Nein. Die sichere Standardkonfiguration bindet alle Dienste ausschließlich an
+Loopback:
+
+| Dienst | Standardadresse | Öffentlich |
+| --- | --- | --- |
+| Grafana | `127.0.0.1:3000` | nein |
+| Prometheus | `127.0.0.1:9090` | nein |
+| Node Exporter | `127.0.0.1:9100` | nein |
+| Blackbox Exporter | `127.0.0.1:9115` | nein |
+
+Grafana kann dann über einen SSH-Tunnel benutzt werden. Eine DNS-Subdomain ist
+nur für den optionalen öffentlichen HTTPS-Zugang zu Grafana erforderlich.
+Prometheus und die Exporter sollten nicht öffentlich veröffentlicht werden.
+
+## Voraussetzungen
+
+- Debian oder Ubuntu auf dem Zielhost;
+- SSH-Zugang mit `become`;
+- ausreichend Speicherplatz für die konfigurierte Prometheus-Retention;
+- ein bereits deployter Stadtplaner, dessen Backend standardmäßig auf `127.0.0.1:8008` hört;
+- ein gemäß der [Ansible-Anleitung](../deploy/ansible/README.md) eingerichteter Controller;
+- ausgehender HTTPS-Zugriff auf `apt.grafana.com`, sofern das offizielle Grafana-Repository noch fehlt.
+
+Prometheus und die Exporter kommen aus den signierten Betriebssystemquellen.
+Grafana OSS kommt aus dem offiziellen, per `signed-by` isolierten
+Grafana-APT-Repository. `monitoring_grafana_package_version` kann eine konkrete
+Paketversion festlegen. Ohne Angabe installiert Ansible das angebotene Paket
+nur, wenn Grafana noch fehlt; normale Läufe erzwingen kein Upgrade.
+Der heruntergeladene Repository-Schlüssel wird zusätzlich gegen den im
+Repository dokumentierten Fingerprint geprüft. Eine Schlüsselrotation muss
+bewusst anhand der offiziellen Grafana-Mitteilung nachvollzogen werden.
+
+## 1. Inventory prüfen
+
+Das Produktions-Inventory enthält denselben Host in den Gruppen `stadtplaner`
+und `monitoring`. Für einen separaten Monitoring-Server wird ein eigenes Ziel
+eingetragen:
+
+```yaml
+all:
+  children:
+    stadtplaner:
+      hosts:
+        stadtplaner-prod:
+          ansible_host: stadtplaner.example.org
+    monitoring:
+      hosts:
+        stadtplaner-monitoring:
+          ansible_host: monitoring-internal.example.org
+```
+
+Ein Verbindungstest verändert nichts:
+
+```bash
+cd deploy/ansible
+ANSIBLE_REMOTE_USER=DEPLOY_USER ansible monitoring -m ping
+```
+
+## 2. Externen Vault ergänzen
+
+Erzeuge ein langes, zufälliges Passwort lokal und trage es direkt in den
+bereits verschlüsselten externen Vault ein:
+
+```bash
+openssl rand -base64 36
+ansible-vault edit ~/stadtplaner-vault.yml
+```
+
+Mindestens erforderlich:
+
+```yaml
+monitoring_grafana_admin_user: admin
+monitoring_grafana_admin_password: EIN_LANGES_ZUFAELLIGES_PASSWORT
+monitoring_grafana_publish: false
+```
+
+Reale Passwörter dürfen niemals nach `vault.example.yml` geschrieben oder
+committet werden. Das Bootstrap-Passwort wird von Grafana nur beim erstmaligen
+Erstellen seiner Datenbank verwendet. Eine spätere Änderung der Vault-Variable
+ändert ein vorhandenes Grafana-Konto nicht automatisch.
+
+## 3. Konfiguration vorab prüfen
+
+```bash
+cd deploy/ansible
+ANSIBLE_REMOTE_USER=DEPLOY_USER ansible-playbook \
+  --syntax-check playbooks/monitoring.yml
+
+ANSIBLE_REMOTE_USER=DEPLOY_USER ansible-playbook playbooks/monitoring.yml \
+  -e @~/stadtplaner-vault.yml \
+  --ask-vault-pass \
+  --check --diff
+```
+
+APT-Installationen und Service-Healthchecks lassen sich im Check Mode nicht in
+jeder Umgebung vollständig simulieren. Der Syntaxcheck bleibt deshalb die
+verlässliche statische Vorprüfung.
+
+## 4. Stack installieren
+
+```bash
+cd deploy/ansible
+ANSIBLE_REMOTE_USER=DEPLOY_USER ansible-playbook playbooks/monitoring.yml \
+  -e @~/stadtplaner-vault.yml \
+  --ask-vault-pass
+```
+
+Das Playbook:
+
+1. validiert Betriebssystem, Passwort und Bind-Konfiguration;
+2. installiert Prometheus, Node Exporter, Blackbox Exporter und Grafana OSS;
+3. konfiguriert Retention und ausschließlich lokale Listener;
+4. installiert Alert-Regeln und die Readiness-Probe;
+5. aktiviert den Textfile Collector für Stadtplaner-Jobs;
+6. provisioniert Prometheus-Datenquelle und Grafana-Dashboard;
+7. validiert Prometheus mit `promtool`;
+8. startet und aktiviert alle Dienste;
+9. prüft Prometheus- und Grafana-Healthendpoints sowie den API-Scrape und die Readiness-Probe.
+
+## 5. Zugriff ohne Subdomain
+
+Baue von der eigenen Workstation einen SSH-Tunnel auf:
+
+```bash
+ssh -N \
+  -L 3000:127.0.0.1:3000 \
+  -L 9090:127.0.0.1:9090 \
+  DEPLOY_USER@stadtplaner.example.org
+```
+
+Danach sind Grafana unter `http://127.0.0.1:3000` und Prometheus unter
+`http://127.0.0.1:9090` erreichbar. Das provisionierte Dashboard liegt in
+Grafana im Ordner **Stadtplaner**; Prometheus ist bereits als Standarddatenquelle
+verbunden.
+
+## 6. Installation verifizieren
+
+```bash
+systemctl --no-pager --full status \
+  prometheus prometheus-node-exporter \
+  prometheus-blackbox-exporter grafana-server
+
+curl --fail http://127.0.0.1:9090/-/ready
+curl --fail http://127.0.0.1:3000/api/health
+curl --fail http://127.0.0.1:9100/metrics >/dev/null
+curl --fail 'http://127.0.0.1:9115/probe?module=http_2xx&target=http://127.0.0.1:8008/health/ready'
+promtool check config /etc/prometheus/prometheus.yml
+promtool check rules /etc/prometheus/rules/stadtplaner-alerts.yml
+```
+
+In Prometheus unter **Status → Targets** müssen `prometheus`,
+`stadtplaner-api`, `stadtplaner-node` und `stadtplaner-readiness` den Zustand
+`UP` zeigen. Die ACL des Job-Metrikverzeichnisses gibt nur dem
+Prometheus-Systemkonto zusätzlichen Lesezugriff; Applikations-Secrets werden
+nicht freigegeben.
+
+## 7. Retention und Backups
+
+Standardmäßig bewahrt Prometheus höchstens 30 Tage beziehungsweise 10 GB auf:
+
+```yaml
+monitoring_prometheus_retention_time: 30d
+monitoring_prometheus_retention_size: 10GB
+```
+
+Die zuerst erreichte Grenze greift. Vor einer Erhöhung freien Speicher prüfen:
+
+```bash
+df -h /var/lib/prometheus
+du -sh /var/lib/prometheus/metrics2
+```
+
+Die Grafana-Datenbank `/var/lib/grafana/grafana.db` gehört in das Serverbackup.
+Provisionierte Dashboards und Datenquellen liegen im Git-Repository und lassen
+sich durch Ansible wiederherstellen. Falls die Prometheus-Historie kritisch ist,
+muss auch `/var/lib/prometheus` gesichert werden.
+
+## 8. Optionale Grafana-Subdomain
+
+Nur Grafana kann optional über Nginx und HTTPS veröffentlicht werden. Lege
+zuerst einen DNS-A/AAAA-Eintrag wie `grafana.stadtplaner.example.org` auf den
+Monitoring-Host an und ergänze den verschlüsselten Vault:
+
+```yaml
+monitoring_grafana_publish: true
+monitoring_grafana_host: grafana.stadtplaner.example.org
+monitoring_grafana_certificate_name: grafana.stadtplaner.example.org
+monitoring_manage_certificates: true
+monitoring_certbot_email: admin@example.org
+```
+
+Zertifikat einmalig ausstellen und anschließend den Stack anwenden:
+
+```bash
+ANSIBLE_REMOTE_USER=DEPLOY_USER ansible-playbook \
+  playbooks/monitoring-certificates.yml \
+  -e @~/stadtplaner-vault.yml --ask-vault-pass
+
+ANSIBLE_REMOTE_USER=DEPLOY_USER ansible-playbook \
+  playbooks/monitoring.yml \
+  -e @~/stadtplaner-vault.yml --ask-vault-pass
+```
+
+Nginx erzwingt HTTPS und proxyt nur Grafana. Grafana selbst bleibt auf
+`127.0.0.1:3000`; Prometheus und Exporter bleiben intern. Schütze das Login
+zusätzlich mit einem starken Passwort und nach Möglichkeit VPN, SSO oder einem
+vorgeschalteten Access-Proxy.
+
+## 9. Separater Monitoring-Server
+
+Auf einem separaten Host zeigen Ziel und Readiness-URL auf die API:
+
+```yaml
+monitoring_prometheus_api_scheme: https
+monitoring_prometheus_api_target: api.stadtplaner.example.org:443
+monitoring_readiness_url: https://api.stadtplaner.example.org/health/ready
+```
+
+Die am API-Server sichtbare Monitoring-Adresse muss anschließend über einen
+normalen Stadtplaner-Deploy freigeschaltet werden:
+
+```yaml
+stadtplaner_metrics_allowed_cidrs:
+  - 10.20.0.15/32
+```
+
+Bei NAT zählt die am API-Server sichtbare Quelladresse. `/metrics` niemals
+global freigeben. Ein Node Exporter auf einem separaten Monitoring-Host sieht
+nur diesen Host; für Jobmetriken ist zusätzlich ein Exporter auf dem
+Applikationsserver oder ein anderer sicherer Transport erforderlich. Für kleine
+Installationen ist deshalb derselbe Host die einfachste Variante.
+
+## 10. Alert-Benachrichtigungen
+
+Prometheus wertet die Regeln ohne weitere Komponenten aus und zeigt aktive
+Alerts in seiner Oberfläche. Für E-Mail-, Matrix- oder andere
+Benachrichtigungen wird zusätzlich ein Alertmanager benötigt. Ein vorhandener
+Alertmanager kann verbunden werden:
+
+```yaml
+monitoring_alertmanager_targets:
+  - 127.0.0.1:9093
+```
+
+Das Playbook installiert bewusst keinen Alertmanager und hinterlegt keine
+Empfänger-Secrets. Diese gehören in eine separate verschlüsselte Konfiguration.
+
+## 11. Kontrollierte Upgrades
+
+Ein normaler Playbook-Lauf erzwingt kein Upgrade vorhandener Pakete. Verfügbare
+Grafana-Versionen lassen sich auf dem Zielhost prüfen und anschließend pinnen:
+
+```bash
+apt-cache madison grafana
+```
+
+```yaml
+monitoring_grafana_package_version: VERSION_AUS_DER_PAKETQUELLE
+```
+
+Vor einem größeren Grafana-Upgrade die SQLite-Datenbank sichern. Paketupdates
+zuerst auf einem Testsystem prüfen.
+
+## 12. Fehlerdiagnose
+
+### Prometheus-Target ist DOWN
+
+```bash
+journalctl -u prometheus -n 200 --no-pager
+curl --fail http://127.0.0.1:8008/metrics | head
+curl --fail http://127.0.0.1:9090/api/v1/targets
+```
+
+Bei einem separaten Host zusätzlich Nginx-Allowlist, Routing, TLS und Quell-IP
+prüfen.
+
+### Grafana startet nicht
+
+```bash
+journalctl -u grafana-server -n 200 --no-pager
+ss -ltnp | grep ':3000'
+```
+
+Häufige Ursachen sind ein belegter Port, falsche Dateirechte oder manuelle
+Änderungen unter `/etc/grafana`.
+
+### Dashboard zeigt keine Daten
+
+1. Prometheus-Health und Targets prüfen.
+2. In Grafana `Stadtplaner Prometheus` unter **Connections → Data sources** testen.
+3. Den Dashboard-Zeitraum auf die letzten 15 Minuten stellen.
+4. Mit `curl http://127.0.0.1:8008/health/live` Testtraffic erzeugen.
+
+### Jobmetriken fehlen
+
+```bash
+namei -l /data/stadtplaner/observability
+getfacl /data/stadtplaner/observability
+sudo -u prometheus find /data/stadtplaner/observability -maxdepth 1 -name '*.prom' -readable
+curl --silent http://127.0.0.1:9100/metrics | grep '^job_'
+```
+
+## Sicherheitsprinzipien
+
+- Prometheus und Exporter niemals direkt ins Internet stellen.
+- Grafana-Adminpasswort ausschließlich verschlüsselt speichern.
+- Keine Secrets in Metriklabels oder Dashboardvariablen aufnehmen.
+- `/metrics` bei einem separaten Server nur für explizite Monitoring-CIDRs erlauben.
+- Grafana-Datenbank und Vault getrennt sichern.
+- Änderungen mit Syntaxcheck und `promtool` validieren.
+- Monitoring-Ausfälle dürfen API und Frontend nicht blockieren.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -52,6 +52,11 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
 Use `deploy/observability/prometheus/prometheus.example.yml` as a starting point and add the Prometheus host network to `stadtplaner_metrics_allowed_cidrs`. Load `deploy/observability/prometheus/alerts.yml` and import `deploy/observability/grafana/stadtplaner-overview.json`. The readiness alert uses the Prometheus blackbox exporter; the API scrape alone cannot prove readiness semantics.
 
+For a complete self-hosted installation, use the separate Ansible monitoring
+playbook described in [monitoring-deployment.md](monitoring-deployment.md). It
+installs Prometheus, Grafana, Node Exporter and Blackbox Exporter, provisions the
+dashboard and datasource, and keeps every listener on loopback by default.
+
 | Signal | Threshold / duration | Severity | Runbook |
 | --- | --- | --- | --- |
 | Readiness | failed 10m | critical | `readiness-down.md` |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,93 @@
+# Production observability
+
+Stadtplaner uses vendor-neutral JSON logs, Prometheus/OpenMetrics metrics and optional OpenTelemetry traces. The application has no dependency on Grafana, a collector or a hosted service to start or serve requests.
+
+## Architecture and correlation
+
+Nginx creates the edge `X-Request-ID` and forwards it to Nuxt and FastAPI. Direct requests may supply a safe 1–96 character ASCII token; both applications replace missing, oversized or control-character values with a UUID. Nuxt forwards the ID on SSR API requests. FastAPI returns it, and CORS exposes the response header to browser code.
+
+FastAPI stores request ID and route template in `ContextVar`s. OpenTelemetry independently propagates W3C `traceparent` and `tracestate`; active trace and span IDs are added to JSON logs. The intended chain is `browser -> nginx -> Nuxt SSR -> FastAPI -> PostgreSQL/HTTP provider`.
+
+## Structured logs and privacy
+
+Production emits one JSON `http_request_completed` event per request. It contains timestamp, level, service, environment, release SHA, logger, request ID, trace/span IDs when active, method, route template, status and duration. 5xx is error-level; 4xx remains info-level. Background jobs emit `job_completed` or `job_failed` with the same deployment metadata. Nginx access logs are JSON and omit headers and bodies.
+
+The formatter recursively redacts keys containing password, token, secret, authorization, cookie, API key, CSRF, recovery code, OTP/TOTP, email or prompt. It also removes emails, bearer values and JWT-shaped strings from messages. Request/response bodies, query strings, SQL bind values and recipient addresses are never observability fields. Assistant provider responses and raw prompts are redacted unless the explicit `ASSISTANT_QUERY_LOGGING` diagnostic switch is enabled; production defaults it to false.
+
+```bash
+journalctl -u stadtplaner-api -o cat
+journalctl -u stadtplaner-frontend -o cat
+journalctl -u stadtplaner-api -o cat | jq 'select(.request_id == "edge-id")'
+```
+
+## Metrics
+
+`GET /metrics` is enabled by default and uses low-cardinality labels only. Nginx denies it except for loopback and configured monitoring CIDRs.
+
+| Area | Metrics | Labels |
+| --- | --- | --- |
+| HTTP RED | `http_requests_total`, `http_request_duration_seconds`, `http_requests_in_progress` | method, route template, status class |
+| Database | `db_pool_size`, `db_pool_capacity`, `db_pool_checked_out`, `db_pool_checked_in`, `db_pool_overflow`, `db_pool_wait_seconds`, `db_connection_errors_total` | none |
+| Redis | `redis_operations_total`, `redis_operation_duration_seconds`, `redis_errors_total`, `redis_cache_hits_total`, `redis_cache_misses_total`, `redis_payload_bytes`, `redis_available` | bounded operation/result |
+| Providers | `external_requests_total`, `external_request_duration_seconds`, `external_request_errors_total` | provider, bounded operation/result/error type |
+| Outboxes | `outbox_pending`, `outbox_oldest_age_seconds`, `outbox_processed_total`, `outbox_failed_total`, `outbox_retry_total` | email, polygon or social |
+| Jobs | `job_runs_total`, `job_failures_total`, `job_duration_seconds`, `job_last_success_timestamp_seconds` | fixed job name |
+| OSM | `osm_replication_lag_seconds` | none |
+| Build | `build_info` | release SHA, version, environment |
+
+Request IDs, user IDs, emails, slugs, provider URLs, search text and queries are never metric labels. Job/outbox/OSM values survive oneshot processes as Prometheus textfiles in `OBSERVABILITY_TEXTFILE_DIR`; configure node_exporter's textfile collector for that directory.
+
+## Tracing
+
+Tracing is disabled unless both `OTEL_ENABLED=true` and an `OTEL_EXPORTER_OTLP_ENDPOINT` are configured. FastAPI, HTTPX and SQLAlchemy are instrumented. SQL bind values are not captured and SQL commenter injection is disabled. The OTLP gRPC exporter uses a batch processor, so an unavailable collector does not block application startup or synchronously export requests.
+
+```dotenv
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=stadtplaner-api
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+## Prometheus, Grafana and alerts
+
+Use `deploy/observability/prometheus/prometheus.example.yml` as a starting point and add the Prometheus host network to `stadtplaner_metrics_allowed_cidrs`. Load `deploy/observability/prometheus/alerts.yml` and import `deploy/observability/grafana/stadtplaner-overview.json`. The readiness alert uses the Prometheus blackbox exporter; the API scrape alone cannot prove readiness semantics.
+
+| Signal | Threshold / duration | Severity | Runbook |
+| --- | --- | --- | --- |
+| Readiness | failed 10m | critical | `readiness-down.md` |
+| 5xx | >5% 10m / >15% 5m | warning / critical | `high-5xx-rate.md` |
+| p95 latency | >2s 15m | warning | `high-5xx-rate.md` |
+| DB pool | >90% 10m | warning | `db-pool-saturation.md` |
+| Redis | unavailable 10m | warning | `redis-down.md` |
+| Outbox | >100 pending or oldest >1h for 15m | warning | `outbox-backlog.md` |
+| Job | failure observed for 5m | warning | `background-job-failure.md` |
+| OSM | lag >2h for 15m | warning | `osm-replication-stale.md` |
+
+## Service objectives
+
+These are pragmatic civic-tech targets, measured monthly and reviewed after enough production data exists:
+
+- API availability: 99.5%, using successful readiness probes; announced maintenance is reported separately.
+- Standard read-request p95 latency: below 1 second. The alert starts at 2 seconds to avoid noisy paging.
+- API server-error ratio: below 1%. Alerts start at 5% because traffic can be low.
+- Readiness: continuously probed every 30 seconds.
+- OSM freshness: normally below two hours behind the imported replication timestamp.
+
+## Configuration and release metadata
+
+| Variable | Production default | Purpose |
+| --- | --- | --- |
+| `LOG_FORMAT` | `json` | `json` or development-only `text` |
+| `LOG_LEVEL` | `INFO` | application log level |
+| `METRICS_ENABLED` | `true` | expose the internal metrics handler |
+| `METRICS_PATH` | `/metrics` | handler path; keep Nginx config aligned |
+| `OBSERVABILITY_TEXTFILE_DIR` | `/data/stadtplaner/observability` | persistent oneshot metrics |
+| `OTEL_ENABLED` | `false` | optional tracing switch |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | empty | collector endpoint, never hardcoded |
+| `STADTPLANER_RELEASE_SHA` | injected by Ansible | exact deployed Git commit |
+
+`/health/info` publishes only version, exact release SHA and environment. `build_info`, backend logs, frontend SSR logs and background logs use the same Ansible-resolved commit.
+
+## Local development and troubleshooting
+
+Start without a monitoring backend; `/metrics` remains directly available on the development API. Generate traffic with `curl -H 'X-Request-ID: local-smoke' http://127.0.0.1:8000/health/live`, then inspect the response header, JSON line and metric counter. If telemetry is absent, check feature flags first; a stopped Prometheus, Grafana or OTLP collector must not affect health. If cardinality grows unexpectedly, inspect route/provider/operation labels and remove dynamic values before deployment.

--- a/docs/runbooks/background-job-failure.md
+++ b/docs/runbooks/background-job-failure.md
@@ -1,0 +1,14 @@
+# Background job failure
+
+Signal: `increase(job_failures_total[15m]) > 0` for 5 minutes. Severity: warning.
+
+Meaning: a systemd timer job exited unsuccessfully. `job_name` identifies OSM replication, statistics, email or social processing.
+
+First checks: run `systemctl status <job>.timer <job>.service`, inspect the last invocation with `journalctl -u <job>.service`, and compare `job_last_success_timestamp_seconds`.
+
+Diagnosis: use the structured `job_failed` log, release SHA, dependency and provider metrics. Validate environment-file readability and writable paths without printing secrets.
+
+Mitigation: correct the dependency/configuration and start the oneshot service once. Avoid overlapping manual and scheduled runs. Roll back when the first failure aligns with a release.
+
+Escalation: escalate repeated failures or missed data-delivery windows with job name, exit status, release SHA and redacted error type.
+

--- a/docs/runbooks/db-pool-saturation.md
+++ b/docs/runbooks/db-pool-saturation.md
@@ -1,0 +1,14 @@
+# Database pool saturation
+
+Signal: `db_pool_checked_out / db_pool_capacity > 0.9` for 10 minutes. Severity: warning.
+
+Meaning: API workers are close to exhausting their configured PostgreSQL connections; requests may wait or time out.
+
+First checks: inspect checked-out, available, overflow, `db_pool_wait_seconds`, DB connection errors and API latency. Check PostgreSQL `pg_stat_activity` and server connection limits.
+
+Diagnosis: correlate slow routes/traces, long transactions and blocked queries. Confirm the sum across all API processes fits PostgreSQL capacity before changing pool settings.
+
+Mitigation: stop a runaway job, resolve locks/slow queries, or restart a leaking worker after capturing evidence. Increase pool capacity only with database headroom. Roll back a release that introduced persistent growth.
+
+Escalation: involve the database operator when saturation persists, blockers cannot be safely cancelled, or recovery risks an active transaction.
+

--- a/docs/runbooks/high-5xx-rate.md
+++ b/docs/runbooks/high-5xx-rate.md
@@ -1,0 +1,14 @@
+# High 5xx rate or latency
+
+Signal: 5xx ratio above 5% for 10 minutes (warning), above 15% for 5 minutes (critical), or p95 latency above 2 seconds for 15 minutes.
+
+Meaning: users are receiving server errors or the API is degraded. A single low-volume error does not trigger the alert.
+
+First checks: split `http_requests_total` and latency by route; inspect DB, Redis and provider panels; query JSON logs for `event="http_request_completed"` with `status_code>=500` and the active `release_sha`.
+
+Diagnosis: follow a representative `request_id`/`trace_id`; inspect child DB/provider spans and `external_request_errors_total`. Compare onset with deployment and job activity.
+
+Mitigation: isolate the failing route/provider, reduce nonessential load, restore dependencies, or roll back the active release. Do not disable logging or alerts to hide the signal.
+
+Escalation: escalate critical rates immediately; include route, release SHA, request ID, trace ID and first failing timestamp.
+

--- a/docs/runbooks/osm-replication-stale.md
+++ b/docs/runbooks/osm-replication-stale.md
@@ -1,0 +1,13 @@
+# OSM replication stale
+
+Signal: `osm_replication_lag_seconds > 7200` for 15 minutes. Severity: warning.
+
+Meaning: the newest locally published OSM snapshot is more than two hours behind its replication timestamp.
+
+First checks: inspect `stadtplaner-osm-update.timer/service`, free disk, network access to the configured replication URL and the last successful job timestamp.
+
+Diagnosis: inspect OSM update JSON logs and phase output, replication state files, PostgreSQL staging/import health and Wikidata provider errors. Confirm the upstream replication feed itself is current.
+
+Mitigation: fix disk/network/database issues and run one non-overlapping update. Use the documented initial import only when replication state cannot be recovered; take a backup before destructive reinitialization.
+
+Escalation: involve the OSM/data operator after two missed hourly runs, corrupted state, or any need for a full reimport.

--- a/docs/runbooks/outbox-backlog.md
+++ b/docs/runbooks/outbox-backlog.md
@@ -1,0 +1,14 @@
+# Outbox backlog
+
+Signal: `outbox_pending > 100` or `outbox_oldest_age_seconds > 3600` for 15 minutes. Severity: warning.
+
+Meaning: email, polygon notification or social work is not keeping pace. Recipient addresses and payloads are intentionally absent from metrics.
+
+First checks: identify `outbox_type`; inspect its timer/service status, `outbox_failed_total`, `outbox_retry_total`, job failures and provider metrics.
+
+Diagnosis: run the relevant CLI in its normal environment with a small limit, inspect redacted JSON logs, database status/attempt counts and provider availability. Do not dump message bodies.
+
+Mitigation: restore the provider, re-enable the timer, or process a bounded batch. Preserve idempotency and existing retry/dead-letter rules; do not mass-reset rows without a backup.
+
+Escalation: involve the service owner when dead letters rise, messages are time-critical, or replay could duplicate external side effects.
+

--- a/docs/runbooks/readiness-down.md
+++ b/docs/runbooks/readiness-down.md
@@ -1,0 +1,14 @@
+# Readiness down
+
+Signal: `probe_success{job="stadtplaner-readiness"} == 0` for 10 minutes. Severity: critical.
+
+Meaning: `/health/ready` cannot confirm the API's PostgreSQL and required Redis dependencies. Liveness may still be healthy.
+
+First checks: request `/health/live` and `/health/ready`; inspect `systemctl status stadtplaner-api postgresql redis-server`; correlate the response `X-Request-ID` with API JSON logs.
+
+Diagnosis: inspect `database` and `redis` in readiness output, `db_connection_errors_total`, `redis_available`, pool gauges and `journalctl -u stadtplaner-api`. Check disk, connections and recent release SHA.
+
+Mitigation: restore the failed dependency, free exhausted DB connections, or restart only the unhealthy dependency. Restart the API only after dependency health is understood. Roll back to the previous release if failures began with a deployment.
+
+Escalation: notify the production operator immediately when readiness remains down after dependency recovery or data integrity may be affected.
+

--- a/docs/runbooks/redis-down.md
+++ b/docs/runbooks/redis-down.md
@@ -1,0 +1,14 @@
+# Redis down
+
+Signal: `redis_available == 0` for 10 minutes. Severity: warning.
+
+Meaning: caching and production security counters are unavailable. Production requires Redis, while optional development mode can fall back to the database.
+
+First checks: inspect `/health/ready`, `systemctl status redis-server`, `redis-cli ping`, `redis_errors_total` and Redis latency. Review API logs without printing the Redis URL.
+
+Diagnosis: check memory pressure, connection limits, disk persistence and network binding. Determine whether the outage followed a deploy or host event.
+
+Mitigation: restore Redis capacity/service and verify `redis_available` returns to 1. Restart the API only if clients fail to reconnect. Never log or paste Redis credentials.
+
+Escalation: escalate immediately if readiness is down, authentication rate limiting is affected, or Redis data recovery is required.
+

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -48,6 +48,7 @@ export const useApi = () => {
   const authStore = useAuthStore()
   const adminMfaRequirement = useState<'MFA_SETUP_REQUIRED' | 'MFA_REAUTH_REQUIRED' | null>('admin-mfa-requirement', () => null)
   const forwardedCookie = import.meta.server ? useRequestHeaders(['cookie']).cookie : undefined
+  const forwardedRequestId = import.meta.server ? useRequestHeaders(['x-request-id'])['x-request-id'] : undefined
 
   async function request<T>(path: string, options: ApiOptions = {}): Promise<T> {
     return execute<T>(path, options)
@@ -97,6 +98,9 @@ export const useApi = () => {
     }
     if (import.meta.server && !headers.has('Cookie')) {
       if (forwardedCookie) headers.set('Cookie', forwardedCookie)
+    }
+    if (!headers.has('X-Request-ID')) {
+      headers.set('X-Request-ID', forwardedRequestId || crypto.randomUUID())
     }
     const csrf = csrfToken(options.method)
     if (csrf) headers.set('X-CSRF-Token', csrf)

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -63,6 +63,8 @@ export default defineNuxtConfig({
   ],
   css: ['~/assets/css/main.css'],
   runtimeConfig: {
+    environment: process.env.APP_ENVIRONMENT || process.env.NODE_ENV || 'development',
+    releaseSha: process.env.STADTPLANER_RELEASE_SHA || 'dev',
     public: {
       siteName: 'OK Lab Flensburg',
       siteUrl: configuredSiteUrl || 'http://localhost:3000',

--- a/frontend/server/middleware/observability.ts
+++ b/frontend/server/middleware/observability.ts
@@ -1,0 +1,25 @@
+import { getHeader, getRequestURL, setHeader } from 'h3'
+import { requestIdFor, routeTemplate } from '../utils/observability'
+
+export default defineEventHandler((event) => {
+  const started = performance.now()
+  const requestId = requestIdFor(getHeader(event, 'x-request-id'))
+  event.context.requestId = requestId
+  setHeader(event, 'X-Request-ID', requestId)
+  event.node.res.once('finish', () => {
+    const config = useRuntimeConfig(event)
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: event.node.res.statusCode >= 500 ? 'error' : 'info',
+      service: 'stadtplaner-frontend',
+      environment: process.env.APP_ENVIRONMENT || config.environment,
+      release_sha: process.env.STADTPLANER_RELEASE_SHA || config.releaseSha,
+      event: 'http_request_completed',
+      request_id: requestId,
+      method: event.method,
+      route: routeTemplate(getRequestURL(event).pathname),
+      status_code: event.node.res.statusCode,
+      duration_ms: Math.round((performance.now() - started) * 1000) / 1000
+    }))
+  })
+})

--- a/frontend/server/routes/sitemap.xml.ts
+++ b/frontend/server/routes/sitemap.xml.ts
@@ -9,8 +9,12 @@ const STATIC_PATHS = ['/', '/gebiete', '/vergleich', '/ueber-das-projekt', '/ope
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
   const [entries, areas] = await Promise.all([
-    $fetch<PolygonSitemapEntry[]>(`${config.public.apiBaseUrl}/polygons/sitemap`),
-    $fetch<AnalysisAreaSitemapEntry[]>(`${config.public.apiBaseUrl}/analysis-areas/sitemap`)
+    $fetch<PolygonSitemapEntry[]>(`${config.public.apiBaseUrl}/polygons/sitemap`, {
+      headers: { 'X-Request-ID': event.context.requestId }
+    }),
+    $fetch<AnalysisAreaSitemapEntry[]>(`${config.public.apiBaseUrl}/analysis-areas/sitemap`, {
+      headers: { 'X-Request-ID': event.context.requestId }
+    })
   ])
   const urls: SitemapUrl[] = [
     ...STATIC_PATHS.map(path => ({ loc: buildAbsoluteUrl(config.public.siteUrl, path) })),

--- a/frontend/server/utils/observability.ts
+++ b/frontend/server/utils/observability.ts
@@ -1,0 +1,17 @@
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$/
+
+export function requestIdFor(value?: string) {
+  return value && REQUEST_ID_PATTERN.test(value) ? value : crypto.randomUUID()
+}
+
+export function routeTemplate(pathname: string) {
+  const segments = pathname.split('/').map((segment, index, values) => {
+    if (!segment) return segment
+    if (/^\d+$/.test(segment) || /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(segment)) return '{id}'
+    const parent = values[index - 1]
+    if (parent && ['flaechen', 'gebiete'].includes(parent)) return '{slug}'
+    if (parent === 'dokumentation' || values[index - 2] === 'dokumentation') return '{slug}'
+    return segment
+  })
+  return segments.join('/') || '/'
+}

--- a/frontend/tests/observability.test.ts
+++ b/frontend/tests/observability.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { requestIdFor, routeTemplate } from '../server/utils/observability'
+
+describe('frontend request correlation', () => {
+  it('accepts bounded safe request IDs and replaces unsafe input', () => {
+    expect(requestIdFor('edge-123')).toBe('edge-123')
+    expect(requestIdFor('bad value')).not.toBe('bad value')
+    expect(requestIdFor('x'.repeat(97))).not.toBe('x'.repeat(97))
+  })
+
+  it('uses low-cardinality templates for dynamic SSR routes', () => {
+    expect(routeTemplate('/flaechen/innenstadt')).toBe('/flaechen/{slug}')
+    expect(routeTemplate('/flaechen/hafen')).toBe('/flaechen/{slug}')
+    expect(routeTemplate('/gebiete/nordstadt')).toBe('/gebiete/{slug}')
+    expect(routeTemplate('/admin/users/123')).toBe('/admin/users/{id}')
+  })
+
+  it('generates an ID when none is supplied', () => {
+    const randomUUID = vi.spyOn(crypto, 'randomUUID').mockReturnValue('generated-id')
+    expect(requestIdFor()).toBe('generated-id')
+    randomUUID.mockRestore()
+  })
+})


### PR DESCRIPTION
Fixes #15

## Architecture
Adds a production observability layer across FastAPI, Nuxt SSR, Redis, SQLAlchemy, external providers, background jobs, Nginx, Prometheus, Grafana, and deployment automation. The implementation is failure-tolerant: unavailable telemetry backends never block application traffic.

## Structured Logging
Backend and SSR emit structured JSON completion events with timestamp, level, service, environment, release SHA, logger, message, request context, route template, status, duration, and trace context. A central recursive redaction layer removes secrets, bearer/JWT values, and email addresses.

## Request Correlation
Nginx accepts a safe incoming `X-Request-ID` or generates one, forwards it through SSR and API calls, and returns it to clients. Invalid IDs are replaced. Backend logs, responses, and traces use the same correlation ID.

## Metrics
Provides a dedicated Prometheus registry and an optionally exposed `/metrics` endpoint. RED metrics cover HTTP requests, latency, errors, and in-flight work using low-cardinality route templates. Build information carries the deployed release SHA.

## Database
Exports SQLAlchemy pool capacity, checked-out connections, utilization, wait duration, and connection errors through public pool/event APIs. Readiness acquisition is timed and instrumented.

## Redis
Measures availability, operation duration/errors, cache hits/misses, and payload sizes while preserving fail-open cache behavior.

## External Providers
Adds bounded-cardinality latency and error metrics plus trace spans for Nominatim, Overpass, assistant providers, Mastodon/SSO, Turnstile, SMTP, Flensburg Superset, and Wikidata. Raw provider responses remain disabled in production logging.

## Background Jobs
Email, polygon, social, statistics, and OSM post-processing jobs emit structured lifecycle logs and persist Prometheus textfile/JSON state. Outbox depth and oldest-item age are sampled without interrupting processing.

## OpenTelemetry
Optional FastAPI, HTTPX, and SQLAlchemy tracing exports via OTLP/gRPC with batch processing. Tracing is disabled when no endpoint is configured and exporter failures are non-blocking.

## Grafana
Ships a provisioning-ready dashboard for traffic, HTTP errors and percentiles, in-flight requests, database saturation, Redis health/cache ratio, external dependencies, outboxes, jobs, OSM lag, and release identity.

## Alerts
Adds Prometheus alert rules for readiness, warning/critical 5xx rates, latency, database saturation, Redis availability, outbox backlog, job failures, and stale OSM replication, each linked to a concrete runbook.

## SLOs
Documents pragmatic availability, latency, freshness, and background-processing SLOs and their PromQL measurement approach.

## Privacy
Logs intentionally exclude query strings, request/response bodies, authorization/cookie headers, and raw provider output. Recursive redaction is applied centrally to structured extras; metrics and route labels are bounded.

## Deployment
Ansible injects the exact resolved release SHA into API, frontend, and one-shot jobs; creates a writable observability state directory; and installs protected Nginx metrics routing. A separate opt-in monitoring playbook now installs and configures Prometheus, Grafana OSS, Node Exporter, and Blackbox Exporter; provisions the datasource, dashboard, alerts, bounded retention, textfile collector, runtime health checks, and optional Grafana-only HTTPS publication. All monitoring listeners default to loopback, so no subdomain is required.

## Tests
- Backend: 589 tests passed, including 12 observability tests for redaction/privacy, request correlation, route cardinality, logs/metrics, real in-memory OpenTelemetry propagation, Redis, external-provider outcomes, and database pool helpers.
- Backend quality/security: Ruff passed, lockfile check passed, dependency audit reported no known vulnerabilities.
- Frontend: 72 test files / 402 tests passed; typecheck and production build passed.
- Deployment: 5 Ansible unit tests and all application, certificate, monitoring, and OSM playbook syntax checks passed; Grafana/Prometheus templates, dashboard JSON, alert YAML, package service conventions, secret scan, and supply-chain policy were validated.
- Smoke/load: 300 concurrent health requests returned 200, the request metric counted exactly 300, metrics registered once, and memory remained bounded.