### PR TITLE
test(seo): add SSR metadata release audit

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -62,6 +62,9 @@ jobs:
     name: Frontend production build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      NUXT_PUBLIC_API_BASE_URL: https://api.stadtplaner.example.test/api/v1
+      NUXT_PUBLIC_SITE_URL: https://stadtplaner.example.test
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -78,6 +81,9 @@ jobs:
       - name: Build Nuxt application
         working-directory: frontend
         run: pnpm build
+      - name: Audit production SSR metadata
+        working-directory: frontend
+        run: pnpm audit:seo
 
   frontend-language-audit:
     name: Frontend language audit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,7 @@ pnpm test
 pnpm typecheck
 pnpm build
 pnpm audit:language
+pnpm audit:seo
 ```
 
 Für Änderungen an wichtigen Nutzerwegen zusätzlich:

--- a/deploy/ansible/vault.example.yml
+++ b/deploy/ansible/vault.example.yml
@@ -197,6 +197,7 @@ stadtplaner_backend_env_content: |
 # Complete frontend/.env, snapshotted below /etc/stadtplaner/releases/<sha>/.
 stadtplaner_frontend_env_content: |
   NUXT_PUBLIC_API_BASE_URL=https://api.stadtplaner.oklabflensburg.de/api/v1
+  NUXT_API_INTERNAL_BASE_URL=
   NUXT_PUBLIC_SITE_URL=https://stadtplaner.oklabflensburg.de
   NUXT_PUBLIC_DEFAULT_OG_IMAGE=
   NUXT_PUBLIC_MEDIA_BASE_URL=https://api.stadtplaner.oklabflensburg.de

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,7 +14,7 @@ bei reinen Dokumentationsänderungen nicht.
 | Backend CI | `backend-migrations` | genau ein Alembic-Head und Upgrade einer frischen PostGIS-Datenbank |
 | Frontend CI | `frontend-tests` | vollständige Vitest-Suite |
 | Frontend CI | `frontend-typecheck` | Nuxt-/Vue-Typecheck |
-| Frontend CI | `frontend-build` | produktiver Nuxt-Build |
+| Frontend CI | `frontend-build` | produktiver Nuxt-Build und zentraler SSR-/SEO-Audit über Sitemap-, Noindex-, Redirect- und Fehler-Routen |
 | Frontend CI | `frontend-language-audit` | Audit der sichtbaren Sprache |
 | E2E Tests | `e2e` | vollständige Playwright-Suite mit echtem Frontend, Backend und frischer PostGIS-Datenbank |
 | Security | `security-policy-validation` | Format, Vollständigkeit und Ablauf befristeter Security-Ausnahmen sowie negative Policy-Tests |
@@ -68,7 +68,16 @@ pnpm test
 pnpm typecheck
 pnpm build
 pnpm audit:language
+pnpm audit:seo
 ```
+
+`pnpm audit:seo` startet den zuvor erzeugten Nitro-Production-Server und eine
+lokale Fixture-API auf freien Loopback-Ports. SSR-Aufrufe verwenden dabei die
+private `NUXT_API_INTERNAL_BASE_URL`; alle geprüften Canonical-, OpenGraph-,
+Twitter-, Sitemap- und JSON-LD-URLs verwenden weiterhin ausschließlich die
+production-artigen öffentlichen HTTPS-Origins. Der Audit crawlt alle
+Sitemap-Ziele sowie eine kompakte Matrix aus Noindex-, Auth-, Admin-,
+Social-Preview-, Redirect- und 404-Routen.
 
 E2E benötigt eine leere PostGIS-Datenbank. `DATABASE_URL` muss auf diese
 Testdatenbank zeigen:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,6 @@
 NUXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1
+# Optional private SSR/API base; defaults to NUXT_PUBLIC_API_BASE_URL.
+NUXT_API_INTERNAL_BASE_URL=
 NUXT_PUBLIC_SITE_URL=http://localhost:3000
 # Optional absolute or site-relative social preview asset, e.g. /og/default.webp
 NUXT_PUBLIC_DEFAULT_OG_IMAGE=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,11 +15,13 @@ pnpm dev
 pnpm test
 pnpm typecheck
 pnpm build
+pnpm audit:language
+pnpm audit:seo
 ```
 
-`NUXT_PUBLIC_API_BASE_URL` zeigt auf die FastAPI-Basis (typisch `http://localhost:8000/api/v1`). `NUXT_PUBLIC_SITE_URL` muss in Produktion die öffentliche Origin enthalten. Kartenstil, Startposition und optionale Medien-/OG-URLs werden über die Variablen in `.env.example` konfiguriert; ohne externen Kartenstil wird der lokale `stadtplaner-light`-Stil genutzt.
+`NUXT_PUBLIC_API_BASE_URL` zeigt auf die öffentliche FastAPI-Basis (typisch `http://localhost:8000/api/v1`). Optional kann `NUXT_API_INTERNAL_BASE_URL` ausschließlich für serverseitige/SSR-Aufrufe auf eine interne Basis zeigen; ohne den Wert wird die öffentliche API-Basis verwendet. `NUXT_PUBLIC_SITE_URL` muss in Produktion die öffentliche Origin enthalten. Kartenstil, Startposition und optionale Medien-/OG-URLs werden über die Variablen in `.env.example` konfiguriert; ohne externen Kartenstil wird der lokale `stadtplaner-light`-Stil genutzt.
 
