### PR TITLE
fix(ui): move mobile create action to FAB

### DIFF
--- a/frontend/app/components/layout/AppShell.vue
+++ b/frontend/app/components/layout/AppShell.vue
@@ -28,12 +28,18 @@
         <button class="map-action" :class="{ 'map-action-active': mapStore.activeGisPanel === 'analytics' }" type="button" aria-label="Analyse öffnen" :aria-pressed="mapStore.activeGisPanel === 'analytics'" @click="openAnalysis">
           <BarChart3 class="size-4" aria-hidden="true" /><span>Analyse</span>
         </button>
-        <ClientOnly>
-          <NuxtLink v-if="authStore.authenticated" class="map-action map-action-primary compact-create-action" to="/flaechen/neu" aria-label="Neue Fläche anlegen">
-            <Plus class="size-4" aria-hidden="true" /><span>Neue Fläche</span>
-          </NuxtLink>
-        </ClientOnly>
       </nav>
+      <ClientOnly>
+        <NuxtLink
+          v-if="authStore.authenticated && (mapStore.activeGisPanel === null || isCompact)"
+          class="mobile-create-fab absolute z-20"
+          to="/flaechen/neu"
+          aria-label="Neue Fläche anlegen"
+          data-mobile-create-fab
+        >
+          <Plus class="size-5" aria-hidden="true" />
+        </NuxtLink>
+      </ClientOnly>
     </section>
 
     <Transition name="gis-tool-panel">
