### PR TITLE
Fix production deploy failure on multiline GitHub secrets

### DIFF
--- a/deploy/ansible/scripts/build-github-vars.py
+++ b/deploy/ansible/scripts/build-github-vars.py
@@ -70,8 +70,26 @@ def truthy(value: str | None) -> bool:
 
 
 def quoted(value: str) -> str:
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
     return f'"{escaped}"'
+
+
+def validate_secret_values() -> None:
+    invalid = sorted(
+        name
+        for name in SECRET_KEYS
+        if (value := os.environ.get(name)) and ("\r" in value or "\n" in value)
+    )
+    if invalid:
+        raise SystemExit(
+            "GitHub environment secrets must be single-line values without CR/LF characters: "
+            + ", ".join(invalid)
+        )
 
 
 def require_secret(name: str, required: set[str]) -> None:
@@ -133,6 +151,8 @@ def main() -> None:
     parser.add_argument("--example", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
+
+    validate_secret_values()
 
     reference = yaml.safe_load(args.example.read_text(encoding="utf-8"))
     generated: dict[str, str] = {}

--- a/deploy/ansible/tests/test_github_secret_validation.py
+++ b/deploy/ansible/tests/test_github_secret_validation.py
@@ -1,0 +1,48 @@
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "deploy/ansible/scripts/build-github-vars.py"
+SPEC = importlib.util.spec_from_file_location("build_github_vars", SCRIPT)
+assert SPEC and SPEC.loader
+BUILDER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BUILDER)
+
+
+class GitHubSecretValidationTest(unittest.TestCase):
+    def test_quoted_escapes_carriage_returns_and_newlines(self) -> None:
+        self.assertEqual(BUILDER.quoted("token\r\nvalue"), '"token\\r\\nvalue"')
+
+    def test_rejects_secret_with_trailing_carriage_return(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"STADTPLANER_MASTODON_ACCESS_TOKEN": "token-value\r"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(
+                SystemExit,
+                "STADTPLANER_MASTODON_ACCESS_TOKEN",
+            ):
+                BUILDER.validate_secret_values()
+
+    def test_rejects_multiline_secret(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"STADTPLANER_GROQ_API_KEY": "first-line\nsecond-line"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(SystemExit, "STADTPLANER_GROQ_API_KEY"):
+                BUILDER.validate_secret_values()
+
+    def test_accepts_single_line_secret(self) -> None:
+        clean_environment = {name: "single-line-value" for name in BUILDER.SECRET_KEYS}
+        with mock.patch.dict(os.environ, clean_environment, clear=True):
+            BUILDER.validate_secret_values()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject GitHub environment secrets containing CR/LF before generating production dotenv content
- escape carriage returns in `quoted()` defensively
- add regression tests for trailing CR, multiline secrets, and valid single-line secrets

## Why
Production deploy run 32814180204 failed at `alembic upgrade head` because `python-dotenv` could not parse the generated backend environment and `MASTODON_ACCESS_TOKEN` was then seen as missing. The failing token is supplied by GitHub Actions, so the deploy path needs to validate secret shape before release assembly/migrations.

## Expected behavior
A malformed secret now fails immediately during `build-github-vars.py` with the exact GitHub secret name instead of reaching the production server, database backup, and Alembic migration step.