### PR TITLE
docs(readme): improve project presentation and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,97 @@
-# Stadtplaner Flensburg
+# Open City Planner
+
+**An open-source Web GIS for exploring, drawing, and analyzing urban areas.**
+
+Open City Planner is a civic-tech project by [OK Lab Flensburg](https://oklabflensburg.de/) that brings together OpenStreetMap, public data, and modern spatial analysis in an accessible web interface. The production instance currently uses Flensburg, Germany, as its reference implementation.
+
+**Making urban GIS accessible beyond GIS specialists.**
+
+[Live demo](https://stadtplaner.oklabflensburg.de/) · [Explore the map](https://stadtplaner.oklabflensburg.de/karte) · [Documentation](https://stadtplaner.oklabflensburg.de/dokumentation) · [Contributing](CONTRIBUTING.md)
 
 [![Backend CI](https://github.com/oklabflensburg/open-city-planner/actions/workflows/backend.yml/badge.svg)](https://github.com/oklabflensburg/open-city-planner/actions/workflows/backend.yml)
 [![Frontend CI](https://github.com/oklabflensburg/open-city-planner/actions/workflows/frontend.yml/badge.svg)](https://github.com/oklabflensburg/open-city-planner/actions/workflows/frontend.yml)
 [![E2E Tests](https://github.com/oklabflensburg/open-city-planner/actions/workflows/e2e.yml/badge.svg)](https://github.com/oklabflensburg/open-city-planner/actions/workflows/e2e.yml)
 [![Security](https://github.com/oklabflensburg/open-city-planner/actions/workflows/security.yml/badge.svg)](https://github.com/oklabflensburg/open-city-planner/actions/workflows/security.yml)
 
-![Screenshot Stadtplaner Flensburg](https://raw.githubusercontent.com/oklabflensburg/open-city-planner/main/screenshot_stadtplaner.webp)
+![Open City Planner web GIS showing urban areas and OpenStreetMap data in Flensburg](screenshot_stadtplaner.webp)
 
-Der Stadtplaner macht Verkaufsflächen, OpenStreetMap-Informationen, Analysegebiete und ausgewählte kommunale Kennzahlen für Flensburg auf einer interaktiven Karte zugänglich. Öffentliche Inhalte sind ohne Anmeldung lesbar; Bearbeitung und Verwaltung sind serverseitig geschützt.
+## Why Open City Planner?
 
-## Architektur
+Traditional GIS tools are powerful, but they often assume specialist knowledge. Open City Planner explores how spatial planning, OpenStreetMap data, and municipal open data can be made accessible through a modern browser interface.
 
-- `frontend/`: Nuxt 4, Vue 3, Tailwind CSS, MapLibre und Terra Draw;
-- `backend/`: FastAPI, SQLAlchemy, GeoAlchemy2 und Alembic;
-- PostgreSQL/PostGIS als fachliche Datenbank;
-- optionaler Redis-Read-Cache und produktives Backend für gemeinsame Sicherheitszähler;
-- lokale OpenStreetMap-Daten, kommunale Statistik und optionale externe Integrationen;
-- GitHub Actions für Backend, Frontend, Migrationen, E2E und Security.
+The goal is not to replace professional GIS software. It is to make common urban exploration and spatial analysis workflows easier to understand, use, and share.
 
-## Repository-Struktur
+## What can you do with it?
 
-```text
-backend/          API, Datenmodelle, Migrationen, CLI und Tests
-frontend/         Webanwendung, öffentliches Benutzerhandbuch und E2E-Tests
-docs/             technische Entwickler-, Architektur- und Betriebsdokumentation
-deploy/ansible/   reproduzierbares Produktionsdeployment
-deploy/nginx/     Stadtplaner-spezifische Nginx-Hardening-Vorlagen
-deploy/systemd/   mitgelieferte Units für Hintergrundaufgaben
-scripts/osm/      initialer OSM-Import und Replikationsupdate
+- Explore OpenStreetMap features alongside curated public city data.
+- Search for addresses, places, businesses, and analysis areas on the map.
+- Select districts and statistical areas and inspect their polygons, POIs, spatial metrics, and available municipal statistics.
+- Filter and analyze mapped areas by attributes such as industry, floor, size, and occupancy status.
+- Compare districts and other analysis areas using a shared set of metrics.
+- Draw and save your own polygons with Terra Draw and manage them from your account.
+
+Public information can be explored without an account. Authentication and authorization for editing and administrative workflows are enforced by the backend.
+
+## Try it
+
+- [Open the live application](https://stadtplaner.oklabflensburg.de/)
+- [Explore the interactive map](https://stadtplaner.oklabflensburg.de/karte)
+- [Open Flensburg Altstadt as a selected example area](https://stadtplaner.oklabflensburg.de/karte?gebiet=altstadt-15630273)
+
+The Altstadt link opens the map with an existing district selected, providing a direct example of the area-selection and analysis workflow.
+
+## Architecture
+
+The application combines a server-rendered web frontend, a spatial API, and reproducible data and deployment workflows.
+
+```mermaid
+flowchart LR
+    User[Browser] --> Nuxt[Nuxt 4 / Vue 3]
+    Nuxt --> MapLibre[MapLibre / Terra Draw]
+    Nuxt --> API[FastAPI]
+    MapLibre --> Tiles[VersaTiles vector tiles]
+    API --> PostGIS[(PostgreSQL / PostGIS)]
+    API -. optional read cache .-> Redis[(Redis)]
+    API -. configured geocoding .-> Nominatim[Nominatim]
+    OSM[OpenStreetMap data] --> Import[Import and sync jobs]
+    Municipal[Municipal open data] --> Import
+    Import --> PostGIS
 ```
 
-## Lokales Schnellsetup
+Core technologies:
 
-Die exakten Entwicklungsruntimes stehen in `.python-version`, `.node-version` und
-`frontend/package.json`. Zusätzlich werden uv 0.12.5 und PostgreSQL mit PostGIS benötigt.
+- **Frontend:** Nuxt 4, Vue 3, Pinia, Tailwind CSS, MapLibre, and Terra Draw.
+- **Backend:** FastAPI, SQLAlchemy, GeoAlchemy2, and Alembic.
+- **Data and infrastructure:** PostgreSQL/PostGIS, an optional Redis read cache, OpenStreetMap imports, VersaTiles, configured Nominatim integration, and municipal statistics.
+- **Delivery:** GitHub Actions for backend, frontend, migrations, E2E, security, and supply-chain checks; Ansible, Nginx, and systemd for production deployment.
 
-Backend:
+PostgreSQL/PostGIS remains the domain source of truth. Redis can cache public reads, and production deployments can also use it for shared security counters.
+
+## Use Open City Planner for another city
+
+Flensburg is the current reference deployment, but the project is being developed with reuse by other cities and civic-tech initiatives in mind.
+
+Some datasets, administrative boundaries, statistics, and external integrations are city-specific today and will require local adaptation. The project does not yet provide one-click deployment for arbitrary cities.
+
+If you are interested in adapting Open City Planner for another city, [open an issue](https://github.com/oklabflensburg/open-city-planner/issues) and tell us about your data, goals, and use case.
+
+## Repository structure
+
+```text
+backend/          API, data models, migrations, CLI tools, and tests
+frontend/         Web application, public user guide, and E2E tests
+docs/             Development, architecture, data, and operations documentation
+deploy/ansible/   Reproducible production deployment
+deploy/nginx/     Application-specific Nginx hardening templates
+deploy/systemd/   Units for the application and background jobs
+scripts/osm/      Initial OpenStreetMap import and replication updates
+```
+
+## Local development
+
+The exact development runtimes are defined in `.python-version`, `.node-version`, and `frontend/package.json`. You also need uv 0.12.5 and PostgreSQL with PostGIS.
+
+Set up and start the backend:
 
 ```bash
 cd backend
@@ -46,7 +102,7 @@ uv run alembic upgrade head
 uv run uvicorn app.main:app --reload
 ```
 
-Frontend in einem zweiten Terminal:
+Start the frontend in a second terminal:
 
 ```bash
 cd frontend
@@ -55,17 +111,23 @@ pnpm install --frozen-lockfile
 pnpm dev
 ```
 
-Das Frontend läuft standardmäßig auf `http://localhost:3000`, die API auf `http://localhost:8000`. Swagger UI ist unter `http://localhost:8000/docs` erreichbar.
+The frontend runs at `http://localhost:3000` by default, the API at `http://localhost:8000`, and Swagger UI at `http://localhost:8000/docs`.
 
-Die lokale Datenbank benötigt die PostGIS-Erweiterung. Alle Werte in den Environment-Beispielen sind vor einem Produktivbetrieb zu prüfen; Entwicklungs-Secrets dürfen nicht übernommen werden.
+The local database must have the PostGIS extension enabled. Review every value in the environment examples before production use, and never reuse development secrets in production.
 
 ## Tests
+
+Run backend linting and tests:
 
 ```bash
 cd backend
 .venv/bin/ruff check app tests
 .venv/bin/pytest
+```
 
+Run the frontend unit tests, TypeScript checks, production build, and German UI language audit:
+
+```bash
 cd ../frontend
 pnpm test
 pnpm typecheck
@@ -73,37 +135,57 @@ pnpm build
 pnpm audit:language
 ```
 
-Die E2E-Suite startet Frontend und Backend in einer isolierten Testumgebung:
+The E2E suite starts the frontend and backend in an isolated test environment:
 
 ```bash
 cd frontend
 pnpm test:e2e
 ```
 
-Die vollständigen CI-Jobs und stabilen Check-Namen stehen in [docs/ci.md](docs/ci.md).
+See [docs/ci.md](docs/ci.md) for the complete CI jobs and stable check names.
 
-## Dokumentation
+## Documentation
 
-- Das öffentliche Benutzerhandbuch ist in der Anwendung unter `/dokumentation` erreichbar und wird aus `frontend/app/config/documentation.ts` erzeugt.
-- [Technische Dokumentation](docs/README.md)
-- [Deployment und Betrieb](docs/deployment.md)
-- [Production Observability](docs/observability.md)
-- [Reproduzierbare Supply Chain](docs/supply-chain.md)
-- [Ansible-Deployment](deploy/ansible/README.md)
-- [Nginx-Hardening und Rate Limits](deploy/nginx/README.md)
-- [OpenStreetMap-Daten](docs/osm-data.md)
-- [Kommunale Statistik](docs/flensburg-statistics.md)
-- [Intelligente Suche](docs/intelligent-search.md) und [Stadtplaner-Assistent](docs/stadtplaner-assistant.md)
-- [Produktions-Sicherheitscheckliste](docs/security/production-checklist.md)
+The public user documentation is available [in the live application](https://stadtplaner.oklabflensburg.de/dokumentation) and is generated from `frontend/app/config/documentation.ts`. Most user and operations documentation is currently written in German.
 
-## Beiträge und Sicherheit
+### Development and architecture
 
-Hinweise für Issues, lokale Entwicklung und Pull Requests stehen in [CONTRIBUTING.md](CONTRIBUTING.md). Sicherheitslücken bitte nach [SECURITY.md](SECURITY.md) melden und nicht in einem öffentlichen Issue veröffentlichen.
+- [Technical documentation](docs/README.md)
+- [Intelligent search](docs/intelligent-search.md)
+- [Open City Planner assistant](docs/stadtplaner-assistant.md)
+- [Reproducible supply chain](docs/supply-chain.md)
 
-## Lizenz und Datenquellen
+### Operations and security
 
-Der Quellcode des Stadtplaners steht unter der **GNU Affero General Public License v3.0 (AGPL-3.0-only)**. Die vollständigen Lizenzbedingungen stehen in [LICENSE](LICENSE).
+- [Deployment and operations](docs/deployment.md)
+- [Production observability](docs/observability.md)
+- [Ansible deployment](deploy/ansible/README.md)
+- [Nginx hardening and rate limits](deploy/nginx/README.md)
+- [Production security checklist](docs/security/production-checklist.md)
 
-Die AGPL erlaubt Nutzung, Weitergabe und Veränderung des Quellcodes und stellt bei modifizierten, öffentlich über ein Netzwerk bereitgestellten Versionen sicher, dass Nutzerinnen und Nutzer Zugang zum entsprechenden Quellcode erhalten.
+### Data
 
-OpenStreetMap-Daten bleiben ihrer jeweiligen ODbL-Attribution unterworfen; kommunale Statistik nennt Quelle, Periode und Lizenz am Datensatz. Weitere eingebundene Daten und Abhängigkeiten behalten ihre jeweiligen Lizenzen.
+- [OpenStreetMap data](docs/osm-data.md)
+- [Municipal statistics for Flensburg](docs/flensburg-statistics.md)
+
+## Contributing
+
+Contributions are welcome—not only code. We are especially interested in contributions around:
+
+- GIS and MapLibre user experience;
+- OpenStreetMap integrations;
+- PostGIS and spatial analysis;
+- accessibility;
+- open-data integrations;
+- documentation and translations;
+- making the application reusable for other cities.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for the development and pull-request workflow. Report security vulnerabilities according to [SECURITY.md](SECURITY.md), not in a public issue.
+
+## License and data sources
+
+Open City Planner source code is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0-only)**. See [LICENSE](LICENSE) for the complete license terms.
+
+The AGPL permits use, distribution, and modification of the source code and requires corresponding source availability when modified versions are provided to users over a network.
+
+OpenStreetMap data remains subject to its applicable ODbL attribution requirements. Municipal statistics retain the source, period, and license recorded for each dataset. Other integrated data and dependencies retain their respective licenses.


### PR DESCRIPTION
## Summary

- adds an international project pitch, mission, and prominent live links
- introduces a verified feature overview and a direct Altstadt example
- adds a Mermaid architecture diagram based on the current deployment
- explains the Flensburg reference implementation and reuse considerations for other cities
- expands the invitation for GIS, OpenStreetMap, accessibility, open-data, documentation, and localization contributions
- preserves the existing local setup, tests, documentation, security, and license information in English

## Validation

- repository Markdown link test: 12/12 passed
- all 14 external README URLs returned HTTP 200
- GitHub GFM rendering checked through the Markdown API
- Mermaid 11.12.1 parser validation passed
- `screenshot_stadtplaner.webp` exists and uses updated descriptive alt text
- `git diff --check` passed

## Scope

Documentation-only change. No application, API, database, deployment, or CI behavior changed.