### PR TITLE
feat(seo): use native map previews for social cards

### DIFF
--- a/backend/tests/test_map_previews.py
+++ b/backend/tests/test_map_previews.py
@@ -10,7 +10,12 @@ from starlette.requests import Request
 import app.api.analysis_areas as analysis_area_api
 import app.api.polygons as polygon_api
 from app.schemas.polygon_directory import PolygonDirectoryItem
-from app.services.map_previews import MapPreview, MapPreviewRenderer, MapPreviewService
+from app.services.map_previews import (
+    MapPreview,
+    MapPreviewRenderer,
+    MapPreviewService,
+    NativeMapPreviewRenderer,
+)
 from app.services.polygon_directory import DIRECTORY_SQL, polygon_directory_page
 
 GEOMETRY = {
@@ -22,6 +27,7 @@ GEOMETRY = {
 class RecordingRenderer(MapPreviewRenderer):
     def __init__(self) -> None:
         self.calls = 0
+        self.sizes: list[tuple[int, int]] = []
 
     async def render(
         self,
@@ -34,16 +40,16 @@ class RecordingRenderer(MapPreviewRenderer):
         feature_kind: str,
     ) -> bytes:
         self.calls += 1
+        self.sizes.append((width, height))
         assert geometry == GEOMETRY
         assert bbox == (9.43, 54.78, 9.44, 54.79)
-        assert (width, height) == (640, 360)
         assert category == "food"
         assert feature_kind == "polygon"
         return b"RIFFxxxxWEBP"
 
 
 @pytest.mark.asyncio
-async def test_preview_cache_uses_version_style_and_dimensions(tmp_path) -> None:
+async def test_preview_cache_uses_updated_at_style_and_dimensions(tmp_path) -> None:
     style = tmp_path / "style.json"
     style.write_text('{"version":8}', encoding="utf-8")
     settings = SimpleNamespace(
@@ -67,14 +73,29 @@ async def test_preview_cache_uses_version_style_and_dimensions(tmp_path) -> None
     first = await service.get(**arguments)
     second = await service.get(**arguments)
     changed = await service.get(**{**arguments, "updated_at": updated_at + timedelta(seconds=1)})
+    style.write_text('{"version":8,"name":"changed"}', encoding="utf-8")
+    changed_style = await service.get(**arguments)
+    social_card = await service.get(**{**arguments, "width": 1200, "height": 630})
 
     assert first.body == b"RIFFxxxxWEBP"
     assert first.cache_hit is False
     assert second.cache_hit is True
     assert second.etag == first.etag
     assert changed.etag != first.etag
-    assert renderer.calls == 2
+    assert changed_style.etag != first.etag
+    assert social_card.etag != changed_style.etag
+    assert renderer.calls == 4
+    assert renderer.sizes == [(640, 360), (640, 360), (640, 360), (1200, 630)]
     assert not list((tmp_path / "cache").rglob("*.partial"))
+
+
+def test_preview_service_uses_native_renderer_by_default(tmp_path) -> None:
+    settings = SimpleNamespace(
+        map_preview_style_path=str(tmp_path / "style.json"),
+        map_preview_cache_dir=str(tmp_path / "cache"),
+    )
+
+    assert isinstance(MapPreviewService(settings).renderer, NativeMapPreviewRenderer)
 
 
 @pytest.mark.asyncio
@@ -199,17 +220,44 @@ async def test_polygon_preview_endpoint_returns_webp_and_honors_etag(monkeypatch
         AsyncMock(return_value=MapPreview(b"RIFFxxxxWEBP", '"preview-etag"', False)),
     )
 
-    response = await polygon_api.get_polygon_preview("test", object(), request(), 640, 360)
+    response = await polygon_api.get_polygon_preview("test", object(), request(), 1200, 630)
     not_modified = await polygon_api.get_polygon_preview(
-        "test", object(), request('"preview-etag"'), 640, 360
+        "test", object(), request('"preview-etag"'), 1200, 630
     )
 
     assert response.status_code == 200
     assert response.media_type == "image/webp"
     assert response.body == b"RIFFxxxxWEBP"
     assert response.headers["etag"] == '"preview-etag"'
+    assert response.headers["cache-control"] == (
+        "public, max-age=86400, stale-while-revalidate=604800"
+    )
     assert not_modified.status_code == 304
     assert not_modified.body == b""
+    polygon_api.map_preview_service.get.assert_awaited_with(
+        slug="test",
+        updated_at=polygon.updated_at,
+        geometry=GEOMETRY,
+        bbox=polygon.bbox,
+        width=1200,
+        height=630,
+        category="food",
+        feature_kind="polygon",
+    )
+
+
+@pytest.mark.asyncio
+async def test_polygon_preview_endpoint_returns_404_when_public_lookup_rejects_slug(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(polygon_api, "guard_public_query", AsyncMock())
+    monkeypatch.setattr(polygon_api, "public_polygon_by_slug", AsyncMock(return_value=None))
+
+    with pytest.raises(HTTPException) as error:
+        await polygon_api.get_polygon_preview("private", object(), request(), 1200, 630)
+
+    assert error.value.status_code == 404
+    assert error.value.detail == "Die Fläche wurde nicht gefunden."
 
 
 @pytest.mark.asyncio
@@ -230,12 +278,26 @@ async def test_area_preview_endpoint_returns_webp_and_unknown_slug_is_404(monkey
     )
 
     response = await analysis_area_api.get_area_preview(
-        "altstadt", object(), request(), 640, 360
+        "altstadt", object(), request(), 1200, 630
     )
     assert response.status_code == 200
     assert response.media_type == "image/webp"
+    assert response.headers["etag"] == '"area-etag"'
+    assert response.headers["cache-control"] == (
+        "public, max-age=86400, stale-while-revalidate=604800"
+    )
+    analysis_area_api.map_preview_service.get.assert_awaited_with(
+        slug="altstadt",
+        updated_at=area.updated_at,
+        geometry=GEOMETRY,
+        bbox=area.bbox,
+        width=1200,
+        height=630,
+        category=None,
+        feature_kind="area",
+    )
 
     detail.return_value = None
     with pytest.raises(HTTPException) as error:
-        await analysis_area_api.get_area_preview("missing", object(), request(), 640, 360)
+        await analysis_area_api.get_area_preview("missing", object(), request(), 1200, 630)
     assert error.value.status_code == 404

--- a/docs/map-previews.md
+++ b/docs/map-previews.md
@@ -1,6 +1,6 @@
 # Serverseitige Kartenvorschauen
 
-Die Startseite verwendet dynamische WebP-Kartenvorschauen für öffentliche Flächen und Analysegebiete. Der Produktionsrenderer ist kein Browser: `stadtplaner-map-renderer.service` lädt MapLibre Native in einem isolierten Node.js-Prozess auf `127.0.0.1:3020`. FastAPI kennt MapLibre nicht, sondern spricht ausschließlich mit der internen `MapPreviewRenderer`-Schnittstelle.
+Die Startseite verwendet dynamische WebP-Kartenvorschauen für öffentliche Flächen und Analysegebiete. Öffentliche Gebiets- und Flächendetailseiten verweisen in ihren serverseitigen OpenGraph- und Twitter-Metadaten auf dieselben FastAPI-Endpunkte mit 1200×630 Pixeln. Der Produktionsrenderer ist kein Browser: `stadtplaner-map-renderer.service` lädt MapLibre Native in einem isolierten Node.js-Prozess auf `127.0.0.1:3020`. FastAPI kennt MapLibre nicht, sondern spricht ausschließlich mit der internen `MapPreviewRenderer`-Schnittstelle.
 
 ## Technische Auswahl
 

--- a/frontend/app/composables/useAnalysisAreaSeo.ts
+++ b/frontend/app/composables/useAnalysisAreaSeo.ts
@@ -1,4 +1,5 @@
 import type { AnalysisAreaDetail } from '~/types/analysisArea'
+import { buildApiUrl } from '~/utils/apiUrl'
 import { buildAbsoluteUrl, buildBreadcrumbStructuredData, serializeStructuredData, toMetaDescription } from '~/utils/seo'
 
 export function useAnalysisAreaSeo(area: MaybeRefOrGetter<AnalysisAreaDetail>) {
@@ -13,6 +14,15 @@ export function useAnalysisAreaSeo(area: MaybeRefOrGetter<AnalysisAreaDetail>) {
       ? `${data.value.name} Flensburg – Standortanalyse | Stadtplaner`
       : `${data.value.name} – Standortdaten im Quartier | Stadtplaner Flensburg`)
   const description = computed(() => toMetaDescription('', `Statistische Kennzahlen, Standort- und Einzelhandelsdaten für ${data.value.name}: Verkaufsflächen, Leerstand, Branchen, Bevölkerung und POIs.`))
+  const image = computed(() => buildApiUrl(
+    config.public.apiBaseUrl,
+    `/analysis-areas/by-slug/${encodeURIComponent(data.value.slug)}/preview.webp?width=1200&height=630`
+  ))
+  const imageAlt = computed(() => data.value.area_type === 'MUNICIPALITY'
+    ? `Kartenansicht der Gemeinde ${data.value.name} im Stadtplaner`
+    : data.value.area_type === 'DISTRICT'
+      ? `Kartenansicht und Standortdaten für den Stadtteil ${data.value.name} im Stadtplaner Flensburg`
+      : `Kartenansicht und Standortdaten für das Quartier ${data.value.name} im Stadtplaner Flensburg`)
   const breadcrumbItems = computed(() => [
     { name: 'Start', path: '/' },
     { name: 'Gebiete', path: '/gebiete' },
@@ -48,9 +58,13 @@ export function useAnalysisAreaSeo(area: MaybeRefOrGetter<AnalysisAreaDetail>) {
     ogUrl: () => url.value,
     ogSiteName: config.public.siteName,
     ogLocale: config.public.siteLocale,
-    twitterCard: 'summary',
+    ogImage: () => image.value,
+    ogImageAlt: () => imageAlt.value,
+    twitterCard: 'summary_large_image',
     twitterTitle: () => title.value,
-    twitterDescription: () => description.value
+    twitterDescription: () => description.value,
+    twitterImage: () => image.value,
+    twitterImageAlt: () => imageAlt.value
   })
   useHead(() => ({
     link: [{ rel: 'canonical', href: url.value }],

--- a/frontend/app/composables/usePolygonSeo.ts
+++ b/frontend/app/composables/usePolygonSeo.ts
@@ -1,4 +1,5 @@
 import type { PublicPolygonDetail } from '~/types/geo'
+import { buildApiUrl } from '~/utils/apiUrl'
 import { buildAbsoluteUrl, buildBreadcrumbStructuredData, serializeStructuredData, toMetaDescription } from '~/utils/seo'
 
 export function usePolygonSeo(polygon: MaybeRefOrGetter<PublicPolygonDetail>) {
@@ -11,6 +12,11 @@ export function usePolygonSeo(polygon: MaybeRefOrGetter<PublicPolygonDetail>) {
     `Informationen zur Fläche „${data.value.name}“ mit Kategorie, Größe und interaktiver Kartendarstellung.`
   ))
   const title = computed(() => `${data.value.name} – ${config.public.siteName}`)
+  const image = computed(() => buildApiUrl(
+    config.public.apiBaseUrl,
+    `/polygons/by-slug/${encodeURIComponent(data.value.slug)}/preview.webp?width=1200&height=630`
+  ))
+  const imageAlt = computed(() => `Kartenansicht der Fläche „${data.value.name}“ mit Lage und öffentlichen Flächendaten im Stadtplaner Flensburg`)
   const structuredData = computed(() => [
     {
       '@context': 'https://schema.org',
@@ -41,9 +47,13 @@ export function usePolygonSeo(polygon: MaybeRefOrGetter<PublicPolygonDetail>) {
     ogUrl: () => url.value,
     ogSiteName: config.public.siteName,
     ogLocale: config.public.siteLocale,
-    twitterCard: 'summary',
+    ogImage: () => image.value,
+    ogImageAlt: () => imageAlt.value,
+    twitterCard: 'summary_large_image',
     twitterTitle: () => title.value,
-    twitterDescription: () => description.value
+    twitterDescription: () => description.value,
+    twitterImage: () => image.value,
+    twitterImageAlt: () => imageAlt.value
   })
   useHead(() => ({
     link: [{ rel: 'canonical', href: url.value }],

--- a/frontend/map-preview-renderer/rendering.test.ts
+++ b/frontend/map-preview-renderer/rendering.test.ts
@@ -60,4 +60,15 @@ describe('native map preview rendering helpers', () => {
     expect(validPayload({ ...payload, bbox: [9.45, 54.77, 9.42, 54.80] })).toBe(false)
     expect(validPayload({ ...payload, width: 801 })).toBe(false)
   })
+
+  it('accepts the 1200 by 630 social-card size', () => {
+    expect(validPayload({
+      geometry: { type: 'Polygon', coordinates: [[[9.43, 54.78], [9.44, 54.78], [9.44, 54.79], [9.43, 54.78]]] },
+      bbox: [9.42, 54.77, 9.45, 54.80],
+      width: 1200,
+      height: 630,
+      featureKind: 'area',
+      category: null
+    })).toBe(true)
+  })
 })

--- a/frontend/tests/seo-routes-ssr.test.ts
+++ b/frontend/tests/seo-routes-ssr.test.ts
@@ -3,6 +3,7 @@ import { fetch, setup } from '@nuxt/test-utils/e2e'
 import { describe, expect, it } from 'vitest'
 
 const siteUrl = 'https://stadtplaner.example'
+const apiBaseUrl = 'http://127.0.0.1:3012/api/v1'
 
 await setup({
   rootDir: fileURLToPath(new URL('..', import.meta.url)),
@@ -10,13 +11,13 @@ await setup({
   port: 3012,
   setupTimeout: 180_000,
   env: {
-    NUXT_PUBLIC_API_BASE_URL: 'http://127.0.0.1:3012/api/v1',
+    NUXT_PUBLIC_API_BASE_URL: apiBaseUrl,
     NUXT_PUBLIC_SITE_URL: siteUrl
   },
   nuxtConfig: {
     runtimeConfig: {
       public: {
-        apiBaseUrl: 'http://127.0.0.1:3012/api/v1',
+        apiBaseUrl,
         siteUrl
       }
     },
@@ -45,6 +46,15 @@ function expectCanonical(html: string, path: string, robots: 'index,follow' | 'n
   expect(links.find(item => item.rel === 'canonical')?.href).toBe(`${siteUrl}${path}`)
   expect(meta.find(item => item.property === 'og:url')?.content).toBe(`${siteUrl}${path}`)
   expect(meta.find(item => item.name === 'robots')?.content).toBe(robots)
+}
+
+function expectSocialImage(html: string, image: string, imageAlt: string) {
+  const meta = tags(html, 'meta').map(attributes)
+  expect(meta.find(item => item.property === 'og:image')?.content).toBe(image)
+  expect(meta.find(item => item.property === 'og:image:alt')?.content).toBe(imageAlt)
+  expect(meta.find(item => item.name === 'twitter:image')?.content).toBe(image)
+  expect(meta.find(item => item.name === 'twitter:image:alt')?.content).toBe(imageAlt)
+  expect(meta.find(item => item.name === 'twitter:card')?.content).toBe('summary_large_image')
 }
 
 describe('SEO routes over Nuxt HTTP', () => {
@@ -144,4 +154,24 @@ describe('SEO routes over Nuxt HTTP', () => {
       expect(html).toContain('Seite nicht gefunden')
     }
   )
+
+  it('renders the native area preview in OpenGraph and Twitter metadata', async () => {
+    const response = await fetch('/gebiete/altstadt')
+    expect(response.status).toBe(200)
+    expectSocialImage(
+      await response.text(),
+      `${apiBaseUrl}/analysis-areas/by-slug/altstadt/preview.webp?width=1200&height=630`,
+      'Kartenansicht und Standortdaten für den Stadtteil Altstadt im Stadtplaner Flensburg'
+    )
+  })
+
+  it('renders the native polygon preview in OpenGraph and Twitter metadata', async () => {
+    const response = await fetch('/flaechen/test-flaeche')
+    expect(response.status).toBe(200)
+    expectSocialImage(
+      await response.text(),
+      `${apiBaseUrl}/polygons/by-slug/test-flaeche/preview.webp?width=1200&height=630`,
+      'Kartenansicht der Fläche „Testfläche“ mit Lage und öffentlichen Flächendaten im Stadtplaner Flensburg'
+    )
+  })
 })


### PR DESCRIPTION
Closes #58

## Problem / Ausgangslage

Öffentliche Gebiets- und Flächendetailseiten lieferten bislang keine inhaltsspezifischen OpenGraph- und Twitter-Bilder. Der vorhandene MapLibre-Native-Preview-Service wurde dafür noch nicht in die SSR-Metadaten eingebunden.

## Umgesetzte Lösung

- Wiederverwendung des bestehenden internen MapLibre-Native-Services
- Keine Playwright- oder Browser-Pipeline für OG-Bilder
- Absolute FastAPI-Preview-URLs mit 1200 × 630 Pixeln
- Serverseitige Ausgabe von:
  - `og:image`
  - `og:image:alt`
  - `twitter:image`
  - `twitter:image:alt`
  - `twitter:card=summary_large_image`
- Bestehende Canonical URLs, Breadcrumbs, strukturierte Daten und reaktive SEO-Werte bleiben erhalten
- Weiterverwendung des persistenten Backend-Disk-Caches und der bestehenden ETags
- Nicht durch den öffentlichen Polygon-Resolver freigegebene Slugs liefern am Preview-Endpunkt `404`
- Kleine Preview-Größen sowie der bestehende Karten-, Highlight- und Attributionsaufbau bleiben unverändert

## Betroffene Bereiche

- Frontend-SEO-Composables für Gebiete und Flächen
- SSR-Metadaten-Tests
- Backend-Preview- und Cache-Regressionstests
- MapLibre-Native-Payload-Test
- Dokumentation der Kartenvorschauen

## Tests

- `pnpm test` – 77 Testdateien, 429 Tests bestanden
- `pnpm typecheck` – bestanden
- `pnpm build` – bestanden
- `pnpm audit:language` – 447 Ressourcen geprüft, 0 unerlaubte Treffer
- `ruff check app tests` – bestanden
- `pytest` – 606 Tests bestanden
- Backend-Import-Smoke-Test – bestanden
- `git diff --check` – bestanden

## Migration, Konfiguration und Rollout

- Keine Datenbankmigration
- Keine neue Konfiguration
- Keine neue Produktionskomponente
- Der bestehende `stadtplaner-map-renderer.service` wird unverändert weiterverwendet
- Der vorhandene FastAPI-Disk-Cache und ETag-Vertrag bleiben kompatibel
- Rollback durch Zurückrollen des Commits; bestehende Cache-Dateien können erhalten bleiben