### PR TITLE
fix(deploy): decouple Alembic from runtime security validation

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -5,7 +5,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
-from app.core.config import get_settings
+from app.core.config import Settings
 from app.db.base import Base
 from app.models import (  # noqa: F401
     AdminAuditLog,
@@ -36,7 +36,8 @@ from app.models import (  # noqa: F401
 )
 
 config = context.config
-config.set_main_option("sqlalchemy.url", get_settings().database_url)
+migration_settings = Settings()
+config.set_main_option("sqlalchemy.url", migration_settings.database_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
@@ -46,7 +47,7 @@ target_metadata = Base.metadata
 
 def run_migrations_offline() -> None:
     context.configure(
-        url=get_settings().database_url,
+        url=migration_settings.database_url,
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},


### PR DESCRIPTION
## Summary
- make Alembic load `Settings()` directly instead of `get_settings()`
- reuse one migration settings instance for online/offline migration URL configuration
- keep application runtime security validation unchanged

## Why
Production deploys reach `alembic upgrade head`, successfully parse the database configuration, but then fail because `get_settings()` runs application-wide runtime security validation and rejects the Mastodon runtime token. Database migrations should not depend on unrelated Mastodon/OAuth/SMTP runtime readiness.

The application still uses `get_settings()` at runtime, so production security validation remains enforced when the API starts. This change only removes that unrelated validation from Alembic's migration bootstrap.

Related failed deploy: https://github.com/oklabflensburg/open-city-planner/actions/runs/32820602207/job/97717688656

Supersedes the abandoned/cleaned-up PR #71.