### PR TITLE
fix(deploy): normalize GitHub dotenv config line endings

### DIFF
--- a/deploy/ansible/scripts/build-github-vars.py
+++ b/deploy/ansible/scripts/build-github-vars.py
@@ -65,6 +65,11 @@ def assignments(content: str) -> dict[str, str]:
     return result
 
 
+def normalize_dotenv_content(content: str) -> str:
+    """Return dotenv content with deterministic LF line endings and one final newline."""
+    return "\n".join(content.splitlines()).strip() + "\n"
+
+
 def truthy(value: str | None) -> bool:
     return (value or "").strip().strip('"').lower() in {"1", "true", "yes", "on"}
 
@@ -159,10 +164,11 @@ def main() -> None:
     secret_dotenv_keys = set(SECRET_KEYS.values())
 
     for ansible_key, environment_name in CONFIG_VARIABLES.items():
-        content = os.environ.get(environment_name, "").strip()
-        if not content:
+        content = os.environ.get(environment_name, "")
+        if not content.strip():
             raise SystemExit(f"Missing GitHub environment variable: {environment_name}")
-        supplied = assignments(content)
+        normalized_content = normalize_dotenv_content(content)
+        supplied = assignments(normalized_content)
         expected = set(assignments(reference[ansible_key]))
         forbidden = sorted(set(supplied) & secret_dotenv_keys)
         if forbidden:
@@ -176,7 +182,7 @@ def main() -> None:
             raise SystemExit(
                 f"Invalid {environment_name}; missing={missing or 'none'}, extra={extra or 'none'}"
             )
-        generated[ansible_key] = content + "\n"
+        generated[ansible_key] = normalized_content
 
     backend_values = assignments(generated["stadtplaner_backend_env_content"])
     try:

--- a/deploy/ansible/tests/test_build_github_vars.py
+++ b/deploy/ansible/tests/test_build_github_vars.py
@@ -115,7 +115,7 @@ class GitHubVarsBuilderTest(unittest.TestCase):
                 self.assertNotIn("\r", generated[key])
                 self.assertTrue(generated[key].endswith("\n"))
             self.assertIn(
-                'MASTODON_ACCESS_TOKEN="test-value-with-#-and-$"\n',
+                'MASTODON_ACCESS_TOKEN=""\n',
                 generated["stadtplaner_backend_env_content"],
             )
 

--- a/deploy/ansible/tests/test_build_github_vars.py
+++ b/deploy/ansible/tests/test_build_github_vars.py
@@ -94,6 +94,31 @@ class GitHubVarsBuilderTest(unittest.TestCase):
             self.assertEqual(generated["stadtplaner_otel_service_name"], "stadtplaner-api")
             self.assertEqual(output.stat().st_mode & 0o777, 0o600)
 
+    def test_normalizes_crlf_configuration_before_appending_secrets(self) -> None:
+        self.environment["STADTPLANER_BACKEND_ENV_CONFIG"] = self.environment[
+            "STADTPLANER_BACKEND_ENV_CONFIG"
+        ].replace("\n", "\r\n")
+        self.environment["STADTPLANER_FRONTEND_ENV_CONFIG"] = self.environment[
+            "STADTPLANER_FRONTEND_ENV_CONFIG"
+        ].replace("\n", "\r\n")
+        self.environment["STADTPLANER_OSM_ENV_CONFIG"] = self.environment[
+            "STADTPLANER_OSM_ENV_CONFIG"
+        ].replace("\n", "\r\n")
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "vars.yml"
+            result = self.run_builder(output)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            generated = yaml.safe_load(output.read_text(encoding="utf-8"))
+            for key in BUILDER.CONFIG_VARIABLES:
+                self.assertNotIn("\r", generated[key])
+                self.assertTrue(generated[key].endswith("\n"))
+            self.assertIn(
+                'MASTODON_ACCESS_TOKEN="test-value-with-#-and-$"\n',
+                generated["stadtplaner_backend_env_content"],
+            )
+
     def test_rejects_secret_in_open_configuration(self) -> None:
         self.environment["STADTPLANER_BACKEND_ENV_CONFIG"] += "\nDATABASE_URL=exposed"
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- normalize GitHub-provided backend, frontend, and OSM dotenv config blocks to LF before generating Ansible vars
- preserve exactly one trailing newline
- add regression coverage for CRLF configuration input and verify appended Mastodon secrets remain parseable

## Why
Production deploy run `32818746246` failed during `alembic upgrade head` with:

```text
python-dotenv could not parse statement starting at line 183
RuntimeError: MASTODON_ACCESS_TOKEN must be configured when Mastodon is enabled
```

The GitHub Actions environment shows `STADTPLANER_BACKEND_ENV_CONFIG` arriving with CRLF line endings while `STADTPLANER_MASTODON_ACCESS_TOKEN` is set. PR #67 correctly validates individual secrets for embedded CR/LF, but the generator validated the multiline config using `splitlines()` and then wrote the original CRLF content back unchanged before appending LF-only secret lines. That can leave the generated `.env` with mixed line endings and make the appended secret section fail parsing.

## Expected behavior
All generated dotenv configuration content uses deterministic LF line endings before secrets are appended. CRLF input from GitHub environment variables is accepted and normalized rather than propagated to production.

Related production failure: https://github.com/oklabflensburg/open-city-planner/actions/runs/32818746246/job/97712291779