### PR TITLE
Fix MapLibre renderer cache under systemd hardening

### DIFF
--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner-map-renderer.service.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner-map-renderer.service.j2
@@ -9,9 +9,13 @@ Type=simple
 User={{ stadtplaner_map_renderer_service_user }}
 Group={{ stadtplaner_map_renderer_service_group }}
 WorkingDirectory={{ stadtplaner_current_path }}/frontend
+CacheDirectory=stadtplaner-map-renderer
+CacheDirectoryMode=0750
 Environment=NODE_ENV=production
 Environment=LIBGL_ALWAYS_SOFTWARE=1
 Environment=GALLIUM_DRIVER=llvmpipe
+Environment=XDG_CACHE_HOME=/var/cache/stadtplaner-map-renderer
+Environment=MESA_SHADER_CACHE_DIR=/var/cache/stadtplaner-map-renderer/mesa-shader-cache
 Environment=MAP_PREVIEW_HOST={{ stadtplaner_map_renderer_bind_address }}
 Environment=MAP_PREVIEW_PORT={{ stadtplaner_map_renderer_port }}
 Environment=MAP_PREVIEW_STYLE_PATH={{ stadtplaner_current_path }}/frontend/public/map-styles/stadtplaner-light.json

--- a/deploy/ansible/tests/test_map_preview_deployment.py
+++ b/deploy/ansible/tests/test_map_preview_deployment.py
@@ -72,6 +72,24 @@ class MapPreviewDeploymentTest(unittest.TestCase):
         self.assertNotIn("EnvironmentFile=", unit)
         self.assertNotIn("0.0.0.0", unit)
 
+    def test_renderer_has_writable_cache_under_systemd_hardening(self) -> None:
+        unit = (APP_ROLE / "templates/stadtplaner-map-renderer.service.j2").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("CacheDirectory=stadtplaner-map-renderer", unit)
+        self.assertIn("CacheDirectoryMode=0750", unit)
+        self.assertIn(
+            "Environment=XDG_CACHE_HOME=/var/cache/stadtplaner-map-renderer",
+            unit,
+        )
+        self.assertIn(
+            "Environment=MESA_SHADER_CACHE_DIR=/var/cache/stadtplaner-map-renderer/mesa-shader-cache",
+            unit,
+        )
+        self.assertIn("ProtectSystem=strict", unit)
+        self.assertNotIn("Environment=XDG_CACHE_HOME=/nonexistent", unit)
+        self.assertNotIn("Environment=MESA_SHADER_CACHE_DIR=/nonexistent", unit)
+
     def test_renderer_participates_in_preflight_rollout_smoke_and_rollback(self) -> None:
         tasks = (APP_ROLE / "tasks/main.yml").read_text(encoding="utf-8")
         binary_smoke = (APP_ROLE / "tasks/webp_smoke.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- give `stadtplaner-map-renderer.service` a dedicated systemd-managed cache directory
- set `XDG_CACHE_HOME` for Fontconfig and other XDG-aware consumers
- set `MESA_SHADER_CACHE_DIR` so Mesa no longer falls back to `/nonexistent`
- add regression coverage while retaining `ProtectSystem=strict`

## Why
Production logs showed the renderer starting successfully on `127.0.0.1:3020`, but repeatedly reporting `Fontconfig error: No writable cache directories` and `Failed to create /nonexistent for shader cache (Read-only file system)`. The dedicated renderer account intentionally has no home directory, so a hardened service needs an explicit writable cache path.

## Rollback note
The observed `disabled` state after the failed deployment is expected when rolling back across the renderer's first deployment: Ansible deliberately disables the renderer if the previous release does not contain it. A successful rollout enables and starts the service again.

## Expected behavior
systemd creates `/var/cache/stadtplaner-map-renderer` with mode `0750`; Fontconfig/XDG caches and Mesa shader cache use that writable location without weakening the existing service hardening.