### PR TITLE
fix(deploy): prevent literal newline in release env

### DIFF
--- a/deploy/ansible/roles/stadtplaner/tasks/main.yml
+++ b/deploy/ansible/roles/stadtplaner/tasks/main.yml
@@ -319,8 +319,7 @@
     content: >-
       {{ (stadtplaner_backend_env_content
           | regex_replace('(?m)^STADTPLANER_RELEASE_SHA=.*\n?', '')
-          | trim)
-         ~ '\nSTADTPLANER_RELEASE_SHA=' ~ stadtplaner_release_sha ~ '\n' }}
+          | trim) }}
     dest: "{{ stadtplaner_target_backend_env }}"
     owner: root
     group: "{{ stadtplaner_service_group }}"
@@ -333,8 +332,7 @@
     content: >-
       {{ (stadtplaner_frontend_env_content
           | regex_replace('(?m)^STADTPLANER_RELEASE_SHA=.*\n?', '')
-          | trim)
-         ~ '\nSTADTPLANER_RELEASE_SHA=' ~ stadtplaner_release_sha ~ '\n' }}
+          | trim) }}
     dest: "{{ stadtplaner_target_frontend_env }}"
     owner: root
     group: "{{ stadtplaner_service_group }}"
@@ -375,19 +373,17 @@
 
 - name: Bind target environment snapshots to the target release SHA
   ansible.builtin.lineinfile:
-    path: "{{ item.path }}"
+    path: "{{ item }}"
     regexp: '^STADTPLANER_RELEASE_SHA='
     line: "STADTPLANER_RELEASE_SHA={{ stadtplaner_release_sha }}"
+    insertafter: EOF
     create: false
     owner: root
     group: "{{ stadtplaner_service_group }}"
     mode: '0640'
   loop:
-    - path: "{{ stadtplaner_target_backend_env }}"
-      supplied: "{{ stadtplaner_backend_env_content is defined }}"
-    - path: "{{ stadtplaner_target_frontend_env }}"
-      supplied: "{{ stadtplaner_frontend_env_content is defined }}"
-  when: not item.supplied | bool
+    - "{{ stadtplaner_target_backend_env }}"
+    - "{{ stadtplaner_target_frontend_env }}"
   no_log: true
 
 - name: Validate target frontend environment syntax without exposing values

--- a/deploy/ansible/tests/test_map_preview_deployment.py
+++ b/deploy/ansible/tests/test_map_preview_deployment.py
@@ -145,7 +145,41 @@ class MapPreviewDeploymentTest(unittest.TestCase):
         self.assertIn("Preserve the original deployment failure", tasks)
         self.assertIn("Report both deployment and rollback failures", tasks)
         self.assertGreaterEqual(tasks.count("STADTPLANER_RELEASE_SHA="), 4)
-        self.assertIn("when: not item.supplied | bool", tasks)
+
+    def test_target_environment_release_sha_is_written_as_a_real_line(self) -> None:
+        tasks_path = APP_ROLE / "tasks/main.yml"
+        tasks_text = tasks_path.read_text(encoding="utf-8")
+        tasks = yaml.safe_load(tasks_text)
+        tasks_by_name = {task["name"]: task for task in tasks}
+
+        for name in (
+            "Install target backend environment snapshot from encrypted input",
+            "Install target frontend environment snapshot from encrypted input",
+        ):
+            content = tasks_by_name[name]["ansible.builtin.copy"]["content"]
+            self.assertNotIn("stadtplaner_release_sha", content)
+            self.assertNotIn("~", content)
+
+        bind_task = tasks_by_name[
+            "Bind target environment snapshots to the target release SHA"
+        ]
+        lineinfile = bind_task["ansible.builtin.lineinfile"]
+        self.assertEqual(lineinfile["regexp"], "^STADTPLANER_RELEASE_SHA=")
+        self.assertEqual(
+            lineinfile["line"],
+            "STADTPLANER_RELEASE_SHA={{ stadtplaner_release_sha }}",
+        )
+        self.assertEqual(lineinfile["insertafter"], "EOF")
+        self.assertFalse(lineinfile["create"])
+        self.assertEqual(
+            bind_task["loop"],
+            [
+                "{{ stadtplaner_target_backend_env }}",
+                "{{ stadtplaner_target_frontend_env }}",
+            ],
+        )
+        self.assertNotIn("when", bind_task)
+        self.assertNotIn("~ '\\nSTADTPLANER_RELEASE_SHA='", tasks_text)
 
     def test_preview_defaults_are_persistent_and_loopback_only(self) -> None:
         defaults = yaml.safe_load(


### PR DESCRIPTION
## Problem

Production-Deployments erzeugten neu gelieferte Backend- und Frontend-Environment-Snapshots mit einer Jinja-String-Konkatenation. Dabei wurden die Zeichen `\n` physisch als Backslash plus `n` geschrieben. Ein betroffenes Dateiende hatte damit sinngemäß die Form:

```text
MASTODON_ACCESS_TOKEN="..."\nSTADTPLANER_RELEASE_SHA=<sha>\n
```

`python-dotenv` konnte diese Zeile nicht parsen; der nachgelagerte Hinweis auf einen fehlenden Mastodon-Token war nur ein Folgefehler.

Betroffene Production-Läufe:

- https://github.com/oklabflensburg/open-city-planner/actions/runs/32820602207
- https://github.com/oklabflensburg/open-city-planner/actions/runs/32822209079

## Lösung

- Die beiden `copy`-Tasks schreiben nur noch den bereinigten Environment-Inhalt.
- Der vorhandene `lineinfile`-Task verwaltet `STADTPLANER_RELEASE_SHA` anschließend als echte separate Zeile.
- Der Task läuft bedingungslos für Backend und Frontend, sowohl bei neu gelieferten als auch bei übernommenen Snapshots.
- `insertafter: EOF` ergänzt die Zeile am Dateiende, wenn sie fehlt; `regexp` ersetzt eine vorhandene Zeile.

PR #72 basiert auf der früheren Alembic-Hypothese und wird durch diesen bestätigten Root-Cause-Fix obsolet. Dieser PR übernimmt den Alembic-Workaround ausdrücklich nicht; Runtime-Security-Validierung und `get_settings()` bleiben unverändert.

## Tests

- `python -m unittest discover -s tests` — 35 Tests erfolgreich
- Syntaxchecks für alle sieben Production-/Betriebs-Playbooks erfolgreich
- `pnpm exec vitest run tests/ansible-deployment.test.ts` — 10 Tests erfolgreich
- `git diff --check` — erfolgreich

## Rollout / Rollback

Keine Schema- oder Konfigurationsänderung erforderlich. Ein erneuter Deploy erzeugt gültige releasegebundene dotenv-Snapshots. Rollback bleibt unverändert und stellt Code sowie beide Environment-Symlinks gemeinsam wieder her.