### PR TITLE
feat(home): simplify navigation and add signup CTA

### DIFF
--- a/frontend/app/composables/useSiteNavigation.ts
+++ b/frontend/app/composables/useSiteNavigation.ts
@@ -5,7 +5,6 @@ export type NavigationItem = {
 
 export function useSiteNavigation() {
   const primaryNavigation: NavigationItem[] = [
-    { label: 'Start', to: '/' },
     { label: 'Karte', to: '/karte' },
     { label: 'Gebiete', to: '/gebiete' },
     { label: 'Über das Projekt', to: '/ueber-das-projekt' },

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -20,6 +20,31 @@
     </section>
 
     <main class="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+      <section
+        v-if="showSignupCta"
+        data-home-signup-cta
+        class="mb-12 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+        aria-labelledby="signup-heading"
+      >
+        <div class="grid gap-7 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.75fr)] lg:items-center">
+          <div>
+            <p class="text-sm font-bold text-[#086b78]">Mit einem kostenlosen Konto</p>
+            <h2 id="signup-heading" class="mt-1 text-3xl font-black text-slate-950">Eigene Flächen dauerhaft verwalten</h2>
+            <p class="mt-3 max-w-2xl leading-7 text-slate-600">Mit einem kostenlosen Konto können Sie eigene Flächen anlegen, später wiederfinden und Ihre Arbeit im Stadtplaner fortführen.</p>
+            <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <NuxtLink class="page-button-primary w-full sm:w-auto" to="/registrieren">Kostenlos registrieren</NuxtLink>
+              <NuxtLink class="page-button-secondary w-full sm:w-auto" to="/login">Anmelden</NuxtLink>
+            </div>
+          </div>
+          <ul class="grid gap-3" aria-label="Vorteile eines Kontos">
+            <li v-for="benefit in accountBenefits" :key="benefit" class="flex min-h-12 items-center gap-3 rounded-xl bg-[#edf4f8] px-4 py-3 font-semibold text-slate-800">
+              <Check class="size-5 shrink-0 text-[#086b78]" aria-hidden="true" />
+              <span>{{ benefit }}</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
       <div v-if="error" class="rounded-xl border border-rose-200 bg-white p-5 text-rose-800" role="alert">Das öffentliche Verzeichnis konnte nicht geladen werden. Bitte versuchen Sie es später erneut.</div>
       <template v-else>
         <nav v-if="polygonGroups.length" class="mb-12 rounded-2xl border border-slate-200 bg-white p-5" aria-label="Branchenübersicht">
@@ -102,6 +127,7 @@
 </template>
 
 <script setup lang="ts">
+import { Check } from '@lucide/vue'
 import type { AnalysisArea, AnalysisAreaType } from '~/types/analysisArea'
 import type { OccupancyStatus, PolygonDirectoryItem } from '~/types/geo'
 import { buildApiUrl } from '~/utils/apiUrl'
@@ -109,6 +135,10 @@ import { buildAbsoluteUrl } from '~/utils/seo'
 import { getIndustryColor, getIndustryLabel, industries } from '~/utils/industries'
 
 const config = useRuntimeConfig()
+const authStore = useAuthStore()
+const mounted = ref(false)
+const showSignupCta = computed(() => !mounted.value || !authStore.authenticated)
+onMounted(() => { mounted.value = true })
 const { data, error } = await useAsyncData('public-home-directory', async () => {
   const [polygons, areas] = await Promise.all([
     usePolygonApi().directoryAll(),
@@ -137,6 +167,11 @@ const areaPreviewSrcset = (slug: string) => previewSrcset(`/analysis-areas/by-sl
 const areaTypeLabel = (type: AnalysisAreaType) => ({ MUNICIPALITY: 'Stadt', DISTRICT: 'Stadtteil', QUARTER: 'Statistischer Bezirk' })[type]
 const occupancyLabel = (status: OccupancyStatus) => ({ OCCUPIED: 'Belegt', VACANT: 'Leerstehend', UNKNOWN: 'Status unbekannt' })[status]
 const formatArea = (area: number) => `${new Intl.NumberFormat('de-DE', { maximumFractionDigits: 1 }).format(area / 1_000_000)} km²`
+const accountBenefits = [
+  'Eigene Flächen anlegen und speichern',
+  'Gespeicherte Flächen wieder aufrufen',
+  'Eigene Einträge verwalten und weiterbearbeiten'
+]
 const topics = [
   { title: 'Flächen und Leerstände', text: 'Öffentliche Verkaufsflächen nach Status, Branche und Lage finden und ihre Detaildaten nachvollziehen.', to: '/karte', link: 'Flächen auf der Karte erkunden' },
   { title: 'Gebiete vergleichen', text: 'Stadtteile und Quartiere anhand vorhandener Flächen-, Branchen- und Statistikdaten einordnen.', to: '/vergleich', link: 'Zum Gebietsvergleich' },

--- a/frontend/e2e/header-create-cta.spec.ts
+++ b/frontend/e2e/header-create-cta.spec.ts
@@ -107,6 +107,42 @@ test('mobile keeps creation in navigation and the top bar overflow-free', async 
   expect(hydrationWarnings).toEqual([])
 })
 
+test('homepage navigation and signup CTA adapt to viewport and session', async ({ page }) => {
+  const session = { authenticated: false }
+  const hydrationWarnings = trackHydrationWarnings(page)
+  await mockOverview(page, session)
+  await page.goto('/')
+  await page.waitForFunction(() => Boolean((document.querySelector('#__nuxt') as HTMLElement & { __vue_app__?: unknown })?.__vue_app__))
+  await expect(page.getByRole('banner').getByRole('link', { name: 'Anmelden' })).toBeVisible()
+
+  const logo = page.getByRole('banner').getByRole('link').first()
+  await expect(logo).toHaveAttribute('href', '/')
+  const desktopNavigation = page.getByRole('navigation', { name: 'Hauptnavigation' })
+  await expect(desktopNavigation.getByRole('link', { name: 'Start', exact: true })).toHaveCount(0)
+  for (const label of ['Karte', 'Gebiete', 'Über das Projekt', 'Dokumentation']) {
+    await expect(desktopNavigation.getByRole('link', { name: label, exact: true })).toHaveCount(1)
+  }
+
+  const signup = page.locator('[data-home-signup-cta]')
+  await expect(signup).toBeVisible()
+  await expect(signup.getByRole('link', { name: 'Kostenlos registrieren' })).toHaveAttribute('href', '/registrieren')
+  await expect(signup.getByRole('link', { name: 'Anmelden' })).toHaveAttribute('href', '/login')
+
+  await page.setViewportSize({ width: 320, height: 844 })
+  await page.getByRole('button', { name: 'Navigation öffnen' }).click()
+  const mobileNavigation = page.getByRole('navigation', { name: 'Mobile Navigation' })
+  await expect(mobileNavigation.getByRole('link', { name: 'Start', exact: true })).toHaveCount(0)
+  await expect(mobileNavigation.getByRole('link', { name: 'Karte', exact: true })).toBeVisible()
+  await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true)
+
+  session.authenticated = true
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.reload()
+  await expect(page.locator('[data-header-account]')).toBeVisible()
+  await expect(page.locator('[data-home-signup-cta]')).toHaveCount(0)
+  expect(hydrationWarnings).toEqual([])
+})
+
 test('account menu stays open until logout and ends the session', async ({ page }) => {
   const session = { authenticated: true }
   await mockOverview(page, session)

--- a/frontend/tests/seo-routes-ssr.test.ts
+++ b/frontend/tests/seo-routes-ssr.test.ts
@@ -106,6 +106,10 @@ describe('SEO routes over Nuxt HTTP', () => {
     expect(html).toContain('Flächen und Stadtgebiete auf einen Blick')
     expect(html).toContain('Flächen nach Branche')
     expect(html).toContain('Branchenübersicht')
+    expect(html).toContain('Eigene Flächen dauerhaft verwalten')
+    expect(html).toContain('Eigene Flächen anlegen und speichern')
+    expect(html).toContain('href="/registrieren"')
+    expect(html).toContain('href="/login"')
     expect(html).toContain('Testfläche')
     expect(html).toContain('Altstadt')
     for (const href of ['/karte', '/gebiete', '/vergleich', '/open-data', '/dokumentation/methodik', '/flaechen/test-flaeche']) {

--- a/frontend/tests/site-navigation.test.ts
+++ b/frontend/tests/site-navigation.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { useSiteNavigation } from '~/composables/useSiteNavigation'
+
+const appFile = (path: string) => readFileSync(fileURLToPath(new URL(`../app/${path}`, import.meta.url)), 'utf8')
+
+describe('site navigation', () => {
+  it('uses the logo as home link and omits the redundant Start item', () => {
+    const { primaryNavigation } = useSiteNavigation()
+
+    expect(primaryNavigation).toEqual([
+      { label: 'Karte', to: '/karte' },
+      { label: 'Gebiete', to: '/gebiete' },
+      { label: 'Über das Projekt', to: '/ueber-das-projekt' },
+      { label: 'Dokumentation', to: '/dokumentation' }
+    ])
+
+    const header = appFile('components/layout/AppHeader.vue')
+    expect(header).toContain('<NuxtLink class="group flex min-h-11 shrink-0 items-center rounded-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#154d73]" to="/"')
+    expect(header).toContain('v-for="item in primaryNavigation"')
+    expect(header).toContain(':primary-navigation="primaryNavigation"')
+    expect(appFile('components/layout/MobileNavigation.vue')).toContain('v-for="item in primaryNavigation"')
+  })
+})


### PR DESCRIPTION
## Ausgangslage

Der primäre Navigationspunkt „Start“ war redundant, da das vollständig fokussierbare OK-Lab-Flensburg-Logo bereits auf die Startseite verlinkt. Gleichzeitig erklärte die öffentliche Startseite Gästen bislang nicht, welchen konkreten Nutzen ein Konto bietet.

## Umsetzung

- „Start“ zentral aus `primaryNavigation` entfernt; Desktop- und Mobile-Navigation übernehmen die Änderung gemeinsam.
- Logo-Link auf `/`, Focus-State, Active-State-Logik und rechtliche Navigation unverändert beibehalten.
- Responsiven Gäste-CTA auf der Startseite ergänzt.
- Vorhandene Kontofunktionen beschrieben: eigene Flächen anlegen und speichern, wieder aufrufen sowie verwalten und weiterbearbeiten.
- „Kostenlos registrieren“ führt zu `/registrieren`, „Anmelden“ zu `/login`.
- CTA bleibt serverseitig gerendert und wird für authentifizierte Nutzer hydration-sicher ausgeblendet.
- Semantische Überschrift, echte Links und vorhandene Button- und Focus-Stile verwendet.

## Tests

- `pnpm test` — 77 Testdateien, 426 Tests erfolgreich
- `pnpm typecheck` — erfolgreich
- `pnpm build` — erfolgreich
- `pnpm audit:language` — 447 Ressourcen, 0 unerlaubte Treffer
- SSR-Routentests — 10 Tests erfolgreich
- Relevanter Playwright-Test — erfolgreich
- `git diff --check` — erfolgreich

## Betrieb

Keine Backend-, API-, Datenbank-, Migrations- oder Konfigurationsänderungen.

Closes #75