-Alle `NUXT_PUBLIC_*`-Werte sind im Browser sichtbar und dürfen keine Secrets enthalten. Der produktive Build- und Deploymentablauf steht in [docs/deployment.md](../docs/deployment.md).
+Alle `NUXT_PUBLIC_*`-Werte sind im Browser sichtbar und dürfen keine Secrets enthalten. `NUXT_API_INTERNAL_BASE_URL` bleibt in der privaten Nuxt-Runtime-Konfiguration und darf nicht für Canonical-, OpenGraph-, Twitter-, JSON-LD- oder andere öffentliche URLs verwendet werden. Der produktive Build- und Deploymentablauf steht in [docs/deployment.md](../docs/deployment.md).
 
 ## Gebiete, SEO und Sitemap
 

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -105,7 +105,10 @@ export const useApi = () => {
     const csrf = csrfToken(options.method)
     if (csrf) headers.set('X-CSRF-Token', csrf)
 
-    return await fetch(buildApiUrl(config.public.apiBaseUrl, path), {
+    const baseUrl = import.meta.server
+      ? config.apiInternalBaseUrl || config.public.apiBaseUrl
+      : config.public.apiBaseUrl
+    return await fetch(buildApiUrl(baseUrl, path), {
       ...options,
       credentials: 'include',
       headers

--- a/frontend/app/pages/gebiete/index.vue
+++ b/frontend/app/pages/gebiete/index.vue
@@ -262,7 +262,11 @@ useSeoMeta({
   ogDescription: description,
   ogUrl: canonical,
   ogType: 'website',
-  twitterCard: 'summary'
+  ogSiteName: config.public.siteName,
+  ogLocale: config.public.siteLocale,
+  twitterCard: 'summary',
+  twitterTitle: title,
+  twitterDescription: description
 })
 useHead(() => ({
   link: [{ rel: 'canonical', href: canonical }],

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -65,6 +65,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     environment: process.env.APP_ENVIRONMENT || process.env.NODE_ENV || 'development',
     releaseSha: process.env.STADTPLANER_RELEASE_SHA || 'dev',
+    apiInternalBaseUrl: process.env.NUXT_API_INTERNAL_BASE_URL || '',
     public: {
       siteName: 'OK Lab Flensburg',
       siteUrl: configuredSiteUrl || 'http://localhost:3000',
@@ -103,8 +104,7 @@ export default defineNuxtConfig({
       '/**': { headers: securityHeaders },
       '/_nuxt/**': { headers: { 'cache-control': 'public, max-age=31536000, immutable' } },
       '/branding/**': { headers: { 'cache-control': 'public, max-age=86400' } },
-      '/map-styles/**': { headers: { 'cache-control': 'public, max-age=86400' } },
-      '/flaechen/neu': { redirect: { to: '/flaechen/neu/', statusCode: 301 } }
+      '/map-styles/**': { headers: { 'cache-control': 'public, max-age=86400' } }
     }
   },
   typescript: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "typecheck": "nuxt typecheck",
     "test": "vitest run",
     "audit:language": "node scripts/audit-ui-language.mjs",
+    "audit:seo": "node scripts/audit-seo.mjs",
     "test:e2e": "playwright test",
     "test:watch": "vitest",
     "map-style:build": "node scripts/build-map-style.mjs",

--- a/frontend/scripts/audit-seo.mjs
+++ b/frontend/scripts/audit-seo.mjs
@@ -1,0 +1,201 @@
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+import { access } from 'node:fs/promises'
+import {
+  auditIndexableHtml,
+  auditNoindexHtml,
+  auditNotFoundHtml,
+  hasLocalHost,
+  parseHtmlSeo,
+  robotsDisallowPaths,
+  sitemapLocations
+} from './seo-audit-lib.mjs'
+import { startSeoAuditFixtureApi } from './seo-audit-fixture-api.mjs'
+import {
+  DYNAMIC_PUBLIC_ROUTES,
+  NOINDEX_ROUTES,
+  NOT_FOUND_ROUTES,
+  REDIRECT_ROUTES,
+  SEO_AUDIT_PUBLIC_API_ORIGIN,
+  SEO_AUDIT_SITE_ORIGIN,
+  SOCIAL_PREVIEW_ROUTES
+} from './seo-route-matrix.mjs'
+
+const outputEntry = new URL('../.output/server/index.mjs', import.meta.url)
+const failures = []
+let fixture
+let frontend
+
+try {
+  await access(outputEntry)
+  fixture = await startSeoAuditFixtureApi()
+  const port = await availablePort()
+  frontend = startFrontend(port, fixture.baseUrl)
+  const baseUrl = `http://127.0.0.1:${port}`
+  await waitForServer(baseUrl, frontend)
+  await auditApplication(baseUrl)
+} catch (error) {
+  failures.push(`audit: ${error instanceof Error ? error.message : String(error)}`)
+} finally {
+  if (frontend && frontend.exitCode === null) frontend.kill('SIGTERM')
+  if (fixture) await fixture.close()
+}
+
+if (failures.length) {
+  console.error(`SEO audit failed with ${failures.length} violation${failures.length === 1 ? '' : 's'}:`)
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exitCode = 1
+} else {
+  console.log('SEO audit passed: production SSR, sitemap, robots, noindex, redirects and 404 routes are valid.')
+}
+
+async function auditApplication(baseUrl) {
+  const sitemapResponse = await fetch(`${baseUrl}/sitemap.xml`)
+  if (sitemapResponse.status !== 200) {
+    fail('/sitemap.xml', `expected HTTP 200, received ${sitemapResponse.status}`)
+    return
+  }
+  const sitemapXml = await sitemapResponse.text()
+  const locations = sitemapLocations(sitemapXml)
+  if (!locations.length) fail('/sitemap.xml', 'contains no URLs')
+  if (new Set(locations).size !== locations.length) fail('/sitemap.xml', 'contains duplicate URLs')
+
+  for (const dynamic of DYNAMIC_PUBLIC_ROUTES) {
+    if (!locations.includes(`${SEO_AUDIT_SITE_ORIGIN}${dynamic.path}`)) {
+      fail('/sitemap.xml', `missing dynamic fixture ${dynamic.path}`)
+    }
+  }
+
+  const robotsResponse = await fetch(`${baseUrl}/robots.txt`)
+  if (robotsResponse.status !== 200) fail('/robots.txt', `expected HTTP 200, received ${robotsResponse.status}`)
+  const robots = await robotsResponse.text()
+  const expectedSitemap = `Sitemap: ${SEO_AUDIT_SITE_ORIGIN}/sitemap.xml`
+  if (!robots.includes(expectedSitemap)) fail('/robots.txt', `missing ${expectedSitemap}`)
+  const disallowed = robotsDisallowPaths(robots)
+
+  for (const location of locations) {
+    let publicUrl
+    try { publicUrl = new URL(location) } catch { fail('/sitemap.xml', `invalid URL ${location}`); continue }
+    if (publicUrl.origin !== SEO_AUDIT_SITE_ORIGIN) fail('/sitemap.xml', `unexpected origin in ${location}`)
+    if (publicUrl.search) fail('/sitemap.xml', `query parameters in ${location}`)
+    if (hasLocalHost(location)) fail('/sitemap.xml', `local host in ${location}`)
+    if (disallowed.some(rule => publicUrl.pathname.startsWith(rule))) fail('/robots.txt', `blocks sitemap route ${publicUrl.pathname}`)
+
+    const response = await fetch(`${baseUrl}${publicUrl.pathname}`, { redirect: 'manual' })
+    if (response.status !== 200) {
+      fail(publicUrl.pathname, `expected HTTP 200 from sitemap, received ${response.status}`)
+      continue
+    }
+    const html = await response.text()
+    const dynamic = DYNAMIC_PUBLIC_ROUTES.find(item => item.path === publicUrl.pathname)
+    report(publicUrl.pathname, auditIndexableHtml(html, {
+      expectedUrl: location,
+      expectSocialImage: Boolean(dynamic)
+    }))
+    if (dynamic) auditDynamicSocialImage(publicUrl.pathname, html, dynamic.previewPath)
+  }
+
+  for (const route of NOINDEX_ROUTES) {
+    const response = await fetch(`${baseUrl}${route.path}`, { redirect: 'manual' })
+    if (response.status !== 200) fail(route.path, `expected HTTP 200 for ${route.type}, received ${response.status}`)
+    else report(route.path, auditNoindexHtml(await response.text()))
+    if (locations.includes(`${SEO_AUDIT_SITE_ORIGIN}${route.path}`)) fail('/sitemap.xml', `contains ${route.type} route ${route.path}`)
+  }
+
+  for (const route of SOCIAL_PREVIEW_ROUTES) {
+    const response = await fetch(`${baseUrl}${route.path}`, { redirect: 'manual' })
+    if (response.status !== 200) fail(route.path, `expected HTTP 200, received ${response.status}`)
+    else report(route.path, auditNoindexHtml(await response.text(), { canonicalUrl: `${SEO_AUDIT_SITE_ORIGIN}${route.canonicalPath}` }))
+  }
+
+  for (const path of NOT_FOUND_ROUTES) {
+    const response = await fetch(`${baseUrl}${path}`, {
+      redirect: 'manual',
+      headers: { Accept: 'text/html' }
+    })
+    if (response.status !== 404) fail(path, `expected HTTP 404, received ${response.status}`)
+    report(path, auditNotFoundHtml(await response.text()))
+  }
+
+  for (const route of REDIRECT_ROUTES) {
+    const response = await fetch(`${baseUrl}${route.path}`, { redirect: 'manual' })
+    if (response.status !== route.status) fail(route.path, `expected HTTP ${route.status}, received ${response.status}`)
+    const location = response.headers.get('location')
+    if (!location) { fail(route.path, 'redirect is missing Location'); continue }
+    const target = new URL(location, SEO_AUDIT_SITE_ORIGIN)
+    if (`${target.pathname}${target.search}` !== route.target) fail(route.path, `redirect target is ${target.pathname}${target.search}, expected ${route.target}`)
+    const targetResponse = await fetch(`${baseUrl}${route.target}`, { redirect: 'manual' })
+    if (targetResponse.status >= 300 && targetResponse.status < 400) fail(route.path, 'redirect target starts another redirect')
+  }
+}
+
+function auditDynamicSocialImage(path, html, expectedPath) {
+  const page = parseHtmlSeo(html)
+  const values = [
+    page.meta.find(item => item.property === 'og:image')?.content,
+    page.meta.find(item => item.name === 'twitter:image')?.content
+  ]
+  for (const value of values) {
+    if (!value) continue
+    const url = new URL(value)
+    if (url.origin !== SEO_AUDIT_PUBLIC_API_ORIGIN) fail(path, `social image uses unexpected origin ${url.origin}`)
+    if (url.pathname !== expectedPath) fail(path, `social image uses unexpected path ${url.pathname}`)
+    if (url.searchParams.get('width') !== '1200' || url.searchParams.get('height') !== '630') {
+      fail(path, 'social image is not 1200x630')
+    }
+  }
+}
+
+function startFrontend(port, internalApiBaseUrl) {
+  const child = spawn(process.execPath, [outputEntry.pathname], {
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      NITRO_HOST: '127.0.0.1',
+      NITRO_PORT: String(port),
+      NUXT_API_INTERNAL_BASE_URL: internalApiBaseUrl,
+      NUXT_PUBLIC_API_BASE_URL: `${SEO_AUDIT_PUBLIC_API_ORIGIN}/api/v1`,
+      NUXT_PUBLIC_SITE_URL: SEO_AUDIT_SITE_ORIGIN
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+  let logs = ''
+  const capture = chunk => { logs = `${logs}${chunk}`.slice(-4000) }
+  child.stdout.on('data', capture)
+  child.stderr.on('data', capture)
+  child.auditLogs = () => logs
+  return child
+}
+
+async function waitForServer(baseUrl, child) {
+  const deadline = Date.now() + 20_000
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`production server exited with ${child.exitCode}: ${child.auditLogs()}`)
+    try {
+      const response = await fetch(`${baseUrl}/robots.txt`)
+      if (response.ok) return
+    } catch { /* server is still starting */ }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(`production server did not become ready: ${child.auditLogs()}`)
+}
+
+async function availablePort() {
+  const server = createServer()
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('Could not reserve SEO audit port')
+  await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+  return address.port
+}
+
+function report(path, messages) {
+  for (const message of messages) fail(path, message)
+}
+
+function fail(path, message) {
+  failures.push(`${path}: ${message}`)
+}

--- a/frontend/scripts/seo-audit-fixture-api.mjs
+++ b/frontend/scripts/seo-audit-fixture-api.mjs
@@ -1,0 +1,161 @@
+import { createServer } from 'node:http'
+import { SEO_AUDIT_AREA_SLUG, SEO_AUDIT_POLYGON_SLUG } from './seo-route-matrix.mjs'
+
+const timestamp = '2026-08-24T10:00:00Z'
+const areaTimestamp = '2026-08-24T09:00:00Z'
+const areaId = '11111111-1111-4111-8111-111111111111'
+
+const area = {
+  id: areaId,
+  slug: SEO_AUDIT_AREA_SLUG,
+  name: 'Audit-Altstadt',
+  area_type: 'DISTRICT',
+  parent_id: null,
+  parent_name: null,
+  parent_slug: null,
+  area_m2: 1_000_000,
+  source: 'OSM',
+  source_osm_type: 'relation',
+  source_osm_id: 123,
+  source_admin_level: 10,
+  source_place: null,
+  source_updated_at: areaTimestamp,
+  updated_at: areaTimestamp,
+  child_count: 0,
+  external_links: { wikidata: null, wikipedia: null }
+}
+
+const metrics = {
+  polygon_count: 1,
+  occupied_count: 1,
+  vacant_count: 0,
+  chain_count: 0,
+  independent_count: 1,
+  total_area_m2: 120,
+  average_area_m2: 120,
+  median_area_m2: 120,
+  vacancy_rate: 0,
+  chain_store_rate: 0,
+  known_occupancy_count: 1,
+  known_business_structure_count: 1,
+  data_updated_at: timestamp
+}
+
+const polygon = {
+  id: '22222222-2222-4222-8222-222222222222',
+  slug: SEO_AUDIT_POLYGON_SLUG,
+  name: 'Audit-Testfläche',
+  description: 'Deterministische öffentliche Audit-Fläche.',
+  floor: 'EG',
+  area_size: 'M',
+  address_display_name: 'Teststraße 1, 24937 Flensburg',
+  address_street: 'Teststraße',
+  address_house_number: '1',
+  address_postal_code: '24937',
+  address_city: 'Flensburg',
+  address_country: 'Deutschland',
+  address_lookup_status: 'resolved',
+  category: 'food',
+  occupancy_status: 'OCCUPIED',
+  occupancy_source: 'MANUAL',
+  business_structure: 'INDEPENDENT',
+  geometry: {
+    type: 'Polygon',
+    coordinates: [[[9.43, 54.78], [9.431, 54.78], [9.431, 54.781], [9.43, 54.78]]]
+  },
+  osm_sources: [],
+  external_links: { wikidata: null, wikipedia: null },
+  area_m2: 120,
+  perimeter_m: 48,
+  centroid: [9.4305, 54.7805],
+  bbox: [9.43, 54.78, 9.431, 54.781],
+  created_at: timestamp,
+  updated_at: timestamp
+}
+
+export async function startSeoAuditFixtureApi() {
+  const server = createServer((request, response) => {
+    const url = new URL(request.url || '/', 'http://fixture.invalid')
+    const result = fixtureResponse(url.pathname)
+    response.writeHead(result.status, {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store'
+    })
+    response.end(JSON.stringify(result.body))
+  })
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('SEO fixture API did not bind to TCP')
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    close: () => new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+  }
+}
+
+function fixtureResponse(path) {
+  if (path === '/api/v1/polygons/sitemap') return ok([{ slug: polygon.slug, updated_at: polygon.updated_at }])
+  if (path === '/api/v1/analysis-areas/sitemap') return ok([{ slug: area.slug, updated_at: area.updated_at }])
+  if (path === '/api/v1/polygons/directory') {
+    return ok({
+      items: [{
+        slug: polygon.slug,
+        name: polygon.name,
+        category: polygon.category,
+        floor: polygon.floor,
+        address_display_name: polygon.address_display_name,
+        occupancy_status: polygon.occupancy_status,
+        business_structure: polygon.business_structure,
+        district_slug: area.slug,
+        district_name: area.name,
+        quarter_slug: null,
+        quarter_name: null,
+        updated_at: polygon.updated_at
+      }],
+      total: 1,
+      offset: 0,
+      limit: 250,
+      next_offset: null
+    })
+  }
+  if (path === '/api/v1/analysis-areas') return ok([area])
+  if (path === `/api/v1/polygons/by-slug/${polygon.slug}`) return ok(polygon)
+  if (path.startsWith('/api/v1/polygons/by-slug/')) return notFound('Die Fläche wurde nicht gefunden.')
+  if (path === `/api/v1/analysis-areas/by-slug/${area.slug}`) {
+    return ok({
+      ...area,
+      parent: null,
+      municipality: null,
+      children: [],
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [[[[9.42, 54.77], [9.44, 54.77], [9.44, 54.79], [9.42, 54.77]]]]
+      },
+      centroid: [9.43, 54.78],
+      bbox: [9.42, 54.77, 9.44, 54.79]
+    })
+  }
+  if (path === `/api/v1/analysis-areas/by-slug/${area.slug}/analytics`) {
+    return ok({ area, metrics, industry_distribution: [], poi_count: 0, poi_categories: [], retail_area_density_m2_per_km2: 120 })
+  }
+  if (path === `/api/v1/analysis-areas/by-slug/${area.slug}/comparison`) {
+    return ok({ area, municipality: area, area_metrics: metrics, municipality_metrics: metrics, differences: [] })
+  }
+  if (path === `/api/v1/analysis-areas/by-slug/${area.slug}/polygons`) return ok([])
+  if (path === `/api/v1/analysis-areas/by-slug/${area.slug}/statistics`) {
+    const reference = { id: area.id, slug: area.slug, name: area.name, area_type: area.area_type }
+    return ok({ area: reference, statistics_area: reference, inherited_from_parent: false, source: null, latest: [] })
+  }
+  if (path.startsWith('/api/v1/analysis-areas/by-slug/')) return notFound('Das Gebiet wurde nicht gefunden.')
+  return notFound('SEO-Audit-Fixture nicht definiert.')
+}
+
+function ok(body) {
+  return { status: 200, body }
+}
+
+function notFound(message) {
+  return { status: 404, body: { detail: message } }
+}

--- a/frontend/scripts/seo-audit-lib.mjs
+++ b/frontend/scripts/seo-audit-lib.mjs
@@ -30,7 +30,7 @@ export function parseHtmlSeo(html) {
     .map(match => textContent(match[1]))
   const headings = [...html.matchAll(/<h1\b[^>]*>([\s\S]*?)<\/h1>/gi)]
     .map(match => textContent(match[1]))
-  const jsonLd = [...html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)]
+  const jsonLd = [...html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi)]
     .filter(match => attributes(`<script ${match[1]}>`).type === 'application/ld+json')
     .map(match => decodeHtml(match[2]).trim())
   return { meta, links, titles, headings, jsonLd }

--- a/frontend/scripts/seo-audit-lib.mjs
+++ b/frontend/scripts/seo-audit-lib.mjs
@@ -1,0 +1,188 @@
+const LOCAL_HOST_PATTERN = /(?:localhost|127\.0\.0\.1|\[?::1\]?)/i
+const KNOWN_SCHEMA_TYPES = new Set([
+  'AdministrativeArea', 'BreadcrumbList', 'CollectionPage', 'FAQPage', 'ItemList',
+  'ListItem', 'Place', 'Question', 'Answer', 'SoftwareApplication', 'WebPage', 'WebSite'
+])
+
+export function attributes(tag) {
+  return Object.fromEntries(
+    [...tag.matchAll(/([:\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g)]
+      .map(match => [match[1].toLowerCase(), decodeHtml(match[2] ?? match[3] ?? '')])
+  )
+}
+
+export function decodeHtml(value) {
+  return value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&apos;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&')
+    .replace(/&#(\d+);/g, (_match, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([\da-f]+);/gi, (_match, code) => String.fromCodePoint(Number.parseInt(code, 16)))
+}
+
+export function parseHtmlSeo(html) {
+  const meta = [...html.matchAll(/<meta\b[^>]*>/gi)].map(match => attributes(match[0]))
+  const links = [...html.matchAll(/<link\b[^>]*>/gi)].map(match => attributes(match[0]))
+  const titles = [...html.matchAll(/<title\b[^>]*>([\s\S]*?)<\/title>/gi)]
+    .map(match => textContent(match[1]))
+  const headings = [...html.matchAll(/<h1\b[^>]*>([\s\S]*?)<\/h1>/gi)]
+    .map(match => textContent(match[1]))
+  const jsonLd = [...html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)]
+    .filter(match => attributes(`<script ${match[1]}>`).type === 'application/ld+json')
+    .map(match => decodeHtml(match[2]).trim())
+  return { meta, links, titles, headings, jsonLd }
+}
+
+export function auditIndexableHtml(html, { expectedUrl, expectSocialImage = false } = {}) {
+  const errors = []
+  const page = parseHtmlSeo(html)
+  const canonical = page.links.filter(item => item.rel === 'canonical')
+  const description = namedMeta(page.meta, 'description')
+  const robots = namedMeta(page.meta, 'robots')
+  const canonicalUrl = canonical[0]?.href
+
+  if (page.titles.length !== 1) errors.push(`expected exactly one title, received ${page.titles.length}`)
+  else if (page.titles[0].length < 3) errors.push('title is empty or too short')
+  if (description.length !== 1 || !description[0].content?.trim()) errors.push('missing or empty meta description')
+  if (robots.length !== 1 || robots[0].content !== 'index,follow') errors.push('expected robots=index,follow')
+  if (canonical.length !== 1) errors.push(`expected exactly one canonical, received ${canonical.length}`)
+  if (!page.headings.some(Boolean)) errors.push('missing non-empty SSR h1')
+
+  if (canonicalUrl) {
+    validatePublicUrl(canonicalUrl, 'canonical', errors)
+    if (expectedUrl && canonicalUrl !== expectedUrl) errors.push(`canonical is ${canonicalUrl}, expected ${expectedUrl}`)
+    try {
+      if (new URL(canonicalUrl).search) errors.push('canonical contains query parameters')
+    } catch { /* reported by validatePublicUrl */ }
+  }
+
+  for (const key of ['og:title', 'og:description', 'og:url', 'og:type', 'og:site_name']) {
+    const values = propertyMeta(page.meta, key)
+    if (values.length !== 1 || !values[0].content?.trim()) errors.push(`missing or duplicate ${key}`)
+  }
+  if (canonicalUrl && propertyMeta(page.meta, 'og:url')[0]?.content !== canonicalUrl) {
+    errors.push('og:url does not match canonical')
+  }
+  for (const key of ['twitter:card', 'twitter:title', 'twitter:description']) {
+    const values = namedMeta(page.meta, key)
+    if (values.length !== 1 || !values[0].content?.trim()) errors.push(`missing or duplicate ${key}`)
+  }
+  if (expectSocialImage) {
+    for (const [kind, key] of [['property', 'og:image'], ['property', 'og:image:alt'], ['name', 'twitter:image'], ['name', 'twitter:image:alt']]) {
+      const values = kind === 'property' ? propertyMeta(page.meta, key) : namedMeta(page.meta, key)
+      if (values.length !== 1 || !values[0].content?.trim()) errors.push(`missing or duplicate ${key}`)
+    }
+    if (namedMeta(page.meta, 'twitter:card')[0]?.content !== 'summary_large_image') {
+      errors.push('expected twitter:card=summary_large_image')
+    }
+  }
+
+  auditSeoUrls(page, errors)
+  auditJsonLd(page.jsonLd, errors)
+  return errors
+}
+
+export function auditNoindexHtml(html, { canonicalUrl } = {}) {
+  const errors = []
+  const page = parseHtmlSeo(html)
+  const robots = namedMeta(page.meta, 'robots')
+  if (robots.length !== 1 || robots[0].content !== 'noindex,nofollow') {
+    errors.push('expected robots=noindex,nofollow')
+  }
+  if (canonicalUrl) {
+    const canonicals = page.links.filter(item => item.rel === 'canonical')
+    if (canonicals.length !== 1 || canonicals[0].href !== canonicalUrl) {
+      errors.push(`expected canonical ${canonicalUrl}`)
+    }
+  }
+  auditSeoUrls(page, errors)
+  auditJsonLd(page.jsonLd, errors)
+  return errors
+}
+
+export function auditNotFoundHtml(html) {
+  const errors = auditNoindexHtml(html)
+  const page = parseHtmlSeo(html)
+  if (page.links.some(item => item.rel === 'canonical')) errors.push('404 page must not define a canonical')
+  if (!page.headings.some(Boolean)) errors.push('404 page has no non-empty SSR h1')
+  return errors
+}
+
+export function sitemapLocations(xml) {
+  return [...xml.matchAll(/<loc>([\s\S]*?)<\/loc>/gi)].map(match => decodeHtml(match[1].trim()))
+}
+
+export function robotsDisallowPaths(text) {
+  return [...text.matchAll(/^Disallow:\s*(\S+)\s*$/gmi)].map(match => match[1])
+}
+
+export function hasLocalHost(value) {
+  return LOCAL_HOST_PATTERN.test(value)
+}
+
+function namedMeta(meta, name) {
+  return meta.filter(item => item.name?.toLowerCase() === name)
+}
+
+function propertyMeta(meta, property) {
+  return meta.filter(item => item.property?.toLowerCase() === property)
+}
+
+function textContent(value) {
+  return decodeHtml(value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim())
+}
+
+function validatePublicUrl(value, label, errors) {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'https:') errors.push(`${label} must use https`)
+    if (hasLocalHost(url.hostname)) errors.push(`${label} points to a local host`)
+  } catch {
+    errors.push(`${label} is not an absolute URL`)
+  }
+}
+
+function auditSeoUrls(page, errors) {
+  const urls = [
+    ...page.links.filter(item => item.rel === 'canonical').map(item => ['canonical', item.href]),
+    ...propertyMeta(page.meta, 'og:url').map(item => ['og:url', item.content]),
+    ...propertyMeta(page.meta, 'og:image').map(item => ['og:image', item.content]),
+    ...namedMeta(page.meta, 'twitter:image').map(item => ['twitter:image', item.content])
+  ]
+  for (const [label, value] of urls) if (value) validatePublicUrl(value, label, errors)
+}
+
+function auditJsonLd(blocks, errors) {
+  blocks.forEach((block, index) => {
+    let value
+    try { value = JSON.parse(block) } catch { errors.push(`invalid JSON-LD block ${index + 1}`); return }
+    const entries = Array.isArray(value) ? value : [value]
+    for (const entry of entries) validateSchemaEntry(entry, index, errors)
+    if (hasLocalHost(JSON.stringify(value))) errors.push(`JSON-LD block ${index + 1} contains a local host`)
+  })
+}
+
+function validateSchemaEntry(entry, index, errors) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    errors.push(`JSON-LD block ${index + 1} must contain objects`)
+    return
+  }
+  if (entry['@context'] !== 'https://schema.org') errors.push(`JSON-LD block ${index + 1} has an invalid @context`)
+  const types = Array.isArray(entry['@type']) ? entry['@type'] : [entry['@type']]
+  if (!types.every(type => typeof type === 'string' && type)) errors.push(`JSON-LD block ${index + 1} is missing @type`)
+  for (const type of types.filter(type => KNOWN_SCHEMA_TYPES.has(type))) {
+    if (['AdministrativeArea', 'CollectionPage', 'Place', 'WebPage', 'WebSite'].includes(type)
+      && !entry.url && !entry['@id']) {
+      errors.push(`JSON-LD ${type} in block ${index + 1} is missing url/@id`)
+    }
+    if (['BreadcrumbList', 'ItemList'].includes(type) && !Array.isArray(entry.itemListElement)) {
+      errors.push(`JSON-LD ${type} in block ${index + 1} is missing itemListElement`)
+    }
+  }
+  for (const key of ['url', '@id']) {
+    if (typeof entry[key] === 'string') validatePublicUrl(entry[key], `JSON-LD ${key}`, errors)
+  }
+}

--- a/frontend/scripts/seo-route-matrix.mjs
+++ b/frontend/scripts/seo-route-matrix.mjs
@@ -1,0 +1,47 @@
+export const SEO_AUDIT_SITE_ORIGIN = 'https://stadtplaner.example.test'
+export const SEO_AUDIT_PUBLIC_API_ORIGIN = 'https://api.stadtplaner.example.test'
+export const SEO_AUDIT_AREA_SLUG = 'audit-altstadt'
+export const SEO_AUDIT_POLYGON_SLUG = 'audit-testflaeche'
+
+export const DYNAMIC_PUBLIC_ROUTES = [
+  {
+    path: `/gebiete/${SEO_AUDIT_AREA_SLUG}`,
+    previewPath: `/api/v1/analysis-areas/by-slug/${SEO_AUDIT_AREA_SLUG}/preview.webp`
+  },
+  {
+    path: `/flaechen/${SEO_AUDIT_POLYGON_SLUG}`,
+    previewPath: `/api/v1/polygons/by-slug/${SEO_AUDIT_POLYGON_SLUG}/preview.webp`
+  }
+]
+
+export const NOINDEX_ROUTES = [
+  { path: '/login', type: 'public-noindex' },
+  { path: '/registrieren', type: 'public-noindex' },
+  { path: '/passwort-vergessen', type: 'public-noindex' },
+  { path: '/passwort-zuruecksetzen', type: 'public-noindex' },
+  { path: '/email-bestaetigen', type: 'public-noindex' },
+  { path: '/email-abmelden', type: 'public-noindex' },
+  { path: '/auth/callback', type: 'auth' },
+  { path: '/auth/mfa', type: 'auth' },
+  { path: '/profil', type: 'auth' },
+  { path: '/meine-flaechen', type: 'auth' },
+  { path: '/flaechen/neu', type: 'auth' },
+  { path: '/admin/social', type: 'admin/internal' },
+  { path: '/verwaltung/kennzahlen', type: 'admin/internal' }
+]
+
+export const SOCIAL_PREVIEW_ROUTES = [
+  { path: '/karte?social-preview=1', canonicalPath: '/karte' },
+  { path: `/gebiete/${SEO_AUDIT_AREA_SLUG}?social-preview=1&map=0`, canonicalPath: `/gebiete/${SEO_AUDIT_AREA_SLUG}` },
+  { path: `/flaechen/${SEO_AUDIT_POLYGON_SLUG}?social-preview=1&map=0`, canonicalPath: `/flaechen/${SEO_AUDIT_POLYGON_SLUG}` }
+]
+
+export const NOT_FOUND_ROUTES = [
+  '/seo-audit-does-not-exist',
+  '/gebiete/seo-audit-does-not-exist',
+  '/flaechen/seo-audit-does-not-exist'
+]
+
+export const REDIRECT_ROUTES = [
+  { path: `/?gebiet=${SEO_AUDIT_AREA_SLUG}`, status: 301, target: `/karte?gebiet=${SEO_AUDIT_AREA_SLUG}` }
+]

--- a/frontend/server/routes/sitemap.xml.ts
+++ b/frontend/server/routes/sitemap.xml.ts
@@ -8,11 +8,12 @@ const STATIC_PATHS = ['/', '/karte', '/gebiete', '/vergleich', '/ueber-das-proje
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
+  const apiBaseUrl = config.apiInternalBaseUrl || config.public.apiBaseUrl
   const [entries, areas] = await Promise.all([
-    $fetch<PolygonSitemapEntry[]>(`${config.public.apiBaseUrl}/polygons/sitemap`, {
+    $fetch<PolygonSitemapEntry[]>(`${apiBaseUrl}/polygons/sitemap`, {
       headers: { 'X-Request-ID': event.context.requestId }
     }),
-    $fetch<AnalysisAreaSitemapEntry[]>(`${config.public.apiBaseUrl}/analysis-areas/sitemap`, {
+    $fetch<AnalysisAreaSitemapEntry[]>(`${apiBaseUrl}/analysis-areas/sitemap`, {
       headers: { 'X-Request-ID': event.context.requestId }
     })
   ])

--- a/frontend/tests/seo-audit.test.ts
+++ b/frontend/tests/seo-audit.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  auditIndexableHtml,
+  auditNoindexHtml,
+  hasLocalHost,
+  sitemapLocations
+} from '../scripts/seo-audit-lib.mjs'
+import {
+  DYNAMIC_PUBLIC_ROUTES,
+  NOINDEX_ROUTES,
+  NOT_FOUND_ROUTES,
+  REDIRECT_ROUTES,
+  SOCIAL_PREVIEW_ROUTES
+} from '../scripts/seo-route-matrix.mjs'
+
+const expectedUrl = 'https://stadtplaner.example.test/test'
+
+function validHtml(overrides: {
+  title?: string
+  description?: string
+  robots?: string
+  canonical?: string
+  ogUrl?: string
+  jsonLd?: string
+} = {}) {
+  const title = overrides.title ?? 'Testseite – OK Lab Flensburg'
+  const description = overrides.description ?? 'Eine aussagekräftige Beschreibung der Testseite.'
+  const robots = overrides.robots ?? 'index,follow'
+  const canonical = overrides.canonical ?? expectedUrl
+  const ogUrl = overrides.ogUrl ?? canonical
+  const jsonLd = overrides.jsonLd ?? JSON.stringify({ '@context': 'https://schema.org', '@type': 'WebPage', url: canonical })
+  return `<!doctype html><html><head><title>${title}</title><meta name="description" content="${description}"><meta name="robots" content="${robots}"><link rel="canonical" href="${canonical}"><meta property="og:title" content="${title}"><meta property="og:description" content="${description}"><meta property="og:url" content="${ogUrl}"><meta property="og:type" content="website"><meta property="og:site_name" content="OK Lab Flensburg"><meta name="twitter:card" content="summary"><meta name="twitter:title" content="${title}"><meta name="twitter:description" content="${description}"><script type="application/ld+json">${jsonLd}</script></head><body><h1>Testseite</h1></body></html>`
+}
+
+describe('SEO audit helpers', () => {
+  it('accepts complete indexable production metadata', () => {
+    expect(auditIndexableHtml(validHtml(), { expectedUrl })).toEqual([])
+  })
+
+  it('reports missing and duplicate titles', () => {
+    expect(auditIndexableHtml(validHtml().replace(/<title>[\s\S]*?<\/title>/, ''), { expectedUrl }))
+      .toContain('expected exactly one title, received 0')
+    expect(auditIndexableHtml(validHtml().replace('</head>', '<title>Zweiter Titel</title></head>'), { expectedUrl }))
+      .toContain('expected exactly one title, received 2')
+  })
+
+  it('reports an empty description', () => {
+    expect(auditIndexableHtml(validHtml({ description: '' }), { expectedUrl }))
+      .toContain('missing or empty meta description')
+  })
+
+  it('rejects local canonical and social metadata URLs', () => {
+    const local = 'http://127.0.0.1:3000/test'
+    const errors = auditIndexableHtml(validHtml({ canonical: local, ogUrl: 'http://localhost:3000/test' }), { expectedUrl })
+    expect(errors).toContain('canonical must use https')
+    expect(errors).toContain('canonical points to a local host')
+    expect(errors).toContain('og:url points to a local host')
+    expect(hasLocalHost('https://api.localhost/preview.webp')).toBe(true)
+  })
+
+  it('reports missing noindex', () => {
+    expect(auditNoindexHtml(validHtml())).toContain('expected robots=noindex,nofollow')
+  })
+
+  it('reports invalid JSON-LD', () => {
+    expect(auditIndexableHtml(validHtml({ jsonLd: '{invalid' }), { expectedUrl }))
+      .toContain('invalid JSON-LD block 1')
+  })
+
+  it('minimally validates known JSON-LD structures', () => {
+    const withoutUrl = JSON.stringify({ '@context': 'https://schema.org', '@type': 'WebPage' })
+    expect(auditIndexableHtml(validHtml({ jsonLd: withoutUrl }), { expectedUrl }))
+      .toContain('JSON-LD WebPage in block 1 is missing url/@id')
+  })
+
+  it('reports duplicate canonicals', () => {
+    const html = validHtml().replace('</head>', `<link rel="canonical" href="${expectedUrl}"></head>`)
+    expect(auditIndexableHtml(html, { expectedUrl }))
+      .toContain('expected exactly one canonical, received 2')
+  })
+
+  it('reports malformed OpenGraph URLs', () => {
+    expect(auditIndexableHtml(validHtml({ ogUrl: 'not-a-url' }), { expectedUrl }))
+      .toContain('og:url is not an absolute URL')
+  })
+
+  it('extracts escaped absolute sitemap locations', () => {
+    expect(sitemapLocations('<urlset><url><loc>https://example.test/a?x=1&amp;y=2</loc></url></urlset>'))
+      .toEqual(['https://example.test/a?x=1&y=2'])
+  })
+})
+
+describe('SEO route inventory', () => {
+  it('classifies representative dynamic, noindex, social, error and redirect routes', () => {
+    expect(DYNAMIC_PUBLIC_ROUTES).toHaveLength(2)
+    expect(new Set(NOINDEX_ROUTES.map(route => route.type))).toEqual(new Set(['public-noindex', 'auth', 'admin/internal']))
+    expect(SOCIAL_PREVIEW_ROUTES.length).toBeGreaterThanOrEqual(3)
+    expect(NOT_FOUND_ROUTES).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^\/gebiete\//),
+      expect.stringMatching(/^\/flaechen\//)
+    ]))
+    expect(REDIRECT_ROUTES.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('keeps the internal API base outside public runtime config and browser requests', () => {
+    const config = readFileSync(fileURLToPath(new URL('../nuxt.config.ts', import.meta.url)), 'utf8')
+    const api = readFileSync(fileURLToPath(new URL('../app/composables/useApi.ts', import.meta.url)), 'utf8')
+    expect(config).toContain("apiInternalBaseUrl: process.env.NUXT_API_INTERNAL_BASE_URL || ''")
+    expect(config.indexOf('apiInternalBaseUrl:')).toBeLessThan(config.indexOf('public: {'))
+    expect(api).toContain('? config.apiInternalBaseUrl || config.public.apiBaseUrl')
+  })
+})


### PR DESCRIPTION
Closes #59

## Ausgangslage

Die vorhandenen SEO-/SSR-Einzeltests decken einzelne Seiten ab. Es fehlte jedoch ein zentraler, reproduzierbarer Crawl des echten Production-Builds als verpflichtendes CI-Gate.

## Umsetzung

- zentrale Route-Matrix für indexierbare Sitemap-Ziele, dynamische öffentliche Seiten, Noindex-, Auth-/Admin-, Social-Preview-, Redirect- und 404-Routen
- lokale Fixture-API für ein Gebiet und eine öffentliche Fläche
- Audit des gebauten Nitro-Servers auf:
  - HTTP-Status
  - Title und Description
  - Robots
  - Canonical
  - OpenGraph
  - Twitter-Metadaten
  - SSR-H1
  - JSON-LD
- Prüfung von `sitemap.xml` und `robots.txt`
- Prüfung dynamischer Social-Preview-URLs auf öffentliche API-Origin, `1200x630`, Alt-Texte und `summary_large_image`
- kompakte, routebezogene Fehlerausgabe
- neues Script `pnpm audit:seo`
- verpflichtende Ausführung direkt nach dem Production-Build im bestehenden Frontend-CI-Job

## Interne und öffentliche API-URLs

- `NUXT_API_INTERNAL_BASE_URL` liegt ausschließlich in der privaten Nuxt-Runtime-Konfiguration.
- Die interne URL wird nur für serverseitige beziehungsweise SSR-API-Aufrufe verwendet.
- Ohne gesetzte interne URL fällt SSR auf `NUXT_PUBLIC_API_BASE_URL` zurück.
- Browser-Aufrufe und öffentliche URLs verwenden weiterhin ausschließlich öffentliche Runtime-Werte.
- Canonical-, OpenGraph-, Twitter-, JSON-LD- und Sitemap-URLs können dadurch keine interne API-Adresse übernehmen.
- Im SEO-Audit zeigt die interne URL auf die lokale Fixture-API, während öffentliche Site- und API-URLs production-artige HTTPS-Origins verwenden.
- `localhost`, `127.0.0.1` und `::1` in SSR-SEO-Metadaten führen zum Fehlschlag.

## Kleine gefundene Korrekturen

- fehlende OpenGraph- und Twitter-Felder auf `/gebiete` ergänzt
- bestehende Redirect-Schleife für `/flaechen/neu` entfernt

## Validierung

- `pnpm test` – 78 Testdateien und 441 Tests erfolgreich
- `pnpm typecheck` – erfolgreich
- Production `pnpm build` mit öffentlichen HTTPS-Origins – erfolgreich
- `pnpm audit:language` – 447 Ressourcen geprüft, keine unerlaubten Treffer
- `pnpm audit:seo` – erfolgreich
- `python -m unittest discover -s deploy/ansible/tests` – 35 Tests erfolgreich
- `git diff --check` – erfolgreich

## Betrieb und Datenbank

- keine Datenbankmigration
- keine externen SEO-Dienste oder Browser-Abhängigkeiten
- `NUXT_API_INTERNAL_BASE_URL` ist optional
- Rollback durch Zurückrollen des Commits, ohne Datenänderungen