@@ -214,14 +220,14 @@ function handlePopState() {
 .map-action:hover { background: #f1f5f9; }
 .map-action-active { border-color: #8baabd; background: #e2edf4; color: #154d73; }
 .map-action:focus-visible { outline: 2px solid #154d73; outline-offset: 2px; }
-.map-action-primary { border-color: #154d73; background: #154d73; color: white; }
-.map-action-primary:hover { background: #0f3f61; }
 .mobile-map-actions { bottom: calc(env(safe-area-inset-bottom) + 2.25rem); display: grid; width: min(calc(100% - 1rem), 25rem); max-width: calc(100% - 1rem); grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.375rem; }
-.mobile-map-actions .map-action-primary { grid-column: 1 / -1; grid-row: 1; }
+.mobile-create-fab { right: 1rem; bottom: calc(env(safe-area-inset-bottom) + 6.5rem); display: inline-flex; width: 3.25rem; height: 3.25rem; align-items: center; justify-content: center; border: 1px solid var(--c-primary-800); border-radius: 1rem; background: var(--c-primary-700); color: white; box-shadow: var(--shadow-floating); transition: background-color 150ms, box-shadow 150ms, transform 150ms; }
+.mobile-create-fab:hover { background: var(--c-primary-800); }
+.mobile-create-fab:focus-visible { outline: 2px solid var(--c-primary-600); outline-offset: 3px; }
+.mobile-create-fab:active { transform: translateY(1px); }
 
 @media (min-width: 480px) {
-  .mobile-map-actions { width: auto; grid-template-columns: repeat(4, max-content); }
-  .mobile-map-actions .map-action-primary { grid-column: auto; grid-row: auto; }
+  .mobile-map-actions { width: auto; grid-template-columns: repeat(3, max-content); }
 }
 @supports (height: 100dvh) { .overview-shell { height: calc(100dvh - var(--app-header-height)); } }
 
@@ -230,8 +236,9 @@ function handlePopState() {
   .overview-shell[data-compact-panel-open='true'] { grid-template-columns: minmax(0, 1fr) clamp(340px, 34vw, 420px); }
   .gis-map-stage { position: relative; inset: auto; padding: 0; }
   .mobile-map-actions { bottom: 1.25rem; }
+  .mobile-create-fab { right: 1.25rem; bottom: 5.5rem; }
 }
-@media (min-width: 1024px) and (max-width: 1279px) { .compact-create-action { display: none; } }
+@media (min-width: 1024px) { .mobile-create-fab { display: none; } }
 @media (min-width: 1280px) {
   .mobile-map-actions { display: none; }
   .overview-shell { display: grid; min-height: 620px; grid-template-columns: 272px minmax(0, 1fr) 312px; gap: 1rem; padding: 1rem; }
@@ -243,5 +250,5 @@ function handlePopState() {
 }
 .gis-tool-panel-enter-active, .gis-tool-panel-leave-active { transition: opacity 180ms ease-out, transform 220ms ease-out; }
 .gis-tool-panel-enter-from, .gis-tool-panel-leave-to { opacity: 0; transform: translateX(1rem); }
-@media (prefers-reduced-motion: reduce) { .overview-shell, .gis-tool-panel-enter-active, .gis-tool-panel-leave-active { transition: none; } }
+@media (prefers-reduced-motion: reduce) { .overview-shell, .mobile-create-fab, .gis-tool-panel-enter-active, .gis-tool-panel-leave-active { transition: none; } }
 </style>

--- a/frontend/e2e/header-create-cta.spec.ts
+++ b/frontend/e2e/header-create-cta.spec.ts
@@ -92,18 +92,42 @@ test('desktop create CTA stays on one line without colliding with adjacent actio
   expect(hydrationWarnings).toEqual([])
 })
 
-test('mobile keeps creation in navigation and the top bar overflow-free', async ({ page }) => {
+test('mobile exposes authenticated creation as a floating action without covering the tool bar', async ({ page }) => {
   await page.setViewportSize({ width: 430, height: 932 })
   const hydrationWarnings = trackHydrationWarnings(page)
-  await mockOverview(page)
+  const session = { authenticated: true }
+  await mockOverview(page, session)
   await page.goto('/karte')
 
   for (const width of [320, 390, 430]) {
     await page.setViewportSize({ width, height: 844 })
     await expect(page.getByRole('button', { name: 'Navigation öffnen' })).toBeVisible()
     await expect(page.locator('[data-header-create-cta]')).toBeHidden()
+    const actionBar = page.locator('[data-mobile-map-actions]')
+    const createFab = page.locator('[data-mobile-create-fab]')
+    await expect(actionBar.getByRole('button')).toHaveCount(3)
+    await expect(createFab).toBeVisible()
+    await expect(createFab).toHaveAttribute('href', '/flaechen/neu')
+    await expect(createFab).toHaveAttribute('aria-label', 'Neue Fläche anlegen')
+    const [actionBarBox, createFabBox] = await Promise.all([
+      actionBar.boundingBox(), createFab.boundingBox()
+    ])
+    expect(createFabBox!.width).toBeGreaterThanOrEqual(44)
+    expect(createFabBox!.height).toBeGreaterThanOrEqual(44)
+    expect(createFabBox!.x + createFabBox!.width).toBeLessThanOrEqual(width)
+    expect(createFabBox!.y + createFabBox!.height).toBeLessThan(actionBarBox!.y)
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true)
   }
+
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.screenshot({ path: 'test-results/mobile-create-fab-390.png' })
+  await page.getByRole('button', { name: 'Suche öffnen' }).click()
+  await expect(page.locator('[data-mobile-create-fab]')).toHaveCount(0)
+  await page.goBack()
+  await expect(page.locator('[data-mobile-create-fab]')).toBeVisible()
+  session.authenticated = false
+  await page.reload()
+  await expect(page.locator('[data-mobile-create-fab]')).toHaveCount(0)
   expect(hydrationWarnings).toEqual([])
 })
 

--- a/frontend/tests/mobile-gis-ui.test.ts
+++ b/frontend/tests/mobile-gis-ui.test.ts
@@ -90,15 +90,28 @@ describe('mobile GIS interface', () => {
     expect(appFile('components/ui/AppBottomSheet.vue')).toContain("querySelector<HTMLElement>('[data-sheet-autofocus]')")
   })
 
-  it('uses the released map space and keeps the four-action toolbar overflow-safe', () => {
+  it('keeps three GIS tools in the mobile bar and moves creation to an authenticated FAB', () => {
     const shell = appFile('components/layout/AppShell.vue')
     const padding = appFile('utils/mapViewportPadding.ts')
+    const actionBar = shell.slice(shell.indexOf('<nav'), shell.indexOf('</nav>'))
     expect(padding).toContain('top: 56')
     expect(padding).not.toContain('top: 104')
+    expect(actionBar.match(/<button class="map-action"/g)).toHaveLength(3)
+    expect(actionBar).toContain('aria-label="Suche öffnen"')
+    expect(actionBar).toContain('aria-label="Filter öffnen"')
+    expect(actionBar).toContain('aria-label="Analyse öffnen"')
+    expect(actionBar).not.toContain('/flaechen/neu')
     expect(shell).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))')
     expect(shell).toContain('@media (min-width: 480px)')
-    expect(shell).toContain('grid-template-columns: repeat(4, max-content)')
-    expect(shell).toContain('grid-column: 1 / -1')
+    expect(shell).toContain('grid-template-columns: repeat(3, max-content)')
+    expect(shell).not.toContain('grid-column: 1 / -1')
+    expect(shell).toContain('data-mobile-create-fab')
+    expect(shell).toContain('v-if="authStore.authenticated && (mapStore.activeGisPanel === null || isCompact)"')
+    expect(shell).toContain('to="/flaechen/neu"')
+    expect(shell).toContain('aria-label="Neue Fläche anlegen"')
+    expect(shell).toContain('bottom: calc(env(safe-area-inset-bottom) + 6.5rem)')
+    expect(shell).toContain('width: 3.25rem; height: 3.25rem')
+    expect(shell).toContain('@media (min-width: 1024px) { .mobile-create-fab { display: none; } }')
   })
 
   it('docks a bounded, non-modal panel beside the map in the compact workbench', () => {

--- a/frontend/tests/polygon-crud-ui.test.ts
+++ b/frontend/tests/polygon-crud-ui.test.ts
@@ -25,7 +25,7 @@ describe('polygon create and delete UI', () => {
     expect(header).toContain('<span class="whitespace-nowrap">Neue Fläche</span>')
     expect(header).toContain('aria-label="Neue Fläche anlegen"')
     expect(header).toContain('min-[1400px]:flex')
-    expect(shell).toContain('v-if="authStore.authenticated"')
+    expect(shell).toContain('v-if="authStore.authenticated && (mapStore.activeGisPanel === null || isCompact)"')
     expect(shell).toContain('to="/flaechen/neu"')
     expect(shell).toContain('aria-label="Neue Fläche anlegen"')
     expect(shell).toContain('<ClientOnly>')


### PR DESCRIPTION
## Problem

Auf kleinen Smartphones belegte die primäre Aktion „Neue Fläche“ innerhalb der mobilen Kartenaktionsleiste eine vollständige zusätzliche Zeile. Dadurch wurde ein erheblicher Teil der nutzbaren Kartenfläche dauerhaft verdeckt.

## Lösung

- „Neue Fläche“ wurde aus der mobilen Bottom-Bar entfernt.
- Die Bottom-Bar enthält jetzt ausschließlich die drei GIS-Werkzeuge:
  - Suche
  - Filter
  - Analyse
- Authentifizierte Nutzer erhalten stattdessen einen kompakten Floating Action Button oberhalb der Bottom-Bar.
- Der FAB verweist auf `/flaechen/neu` und besitzt das zugängliche Label `Neue Fläche anlegen`.
- Der FAB ist 52 × 52 Pixel groß und berücksichtigt die mobile Safe Area.
- Bei geöffnetem Mobile-Bottom-Sheet wird der FAB ausgeblendet.
- Im Compact-Modus bleibt er verfügbar, solange kein vorhandener Header-CTA übernimmt.
- Ab 1024 Pixel Breite wird weiterhin die bestehende Aktion im Header verwendet.
- Desktop-Verhalten, Kartenlogik und die Funktionen von Suche, Filter und Analyse bleiben unverändert.

## Barrierefreiheit und visuelle Integration

- Plus-Icon aus dem bestehenden Lucide-System
- vorhandene Farb- und Schatten-Tokens
- sichtbarer Tastaturfokus
- Touch-Fläche größer als 44 × 44 Pixel
- Unterstützung für `prefers-reduced-motion`
- ausreichender Abstand zur Bottom-Bar
- keine Kollision mit MapLibre-Steuerung oder Attribution

## Tests

- `pnpm test` — 425 Tests erfolgreich
- `pnpm typecheck` — erfolgreich
- `pnpm build` — erfolgreich
- `pnpm audit:language` — erfolgreich
- `pnpm exec vitest run tests/mobile-gis-ui.test.ts tests/polygon-crud-ui.test.ts` — 31 Tests erfolgreich
- `pnpm exec playwright test e2e/header-create-cta.spec.ts --workers=1` — 3 Tests erfolgreich
- gezielter Mobile-E2E-Test für:
  - authentifizierte und nicht authentifizierte Nutzer
  - Zielroute `/flaechen/neu`
  - Mindestgröße der Touch-Fläche
  - Position oberhalb der Bottom-Bar
  - Ausblenden beim geöffneten Bottom Sheet
  - Wiederherstellung über Browser-Zurück
  - fehlenden horizontalen Seitenüberlauf
- `git diff --check` — erfolgreich

## Umfang

Die Änderung ist auf `AppShell.vue` und die unmittelbar betroffenen Frontend- und E2E-Tests begrenzt. Backend, API, MapLibre-Datenlogik und GIS-Geschäftslogik wurden nicht verändert.

Closes #74