### PR TITLE
feat(modules): define manifest and dependency contract

### DIFF
--- a/backend/app/platform/__init__.py
+++ b/backend/app/platform/__init__.py
@@ -1,0 +1,1 @@
+"""Fachneutrale Plattformverträge des Open City Planner Hosts."""

--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -1,0 +1,55 @@
+"""Öffentlicher Contract für Modulmanifeste und Abhängigkeitsauflösung."""
+
+from app.platform.modules.dependency_graph import resolve_module_order
+from app.platform.modules.errors import (
+    DuplicateConfigNamespaceError,
+    DuplicateModuleIdError,
+    InvalidRuntimeVersionError,
+    MissingModuleDependencyError,
+    ModuleCompatibilityError,
+    ModuleDependencyCycleError,
+    ModuleDependencyError,
+    ModuleDependencyVersionError,
+    ModuleManifestError,
+    ModuleSelfDependencyError,
+    UnsupportedManifestVersionError,
+)
+from app.platform.modules.manifest import (
+    ModuleBackendPackage,
+    ModuleConfig,
+    ModuleFrontendPackage,
+    ModuleManifestV1,
+    ModuleOptionalRequirements,
+    ModulePersistence,
+    ModuleRequirements,
+    module_manifest_json_schema,
+    parse_manifest,
+    validate_manifest,
+    validate_manifests,
+)
+
+__all__ = [
+    "DuplicateConfigNamespaceError",
+    "DuplicateModuleIdError",
+    "InvalidRuntimeVersionError",
+    "MissingModuleDependencyError",
+    "ModuleBackendPackage",
+    "ModuleCompatibilityError",
+    "ModuleConfig",
+    "ModuleDependencyCycleError",
+    "ModuleDependencyError",
+    "ModuleDependencyVersionError",
+    "ModuleFrontendPackage",
+    "ModuleManifestError",
+    "ModuleManifestV1",
+    "ModuleOptionalRequirements",
+    "ModulePersistence",
+    "ModuleRequirements",
+    "ModuleSelfDependencyError",
+    "UnsupportedManifestVersionError",
+    "module_manifest_json_schema",
+    "parse_manifest",
+    "resolve_module_order",
+    "validate_manifest",
+    "validate_manifests",
+]

--- a/backend/app/platform/modules/dependency_graph.py
+++ b/backend/app/platform/modules/dependency_graph.py
@@ -1,0 +1,99 @@
+"""Reine, deterministische Auflösung des Modulabhängigkeitsgraphen."""
+
+import heapq
+from collections.abc import Sequence
+
+from app.platform.modules.errors import (
+    DuplicateModuleIdError,
+    MissingModuleDependencyError,
+    ModuleDependencyCycleError,
+    ModuleSelfDependencyError,
+)
+from app.platform.modules.manifest import ModuleManifestV1
+
+
+def _available_dependencies(
+    manifest: ModuleManifestV1,
+    modules_by_id: dict[str, ModuleManifestV1],
+) -> set[str]:
+    dependencies = set(manifest.requires.modules)
+    dependencies.update(
+        dependency_id
+        for dependency_id in manifest.optional.modules
+        if dependency_id in modules_by_id
+    )
+    return dependencies
+
+
+def _find_cycle(
+    modules_by_id: dict[str, ModuleManifestV1],
+) -> tuple[str, ...]:
+    state: dict[str, int] = {module_id: 0 for module_id in modules_by_id}
+    stack: list[str] = []
+    stack_positions: dict[str, int] = {}
+
+    def visit(module_id: str) -> tuple[str, ...] | None:
+        state[module_id] = 1
+        stack_positions[module_id] = len(stack)
+        stack.append(module_id)
+        dependencies = _available_dependencies(modules_by_id[module_id], modules_by_id)
+        for dependency_id in sorted(dependencies):
+            if state[dependency_id] == 0:
+                cycle = visit(dependency_id)
+                if cycle is not None:
+                    return cycle
+            elif state[dependency_id] == 1:
+                start = stack_positions[dependency_id]
+                return tuple(stack[start:] + [dependency_id])
+        stack.pop()
+        stack_positions.pop(module_id)
+        state[module_id] = 2
+        return None
+
+    for module_id in sorted(modules_by_id):
+        if state[module_id] == 0:
+            cycle = visit(module_id)
+            if cycle is not None:
+                return cycle
+    return ()
+
+
+def resolve_module_order(manifests: Sequence[ModuleManifestV1]) -> tuple[ModuleManifestV1, ...]:
+    """Sortiere Dependencies vor Consumer; gleiche Kandidaten lexikografisch nach ID."""
+
+    modules_by_id: dict[str, ModuleManifestV1] = {}
+    for manifest in manifests:
+        if manifest.id in modules_by_id:
+            raise DuplicateModuleIdError(manifest.id)
+        modules_by_id[manifest.id] = manifest
+
+    dependents: dict[str, set[str]] = {module_id: set() for module_id in modules_by_id}
+    indegree: dict[str, int] = {module_id: 0 for module_id in modules_by_id}
+    for manifest in manifests:
+        dependencies = _available_dependencies(manifest, modules_by_id)
+        for dependency_id in sorted(dependencies):
+            if dependency_id == manifest.id:
+                raise ModuleSelfDependencyError(
+                    manifest.id,
+                    optional=dependency_id in manifest.optional.modules,
+                )
+            if dependency_id not in modules_by_id:
+                expected = manifest.requires.modules[dependency_id]
+                raise MissingModuleDependencyError(manifest.id, dependency_id, expected)
+            dependents[dependency_id].add(manifest.id)
+            indegree[manifest.id] += 1
+
+    ready = [module_id for module_id, degree in indegree.items() if degree == 0]
+    heapq.heapify(ready)
+    order: list[ModuleManifestV1] = []
+    while ready:
+        module_id = heapq.heappop(ready)
+        order.append(modules_by_id[module_id])
+        for dependent_id in sorted(dependents[module_id]):
+            indegree[dependent_id] -= 1
+            if indegree[dependent_id] == 0:
+                heapq.heappush(ready, dependent_id)
+
+    if len(order) != len(manifests):
+        raise ModuleDependencyCycleError(_find_cycle(modules_by_id))
+    return tuple(order)

--- a/backend/app/platform/modules/errors.py
+++ b/backend/app/platform/modules/errors.py
@@ -1,0 +1,155 @@
+"""Strukturierte Fehler des Modulmanifest-Contracts."""
+
+from collections.abc import Sequence
+from typing import Any
+
+
+class ModuleManifestError(ValueError):
+    """Basisklasse für ungültige Manifestdaten."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        module_id: str | None = None,
+        origin: str | None = None,
+        details: list[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.module_id = module_id
+        self.origin = origin
+        self.details = details or []
+
+
+class UnsupportedManifestVersionError(ModuleManifestError):
+    """Die angegebene Manifest-Schemaversion wird nicht unterstützt."""
+
+    def __init__(self, manifest_version: object, *, origin: str | None = None) -> None:
+        super().__init__(
+            f"Unsupported module manifest version: {manifest_version!r}; supported version is 1.",
+            origin=origin,
+        )
+        self.manifest_version = manifest_version
+
+
+class InvalidRuntimeVersionError(ModuleManifestError):
+    """Host oder SDK haben keine gültige SemVer-Version übergeben."""
+
+    def __init__(self, target: str, version: str) -> None:
+        super().__init__(f"Current {target} version {version!r} is not valid SemVer.")
+        self.target = target
+        self.version = version
+
+
+class DuplicateModuleIdError(ModuleManifestError):
+    """Mehrere verfügbare Manifeste verwenden dieselbe Modul-ID."""
+
+    def __init__(
+        self,
+        module_id: str,
+        *,
+        origins: Sequence[str | None] = (),
+    ) -> None:
+        known_origins = [origin for origin in origins if origin]
+        origin_suffix = f" Origins: {', '.join(known_origins)}." if known_origins else ""
+        super().__init__(
+            f'Duplicate module ID "{module_id}".{origin_suffix}',
+            module_id=module_id,
+        )
+        self.origins = tuple(origins)
+
+
+class DuplicateConfigNamespaceError(ModuleManifestError):
+    """Zwei Module beanspruchen denselben Konfigurations-Namespace."""
+
+    def __init__(self, namespace: str, module_ids: Sequence[str]) -> None:
+        joined_ids = ", ".join(module_ids)
+        super().__init__(
+            f'Config namespace "{namespace}" is used by multiple modules: {joined_ids}.'
+        )
+        self.namespace = namespace
+        self.module_ids = tuple(module_ids)
+
+
+class ModuleCompatibilityError(ModuleManifestError):
+    """Ein Modul ist mit der aktuellen Host- oder SDK-Version inkompatibel."""
+
+    def __init__(
+        self,
+        module_id: str,
+        module_version: str,
+        target: str,
+        expected: str,
+        found: str,
+    ) -> None:
+        super().__init__(
+            f'Module "{module_id}" {module_version} requires {target} {expected}, '
+            f"current {target} is {found}.",
+            module_id=module_id,
+        )
+        self.module_version = module_version
+        self.target = target
+        self.expected = expected
+        self.found = found
+
+
+class ModuleDependencyError(ModuleManifestError):
+    """Basisklasse für ungültige Modulabhängigkeiten."""
+
+
+class MissingModuleDependencyError(ModuleDependencyError):
+    """Eine erforderliche Modulabhängigkeit ist nicht verfügbar."""
+
+    def __init__(self, module_id: str, dependency_id: str, expected: str) -> None:
+        super().__init__(
+            f'Module "{module_id}" requires module "{dependency_id}" {expected}, '
+            "but it is not available.",
+            module_id=module_id,
+        )
+        self.dependency_id = dependency_id
+        self.expected = expected
+
+
+class ModuleDependencyVersionError(ModuleDependencyError):
+    """Eine vorhandene required/optional Dependency hat die falsche Version."""
+
+    def __init__(
+        self,
+        module_id: str,
+        dependency_id: str,
+        expected: str,
+        found: str,
+        *,
+        optional: bool,
+    ) -> None:
+        dependency_kind = "optional module" if optional else "module"
+        super().__init__(
+            f'Module "{module_id}" requires {dependency_kind} "{dependency_id}" '
+            f"{expected}, found {found}.",
+            module_id=module_id,
+        )
+        self.dependency_id = dependency_id
+        self.expected = expected
+        self.found = found
+        self.optional = optional
+
+
+class ModuleSelfDependencyError(ModuleDependencyError):
+    """Ein Modul darf weder required noch optional von sich selbst abhängen."""
+
+    def __init__(self, module_id: str, *, optional: bool) -> None:
+        dependency_kind = "optional" if optional else "required"
+        super().__init__(
+            f'Module "{module_id}" has a {dependency_kind} dependency on itself.',
+            module_id=module_id,
+        )
+        self.optional = optional
+
+
+class ModuleDependencyCycleError(ModuleDependencyError):
+    """Der Modulgraph enthält einen Zyklus."""
+
+    def __init__(self, cycle: Sequence[str]) -> None:
+        cycle_path = tuple(cycle)
+        super().__init__(f"Module dependency cycle detected: {' -> '.join(cycle_path)}.")
+        self.cycle = cycle_path

--- a/backend/app/platform/modules/manifest.py
+++ b/backend/app/platform/modules/manifest.py
@@ -1,0 +1,378 @@
+"""Manifest Schema V1 und reine Compatibility-Validierung.
+
+Der Contract verarbeitet bereits dekodierte Mappings. Dateizugriff, YAML-Loader,
+Package-Discovery und Runtime-Aktivierung gehören bewusst nicht in dieses Modul.
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import Annotated, Any, Literal
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+    WithJsonSchema,
+    field_validator,
+    model_validator,
+)
+from semantic_version import SimpleSpec, Version
+
+from app.platform.modules.errors import (
+    DuplicateConfigNamespaceError,
+    DuplicateModuleIdError,
+    InvalidRuntimeVersionError,
+    MissingModuleDependencyError,
+    ModuleCompatibilityError,
+    ModuleDependencyVersionError,
+    ModuleManifestError,
+    ModuleSelfDependencyError,
+    UnsupportedManifestVersionError,
+)
+
+MANIFEST_VERSION = 1
+MODULE_ID_PATTERN = r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+NAMESPACED_ID_PATTERN = (
+    r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$"
+)
+PYTHON_PACKAGE_PATTERN = r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$"
+NPM_PACKAGE_PATTERN = r"^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$"
+POSTGRES_IDENTIFIER_PATTERN = r"^[a-z][a-z0-9_]*$"
+VERSION_OPERATORS = (">=", "<=", "==", "!=", ">", "<")
+
+
+def _validate_semver(value: str) -> str:
+    try:
+        Version(value)
+    except ValueError as exc:
+        raise ValueError("must be a complete SemVer version such as 1.2.3") from exc
+    return value
+
+
+def _validate_version_range(value: str) -> str:
+    if value != value.strip() or not value:
+        raise ValueError("must be a non-empty canonical SemVer range without outer whitespace")
+
+    clauses = value.split(",")
+    for clause in clauses:
+        if not clause or clause != clause.strip():
+            raise ValueError("range clauses must be comma-separated without whitespace")
+        operator = next(
+            (candidate for candidate in VERSION_OPERATORS if clause.startswith(candidate)), None
+        )
+        if operator is None:
+            raise ValueError(
+                "range clauses must use one of >=, <=, ==, !=, > or < with a complete SemVer"
+            )
+        version_text = clause[len(operator) :]
+        try:
+            Version(version_text)
+        except ValueError as exc:
+            raise ValueError(
+                f"range clause {clause!r} must contain a complete SemVer version"
+            ) from exc
+
+    try:
+        SimpleSpec(value)
+    except ValueError as exc:
+        raise ValueError("must be a valid canonical SemVer range") from exc
+    return value
+
+
+type ModuleId = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=False,
+        min_length=1,
+        max_length=63,
+        pattern=MODULE_ID_PATTERN,
+    ),
+]
+type NamespacedId = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=False,
+        min_length=3,
+        max_length=127,
+        pattern=NAMESPACED_ID_PATTERN,
+    ),
+]
+type SemanticVersion = Annotated[
+    str,
+    StringConstraints(strip_whitespace=False, min_length=1, max_length=128),
+    AfterValidator(_validate_semver),
+    WithJsonSchema(
+        {
+            "type": "string",
+            "format": "semver",
+            "minLength": 1,
+            "maxLength": 128,
+            "examples": ["1.2.3"],
+        }
+    ),
+]
+type SemanticVersionRange = Annotated[
+    str,
+    StringConstraints(strip_whitespace=False, min_length=1, max_length=512),
+    AfterValidator(_validate_version_range),
+    WithJsonSchema(
+        {
+            "type": "string",
+            "format": "semver-range",
+            "minLength": 1,
+            "maxLength": 512,
+            "examples": [">=1.2.0,<2.0.0"],
+        }
+    ),
+]
+
+
+class StrictManifestModel(BaseModel):
+    """Gemeinsame Strictness-Regeln aller Manifest-V1-Objekte."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class ModuleRequirements(StrictManifestModel):
+    """Pflichtkompatibilität und erforderliche Modulabhängigkeiten."""
+
+    host: SemanticVersionRange
+    sdk: SemanticVersionRange
+    modules: dict[ModuleId, SemanticVersionRange] = Field(default_factory=dict)
+
+
+class ModuleOptionalRequirements(StrictManifestModel):
+    """Optionale Module, deren vorhandene Version dennoch kompatibel sein muss."""
+
+    modules: dict[ModuleId, SemanticVersionRange] = Field(default_factory=dict)
+
+
+class ModuleBackendPackage(StrictManifestModel):
+    """Deklarativer Python-Distributionsname; keine Import-Anweisung."""
+
+    package: str = Field(min_length=1, max_length=214, pattern=PYTHON_PACKAGE_PATTERN)
+
+
+class ModuleFrontendPackage(StrictManifestModel):
+    """Deklarativer npm-Paketname; kein Runtime-Bundle oder Download-Endpunkt."""
+
+    package: str = Field(min_length=1, max_length=214, pattern=NPM_PACKAGE_PATTERN)
+
+
+class ModuleConfig(StrictManifestModel):
+    """Stabile Identität für das spätere Settings-Namespace aus #99."""
+
+    namespace: ModuleId
+
+
+class ModulePersistence(StrictManifestModel):
+    """Deklarative Metadaten für das spätere Migrations-Ownership aus #97."""
+
+    schema_name: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=63,
+        pattern=POSTGRES_IDENTIFIER_PATTERN,
+    )
+    migrations: bool = False
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        strict=True,
+        validate_by_alias=True,
+        validate_by_name=False,
+    )
+
+
+class ModuleManifestV1(StrictManifestModel):
+    """Versionierter, deklarativer Kernvertrag eines Open-City-Planner-Moduls."""
+
+    manifest_version: Literal[1]
+    id: ModuleId
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=120)]
+    version: SemanticVersion
+    requires: ModuleRequirements
+    optional: ModuleOptionalRequirements = Field(default_factory=ModuleOptionalRequirements)
+    backend: ModuleBackendPackage | None = None
+    frontend: ModuleFrontendPackage | None = None
+    capabilities: list[NamespacedId] = Field(
+        default_factory=list, json_schema_extra={"uniqueItems": True}
+    )
+    permissions: list[NamespacedId] = Field(
+        default_factory=list, json_schema_extra={"uniqueItems": True}
+    )
+    config: ModuleConfig | None = None
+    persistence: ModulePersistence | None = None
+
+    @field_validator("capabilities", "permissions")
+    @classmethod
+    def identifiers_must_be_unique(cls, values: list[str]) -> list[str]:
+        duplicates = sorted({value for value in values if values.count(value) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate identifiers are forbidden: {', '.join(duplicates)}")
+        return values
+
+    @model_validator(mode="after")
+    def validate_owned_identifiers(self) -> "ModuleManifestV1":
+        permission_prefix = f"{self.id}."
+        invalid_permissions = [
+            permission for permission in self.permissions if not permission.startswith(permission_prefix)
+        ]
+        if invalid_permissions:
+            raise ValueError(
+                f'module permissions must start with "{permission_prefix}": '
+                f"{', '.join(invalid_permissions)}"
+            )
+        overlapping_dependencies = sorted(
+            set(self.requires.modules).intersection(self.optional.modules)
+        )
+        if overlapping_dependencies:
+            raise ValueError(
+                "module dependencies cannot be both required and optional: "
+                f"{', '.join(overlapping_dependencies)}"
+            )
+        return self
+
+
+type ManifestInput = Mapping[str, Any]
+
+
+def parse_manifest(data: ManifestInput, *, origin: str | None = None) -> ModuleManifestV1:
+    """Parse ein bereits sicher dekodiertes Mapping als Manifest Schema V1."""
+
+    if not isinstance(data, Mapping):
+        raise ModuleManifestError("Invalid module manifest: expected a decoded mapping.")
+    manifest_version = data.get("manifest_version")
+    if type(manifest_version) is not int or manifest_version != MANIFEST_VERSION:
+        raise UnsupportedManifestVersionError(manifest_version, origin=origin)
+    try:
+        return ModuleManifestV1.model_validate(data)
+    except ValidationError as exc:
+        module_id = data.get("id") if isinstance(data.get("id"), str) else None
+        location = f" from {origin}" if origin else ""
+        raise ModuleManifestError(
+            f"Invalid module manifest{location}: {exc}",
+            module_id=module_id,
+            origin=origin,
+            details=exc.errors(include_url=False),
+        ) from exc
+
+
+def _runtime_version(value: str, target: str) -> Version:
+    try:
+        return Version(value)
+    except ValueError as exc:
+        raise InvalidRuntimeVersionError(target, value) from exc
+
+
+def _matches(version: str, expected: str) -> bool:
+    return Version(version) in SimpleSpec(expected)
+
+
+def validate_manifest(
+    manifest: ModuleManifestV1,
+    *,
+    host_version: str,
+    sdk_version: str,
+) -> ModuleManifestV1:
+    """Prüfe ein Manifest isoliert gegen explizit übergebene Host-/SDK-Versionen."""
+
+    if manifest.id in manifest.requires.modules:
+        raise ModuleSelfDependencyError(manifest.id, optional=False)
+    if manifest.id in manifest.optional.modules:
+        raise ModuleSelfDependencyError(manifest.id, optional=True)
+
+    host = _runtime_version(host_version, "host")
+    sdk = _runtime_version(sdk_version, "sdk")
+    for target, current, expected in (
+        ("host", host, manifest.requires.host),
+        ("sdk", sdk, manifest.requires.sdk),
+    ):
+        if current not in SimpleSpec(expected):
+            raise ModuleCompatibilityError(
+                manifest.id,
+                manifest.version,
+                target,
+                expected,
+                str(current),
+            )
+    return manifest
+
+
+def validate_manifests(
+    manifests: Sequence[ModuleManifestV1],
+    *,
+    host_version: str,
+    sdk_version: str,
+    origins: Sequence[str | None] | None = None,
+) -> tuple[ModuleManifestV1, ...]:
+    """Prüfe Compatibility und Dependencies einer verfügbaren/aktiven Modulmenge."""
+
+    if origins is not None and len(origins) != len(manifests):
+        raise ValueError("origins must have the same length as manifests")
+
+    modules_by_id: dict[str, ModuleManifestV1] = {}
+    first_index_by_id: dict[str, int] = {}
+    for index, manifest in enumerate(manifests):
+        if manifest.id in modules_by_id:
+            duplicate_origins: tuple[str | None, ...] = ()
+            if origins is not None:
+                duplicate_origins = (origins[first_index_by_id[manifest.id]], origins[index])
+            raise DuplicateModuleIdError(manifest.id, origins=duplicate_origins)
+        modules_by_id[manifest.id] = manifest
+        first_index_by_id[manifest.id] = index
+
+    config_owners: dict[str, str] = {}
+    for manifest in manifests:
+        if manifest.config is None:
+            continue
+        namespace = manifest.config.namespace
+        if namespace in config_owners:
+            raise DuplicateConfigNamespaceError(
+                namespace, (config_owners[namespace], manifest.id)
+            )
+        config_owners[namespace] = manifest.id
+
+    for manifest in manifests:
+        validate_manifest(
+            manifest,
+            host_version=host_version,
+            sdk_version=sdk_version,
+        )
+        for dependency_id, expected in manifest.requires.modules.items():
+            if dependency_id == manifest.id:
+                raise ModuleSelfDependencyError(manifest.id, optional=False)
+            dependency = modules_by_id.get(dependency_id)
+            if dependency is None:
+                raise MissingModuleDependencyError(manifest.id, dependency_id, expected)
+            if not _matches(dependency.version, expected):
+                raise ModuleDependencyVersionError(
+                    manifest.id,
+                    dependency_id,
+                    expected,
+                    dependency.version,
+                    optional=False,
+                )
+        for dependency_id, expected in manifest.optional.modules.items():
+            if dependency_id == manifest.id:
+                raise ModuleSelfDependencyError(manifest.id, optional=True)
+            dependency = modules_by_id.get(dependency_id)
+            if dependency is not None and not _matches(dependency.version, expected):
+                raise ModuleDependencyVersionError(
+                    manifest.id,
+                    dependency_id,
+                    expected,
+                    dependency.version,
+                    optional=True,
+                )
+    return tuple(manifests)
+
+
+def module_manifest_json_schema() -> dict[str, Any]:
+    """Liefere das deterministische JSON Schema des Manifest-V1-Single-Source-of-Truth."""
+
+    schema = ModuleManifestV1.model_json_schema(by_alias=True)
+    return {"$schema": "https://json-schema.org/draft/2020-12/schema", **schema}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "pyotp>=2.9.0",
   "python-multipart>=0.0.20",
   "redis>=5.2,<9",
+  "semantic-version>=2.10.0,<3",
   "shapely>=2.1.1",
   "sqlalchemy>=2.0.42",
   "uvicorn[standard]>=0.35.0",

--- a/backend/tests/test_module_manifest.py
+++ b/backend/tests/test_module_manifest.py
@@ -1,0 +1,474 @@
+import itertools
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.platform.modules import (
+    DuplicateConfigNamespaceError,
+    DuplicateModuleIdError,
+    InvalidRuntimeVersionError,
+    MissingModuleDependencyError,
+    ModuleCompatibilityError,
+    ModuleDependencyCycleError,
+    ModuleDependencyVersionError,
+    ModuleManifestError,
+    ModuleSelfDependencyError,
+    UnsupportedManifestVersionError,
+    module_manifest_json_schema,
+    parse_manifest,
+    resolve_module_order,
+    validate_manifest,
+    validate_manifests,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "docs/modules/schema/module-manifest-v1.schema.json"
+EXAMPLES_PATH = ROOT / "docs/modules/examples"
+
+
+def manifest_data(
+    module_id: str = "example-module",
+    *,
+    version: str = "1.0.0",
+    required_modules: dict[str, str] | None = None,
+    optional_modules: dict[str, str] | None = None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "manifest_version": 1,
+        "id": module_id,
+        "name": module_id.replace("-", " ").title(),
+        "version": version,
+        "requires": {
+            "host": ">=1.0.0,<2.0.0",
+            "sdk": ">=1.0.0,<2.0.0",
+            "modules": required_modules or {},
+        },
+    }
+    if optional_modules is not None:
+        data["optional"] = {"modules": optional_modules}
+    data.update(overrides)
+    return data
+
+
+def parsed_manifest(module_id: str = "example-module", **kwargs: Any):
+    return parse_manifest(manifest_data(module_id, **kwargs))
+
+
+def module_ids(manifests) -> list[str]:
+    return [manifest.id for manifest in manifests]
+
+
+def test_parse_minimal_manifest() -> None:
+    manifest = parsed_manifest()
+
+    assert manifest.id == "example-module"
+    assert manifest.version == "1.0.0"
+    assert manifest.backend is None
+    assert manifest.frontend is None
+    assert manifest.optional.modules == {}
+
+
+def test_parse_full_manifest() -> None:
+    manifest = parse_manifest(
+        manifest_data(
+            "example-biotopes",
+            version="2.3.1",
+            required_modules={"example-layer-catalog": ">=1.0.0,<2.0.0"},
+            optional_modules={"example-statistics": ">=1.0.0"},
+            backend={"package": "open_city_planner_biotopes"},
+            frontend={"package": "@open-city-planner/biotopes"},
+            capabilities=["map.layer", "map.feature-info", "analysis.provider"],
+            permissions=["example-biotopes.read", "example-biotopes.admin"],
+            config={"namespace": "example-biotopes"},
+            persistence={"schema": "example_biotopes", "migrations": True},
+        )
+    )
+
+    assert manifest.backend and manifest.backend.package == "open_city_planner_biotopes"
+    assert manifest.frontend and manifest.frontend.package == "@open-city-planner/biotopes"
+    assert manifest.persistence and manifest.persistence.schema_name == "example_biotopes"
+    assert manifest.model_dump(by_alias=True)["persistence"]["schema"] == "example_biotopes"
+
+
+@pytest.mark.parametrize(
+    ("backend", "frontend"),
+    [
+        ({"package": "example_backend"}, None),
+        (None, {"package": "@open-city-planner/example"}),
+        ({"package": "example_backend"}, {"package": "example-frontend"}),
+    ],
+)
+def test_backend_only_frontend_only_and_combined_manifests(backend, frontend) -> None:
+    manifest = parse_manifest(manifest_data(backend=backend, frontend=frontend))
+
+    assert (manifest.backend is not None) == (backend is not None)
+    assert (manifest.frontend is not None) == (frontend is not None)
+
+
+@pytest.mark.parametrize(
+    "module_id",
+    ["Analysis-Areas", "analysis_areas", "analysis--areas", "analysis-", "1-analysis"],
+)
+def test_invalid_module_id_is_rejected(module_id: str) -> None:
+    with pytest.raises(ModuleManifestError, match="Invalid module manifest"):
+        parse_manifest(manifest_data(module_id))
+
+
+@pytest.mark.parametrize("version", ["1.0", "v1.0.0", "1.0.0.0", "latest"])
+def test_invalid_module_version_is_rejected(version: str) -> None:
+    with pytest.raises(ModuleManifestError, match="complete SemVer"):
+        parsed_manifest(version=version)
+
+
+@pytest.mark.parametrize(
+    "version_range",
+    ["^1.2.0", "~1.2.0", ">=1.2", ">=1.2.0, <2.0.0", "*"],
+)
+def test_only_canonical_explicit_version_ranges_are_accepted(version_range: str) -> None:
+    data = manifest_data()
+    data["requires"]["host"] = version_range
+
+    with pytest.raises(ModuleManifestError, match="SemVer|range clauses"):
+        parse_manifest(data)
+
+
+def test_unsupported_manifest_version_has_structured_error() -> None:
+    with pytest.raises(UnsupportedManifestVersionError) as exc_info:
+        parse_manifest({**manifest_data(), "manifest_version": 999}, origin="module.json")
+
+    assert exc_info.value.manifest_version == 999
+    assert exc_info.value.origin == "module.json"
+
+
+def test_unknown_manifest_field_is_rejected() -> None:
+    with pytest.raises(ModuleManifestError) as exc_info:
+        parse_manifest({**manifest_data(), "permisions": ["example-module.read"]})
+
+    assert any(detail["type"] == "extra_forbidden" for detail in exc_info.value.details)
+
+
+def test_persistence_internal_field_name_is_not_accepted_as_manifest_alias() -> None:
+    with pytest.raises(ModuleManifestError):
+        parse_manifest(manifest_data(persistence={"schema_name": "example_module"}))
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"manifest_version": True},
+        {"version": 1},
+        {"persistence": {"schema": "example_module", "migrations": "true"}},
+    ],
+)
+def test_manifest_values_are_not_coerced(overrides: dict[str, Any]) -> None:
+    with pytest.raises(ModuleManifestError):
+        parse_manifest(manifest_data(**overrides))
+
+
+@pytest.mark.parametrize(
+    ("field", "values"),
+    [
+        ("capabilities", ["map.layer", "map.layer"]),
+        ("permissions", ["example-module.read", "example-module.read"]),
+    ],
+)
+def test_duplicate_capabilities_and_permissions_are_rejected(field, values) -> None:
+    with pytest.raises(ModuleManifestError, match="duplicate identifiers"):
+        parse_manifest(manifest_data(**{field: values}))
+
+
+def test_unknown_well_formed_capability_is_forward_compatible() -> None:
+    manifest = parse_manifest(manifest_data(capabilities=["future.unlisted-capability"]))
+
+    assert manifest.capabilities == ["future.unlisted-capability"]
+
+
+def test_permissions_must_be_owned_by_the_module_namespace() -> None:
+    with pytest.raises(ModuleManifestError, match="example-module\\."):
+        parse_manifest(manifest_data(permissions=["other-module.admin"]))
+
+
+@pytest.mark.parametrize("namespace", ["Example", "example_namespace", "example--config"])
+def test_invalid_config_namespace_is_rejected(namespace: str) -> None:
+    with pytest.raises(ModuleManifestError):
+        parse_manifest(manifest_data(config={"namespace": namespace}))
+
+
+def test_compatible_host_and_sdk_versions_are_accepted() -> None:
+    manifest = parsed_manifest()
+
+    assert validate_manifest(manifest, host_version="1.5.0", sdk_version="1.9.9") is manifest
+
+
+@pytest.mark.parametrize(
+    ("target", "host_version", "sdk_version", "found"),
+    [
+        ("host", "0.9.9", "1.0.0", "0.9.9"),
+        ("host", "2.0.0", "1.0.0", "2.0.0"),
+        ("sdk", "1.0.0", "2.0.0", "2.0.0"),
+    ],
+)
+def test_incompatible_host_or_sdk_version_has_structured_error(
+    target: str, host_version: str, sdk_version: str, found: str
+) -> None:
+    with pytest.raises(ModuleCompatibilityError) as exc_info:
+        validate_manifest(
+            parsed_manifest(),
+            host_version=host_version,
+            sdk_version=sdk_version,
+        )
+
+    assert exc_info.value.target == target
+    assert exc_info.value.expected == ">=1.0.0,<2.0.0"
+    assert exc_info.value.found == found
+
+
+def test_invalid_runtime_version_is_rejected() -> None:
+    with pytest.raises(InvalidRuntimeVersionError, match="host"):
+        validate_manifest(parsed_manifest(), host_version="latest", sdk_version="1.0.0")
+
+
+def test_required_dependency_is_validated() -> None:
+    dependency = parsed_manifest("example-layer-catalog", version="1.5.0")
+    consumer = parsed_manifest(
+        "example-biotopes",
+        required_modules={"example-layer-catalog": ">=1.0.0,<2.0.0"},
+    )
+
+    assert validate_manifests(
+        [consumer, dependency], host_version="1.0.0", sdk_version="1.0.0"
+    ) == (consumer, dependency)
+
+
+def test_missing_required_dependency_has_structured_error() -> None:
+    consumer = parsed_manifest(
+        "example-biotopes",
+        required_modules={"example-layer-catalog": ">=1.0.0,<2.0.0"},
+    )
+
+    with pytest.raises(MissingModuleDependencyError) as exc_info:
+        validate_manifests([consumer], host_version="1.0.0", sdk_version="1.0.0")
+
+    assert exc_info.value.dependency_id == "example-layer-catalog"
+    assert exc_info.value.expected == ">=1.0.0,<2.0.0"
+
+
+def test_incompatible_required_dependency_has_structured_error() -> None:
+    dependency = parsed_manifest("example-layer-catalog", version="2.1.0")
+    consumer = parsed_manifest(
+        "example-biotopes",
+        required_modules={"example-layer-catalog": ">=1.0.0,<2.0.0"},
+    )
+
+    with pytest.raises(ModuleDependencyVersionError) as exc_info:
+        validate_manifests(
+            [consumer, dependency], host_version="1.0.0", sdk_version="1.0.0"
+        )
+
+    assert exc_info.value.optional is False
+    assert exc_info.value.found == "2.1.0"
+
+
+def test_missing_optional_dependency_is_accepted() -> None:
+    consumer = parsed_manifest(
+        "example-biotopes",
+        optional_modules={"example-statistics": ">=1.0.0,<2.0.0"},
+    )
+
+    validate_manifests([consumer], host_version="1.0.0", sdk_version="1.0.0")
+
+
+def test_present_compatible_optional_dependency_is_accepted() -> None:
+    dependency = parsed_manifest("example-statistics", version="1.5.0")
+    consumer = parsed_manifest(
+        "example-biotopes",
+        optional_modules={"example-statistics": ">=1.0.0,<2.0.0"},
+    )
+
+    validate_manifests(
+        [consumer, dependency], host_version="1.0.0", sdk_version="1.0.0"
+    )
+
+
+def test_present_incompatible_optional_dependency_is_rejected() -> None:
+    dependency = parsed_manifest("example-statistics", version="2.0.0")
+    consumer = parsed_manifest(
+        "example-biotopes",
+        optional_modules={"example-statistics": ">=1.0.0,<2.0.0"},
+    )
+
+    with pytest.raises(ModuleDependencyVersionError) as exc_info:
+        validate_manifests(
+            [consumer, dependency], host_version="1.0.0", sdk_version="1.0.0"
+        )
+
+    assert exc_info.value.optional is True
+
+
+def test_dependency_cannot_be_both_required_and_optional() -> None:
+    with pytest.raises(ModuleManifestError, match="both required and optional"):
+        parsed_manifest(
+            required_modules={"example-statistics": ">=1.0.0"},
+            optional_modules={"example-statistics": ">=1.0.0"},
+        )
+
+
+@pytest.mark.parametrize("optional", [False, True])
+def test_self_dependency_is_rejected(optional: bool) -> None:
+    kwargs = (
+        {"optional_modules": {"example-module": ">=1.0.0"}}
+        if optional
+        else {"required_modules": {"example-module": ">=1.0.0"}}
+    )
+
+    with pytest.raises(ModuleSelfDependencyError) as exc_info:
+        validate_manifest(
+            parsed_manifest(**kwargs), host_version="1.0.0", sdk_version="1.0.0"
+        )
+
+    assert exc_info.value.optional is optional
+
+
+def test_duplicate_module_ids_fail_fast_and_include_origins() -> None:
+    first = parsed_manifest("example-module")
+    second = parsed_manifest("example-module", version="2.0.0")
+
+    with pytest.raises(DuplicateModuleIdError) as exc_info:
+        validate_manifests(
+            [first, second],
+            host_version="1.0.0",
+            sdk_version="1.0.0",
+            origins=["first.json", "second.json"],
+        )
+
+    assert exc_info.value.origins == ("first.json", "second.json")
+    assert "first.json" in str(exc_info.value)
+
+
+def test_duplicate_config_namespaces_are_rejected() -> None:
+    first = parsed_manifest("module-a", config={"namespace": "shared-config"})
+    second = parsed_manifest("module-b", config={"namespace": "shared-config"})
+
+    with pytest.raises(DuplicateConfigNamespaceError):
+        validate_manifests([first, second], host_version="1.0.0", sdk_version="1.0.0")
+
+
+def test_graph_without_dependencies_is_lexicographic() -> None:
+    manifests = [parsed_manifest("module-c"), parsed_manifest("module-a"), parsed_manifest("module-b")]
+
+    assert module_ids(resolve_module_order(manifests)) == ["module-a", "module-b", "module-c"]
+
+
+def test_linear_dependency_order() -> None:
+    first = parsed_manifest("module-a")
+    second = parsed_manifest("module-b", required_modules={"module-a": ">=1.0.0"})
+    third = parsed_manifest("module-c", required_modules={"module-b": ">=1.0.0"})
+
+    assert module_ids(resolve_module_order([third, first, second])) == [
+        "module-a",
+        "module-b",
+        "module-c",
+    ]
+
+
+def test_diamond_dependency_order_is_deterministic() -> None:
+    root = parsed_manifest("module-a")
+    left = parsed_manifest("module-b", required_modules={"module-a": ">=1.0.0"})
+    right = parsed_manifest("module-c", required_modules={"module-a": ">=1.0.0"})
+    tip = parsed_manifest(
+        "module-d",
+        required_modules={"module-b": ">=1.0.0", "module-c": ">=1.0.0"},
+    )
+
+    assert module_ids(resolve_module_order([tip, right, left, root])) == [
+        "module-a",
+        "module-b",
+        "module-c",
+        "module-d",
+    ]
+
+
+def test_load_order_is_independent_of_input_order() -> None:
+    manifests = [
+        parsed_manifest("module-a"),
+        parsed_manifest("module-b"),
+        parsed_manifest("module-c", required_modules={"module-a": ">=1.0.0"}),
+    ]
+
+    orders = {
+        tuple(module_ids(resolve_module_order(permutation)))
+        for permutation in itertools.permutations(manifests)
+    }
+
+    assert orders == {("module-a", "module-b", "module-c")}
+
+
+def test_present_optional_dependency_loads_before_consumer() -> None:
+    dependency = parsed_manifest("module-b")
+    consumer = parsed_manifest("module-a", optional_modules={"module-b": ">=1.0.0"})
+
+    assert module_ids(resolve_module_order([consumer, dependency])) == ["module-b", "module-a"]
+
+
+@pytest.mark.parametrize(
+    ("manifests", "cycle"),
+    [
+        (
+            [
+                parsed_manifest("module-a", required_modules={"module-b": ">=1.0.0"}),
+                parsed_manifest("module-b", required_modules={"module-a": ">=1.0.0"}),
+            ],
+            ("module-a", "module-b", "module-a"),
+        ),
+        (
+            [
+                parsed_manifest("module-a", required_modules={"module-b": ">=1.0.0"}),
+                parsed_manifest("module-b", required_modules={"module-c": ">=1.0.0"}),
+                parsed_manifest("module-c", required_modules={"module-a": ">=1.0.0"}),
+            ],
+            ("module-a", "module-b", "module-c", "module-a"),
+        ),
+    ],
+)
+def test_direct_and_indirect_cycles_report_the_cycle_path(manifests, cycle) -> None:
+    with pytest.raises(ModuleDependencyCycleError) as exc_info:
+        resolve_module_order(manifests)
+
+    assert exc_info.value.cycle == cycle
+    assert " -> ".join(cycle) in str(exc_info.value)
+
+
+def test_graph_rejects_duplicate_module_ids() -> None:
+    manifest = parsed_manifest()
+
+    with pytest.raises(DuplicateModuleIdError):
+        resolve_module_order([manifest, manifest])
+
+
+def test_committed_json_schema_matches_pydantic_source_of_truth() -> None:
+    committed_schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert committed_schema == module_manifest_json_schema()
+
+
+def test_documentation_examples_match_schema_v1() -> None:
+    manifests = [
+        parse_manifest(json.loads(path.read_text(encoding="utf-8")), origin=str(path))
+        for path in sorted(EXAMPLES_PATH.glob("*.module.json"))
+    ]
+
+    validated = validate_manifests(
+        manifests,
+        host_version="1.0.0",
+        sdk_version="1.0.0",
+        origins=[str(path) for path in sorted(EXAMPLES_PATH.glob("*.module.json"))],
+    )
+
+    assert module_ids(resolve_module_order(validated)) == [
+        "example-layer-catalog",
+        "example-biotopes",
+        "example-pois",
+    ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -657,6 +657,7 @@ dependencies = [
     { name = "pyotp" },
     { name = "python-multipart" },
     { name = "redis" },
+    { name = "semantic-version" },
     { name = "shapely" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
@@ -706,6 +707,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'security'", specifier = "==6.0.3" },
     { name = "redis", specifier = ">=5.2,<9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.8" },
+    { name = "semantic-version", specifier = ">=2.10.0,<3" },
     { name = "shapely", specifier = ">=2.1.1" },
     { name = "sqlalchemy", specifier = ">=2.0.42" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.35.0" },
@@ -1334,6 +1336,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
     { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
     { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
+name = "semantic-version"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
 ]
 
 [[package]]

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 ## Architektur und Frontend
 
 - [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
+- [Module Manifest Schema V1](modules/module-manifest-v1.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)
 - [Intelligente Suche](intelligent-search.md)

--- a/docs/modules/examples/example-biotopes.module.json
+++ b/docs/modules/examples/example-biotopes.module.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": 1,
+  "id": "example-biotopes",
+  "name": "Beispiel-Biotope",
+  "version": "1.0.0",
+  "requires": {
+    "host": ">=1.0.0,<2.0.0",
+    "sdk": ">=1.0.0,<2.0.0",
+    "modules": {
+      "example-layer-catalog": ">=1.0.0,<2.0.0"
+    }
+  },
+  "optional": {
+    "modules": {
+      "example-statistics": ">=1.0.0,<2.0.0"
+    }
+  },
+  "backend": {
+    "package": "open_city_planner_example_biotopes"
+  },
+  "frontend": {
+    "package": "@open-city-planner/example-biotopes"
+  },
+  "capabilities": [
+    "map.layer",
+    "map.feature-info",
+    "analysis.provider"
+  ],
+  "permissions": [
+    "example-biotopes.read",
+    "example-biotopes.admin"
+  ],
+  "config": {
+    "namespace": "example-biotopes"
+  },
+  "persistence": {
+    "schema": "example_biotopes",
+    "migrations": true
+  }
+}

--- a/docs/modules/examples/example-layer-catalog.module.json
+++ b/docs/modules/examples/example-layer-catalog.module.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 1,
+  "id": "example-layer-catalog",
+  "name": "Beispiel-Layerkatalog",
+  "version": "1.1.0",
+  "requires": {
+    "host": ">=1.0.0,<2.0.0",
+    "sdk": ">=1.0.0,<2.0.0"
+  },
+  "frontend": {
+    "package": "@open-city-planner/example-layer-catalog"
+  },
+  "capabilities": [
+    "map.layer",
+    "ui.navigation"
+  ],
+  "permissions": [
+    "example-layer-catalog.read"
+  ]
+}

--- a/docs/modules/examples/example-pois.module.json
+++ b/docs/modules/examples/example-pois.module.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 1,
+  "id": "example-pois",
+  "name": "Beispiel-POIs",
+  "version": "1.0.0",
+  "requires": {
+    "host": ">=1.0.0,<2.0.0",
+    "sdk": ">=1.0.0,<2.0.0"
+  },
+  "backend": {
+    "package": "open_city_planner_example_pois"
+  },
+  "capabilities": [
+    "map.layer",
+    "map.feature-info"
+  ],
+  "permissions": [
+    "example-pois.read"
+  ],
+  "config": {
+    "namespace": "example-pois"
+  },
+  "persistence": {
+    "schema": "example_pois",
+    "migrations": true
+  }
+}

--- a/docs/modules/module-manifest-v1.md
+++ b/docs/modules/module-manifest-v1.md
@@ -1,0 +1,176 @@
+# Module Manifest Schema V1
+
+Diese Dokumentation präzisiert den maschinenlesbaren Modulvertrag aus
+[ADR: Modularer Host und Grenzen von Fachmodulen](../architecture/adr-modular-host-and-module-boundaries.md).
+Sie führt keine Module Runtime ein. Discovery, Aktivierung und das Laden von Paketen
+folgen in #94, #112 und #113.
+
+## Contract und Formate
+
+`ModuleManifestV1` in `backend/app/platform/modules/manifest.py` ist die typisierte
+Single Source of Truth. Das daraus erzeugte, versionierte
+[JSON Schema](schema/module-manifest-v1.schema.json) ist für externe Werkzeuge
+committed. Ein Test verhindert Abweichungen zwischen Pydantic-Modell und Datei.
+
+Der Parser akzeptiert ein bereits dekodiertes Python-Mapping. JSON ist damit direkt
+nutzbar. YAML darf ein Authoring-Format sein, ist aber kein eigener Contract und wird
+vom Host in V1 nicht geladen. Ein späterer Dateiloader muss für YAML ausschließlich
+einen Safe Loader verwenden. Manifestwerte werden nicht als Python-Import,
+Shell-Befehl, SQL oder Template ausgeführt; Package-Referenzen sind nur Strings.
+
+Unbekannte Felder sind auf jeder Schemaebene verboten. Dadurch wird zum Beispiel
+`permisions` nicht stillschweigend ignoriert. Capability-IDs bleiben dagegen offen:
+Ein älterer Host darf eine syntaktisch gültige, ihm noch unbekannte Capability
+transportieren.
+
+## Versionen
+
+Der Contract unterscheidet drei Versionen:
+
+1. `manifest_version` versioniert das Schema. V1 akzeptiert ausschließlich den Wert
+   `1`; andere Werte schlagen mit `UnsupportedManifestVersionError` fehl.
+2. `version` ist die vollständige SemVer-Version des Moduls, zum Beispiel `2.3.1`.
+3. `requires.host`, `requires.sdk` und Modulabhängigkeiten sind Compatibility-Ranges.
+
+V1 verwendet genau eine Range-Sprache: komma-separierte, explizite Vergleiche mit
+vollständigen SemVer-Versionen, zum Beispiel `>=1.2.0,<2.0.0`. Erlaubte Operatoren
+sind `>=`, `<=`, `>`, `<`, `==` und `!=`. Npm-Kurzformen wie `^1.2.0`, `~1.4.0`,
+Wildcards und unvollständige Versionen sind nicht Teil des Contracts. Parsing und
+Vergleich erfolgen mit `python-semanticversion`; das Manifest verwendet weder
+PEP-440- noch npm-Range-Semantik.
+
+Die spätere Runtime übergibt ihre Versionen explizit:
+
+```python
+validated = validate_manifests(
+    manifests,
+    host_version="1.0.0",
+    sdk_version="1.0.0",
+)
+order = resolve_module_order(validated)
+```
+
+Der Validator sucht Versionen nicht selbst in Paketen, Settings oder im Netzwerk.
+Host, SDK und Module folgen langfristig SemVer; Details zu Compatibility und
+Deprecation bleiben Teil von #93/#94.
+
+## Identität und IDs
+
+Modul-IDs sind stabile ASCII-IDs in lowercase kebab-case. Sie erfüllen
+`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`, sind höchstens 63 Zeichen lang und hängen nicht
+vom Anzeigenamen ab:
+
+```json
+{
+  "id": "analysis-areas",
+  "name": "Analysegebiete"
+}
+```
+
+Eine ID darf nicht ohne eigenes Migrations- und Compatibility-Konzept umbenannt
+werden. Zwei verfügbare Manifeste mit derselben ID schlagen fail-fast fehl; bekannte
+Manifestquellen können für die Fehlermeldung separat an `validate_manifests`
+übergeben werden.
+
+Capability- und Permission-IDs verwenden mindestens zwei durch Punkte getrennte,
+ebenfalls kebab-case-formatierte Segmente. Capabilities wie `map.layer`,
+`map.feature-info`, `analysis.provider`, `ui.navigation`, `jobs.provider` und
+`events.publisher` werden nur validiert, dedupliziert und transportiert. V1 führt
+keine abschließende Capability-Registry ein.
+
+Moduldefinierte Permissions müssen mit `<module-id>.` beginnen, zum Beispiel
+`example-biotopes.read`. Host/Core-Permissions werden nicht über ein Fachmanifest
+definiert. Auswertung und Registrierung der Permissions folgen in #104.
+
+## Felder
+
+| Feld | Bedeutung |
+|---|---|
+| `manifest_version` | Version des Manifest-Schemas, in V1 exakt `1` |
+| `id` | stabile technische Modul-ID |
+| `name` | menschenlesbarer Anzeigename |
+| `version` | vollständige SemVer-Modulversion |
+| `requires.host` | kompatible Host-Versionen |
+| `requires.sdk` | kompatible Public-SDK-Versionen |
+| `requires.modules` | erforderliche Module und deren Ranges |
+| `optional.modules` | optionale Module und deren Ranges |
+| `backend.package` | optionaler Python-Distributionsbezeichner |
+| `frontend.package` | optionaler npm-Paketbezeichner |
+| `capabilities` | offene, stabile Capability-IDs |
+| `permissions` | stabile, vom Modul namespacete Permission-IDs |
+| `config.namespace` | eindeutige Identität für die spätere Config Runtime aus #99 |
+| `persistence.schema` | deklarativer, unquoted-sicherer PostgreSQL-Schemaname |
+| `persistence.migrations` | kündigt eigene Migrationen für #97 deklarativ an |
+
+Backend-only-, Frontend-only- und kombinierte Module sind darstellbar. Die
+Package-Felder lösen in #93 weder Imports noch Downloads aus. Das Manifest enthält
+keine Secrets, SQL-Anweisungen, Entry-Point-Ausführung oder Settingswerte.
+
+`config.namespace` ist über die validierte Manifestmenge eindeutig und stabil.
+Environment-Namen, Secret-Zugriff und Settings-Lifecycle werden erst in #99
+definiert. Persistence-Metadaten erzeugen weder DB-Schemas noch Migrationen; der
+Alembic-Runner bleibt bis #97 unverändert.
+
+## Dependency-Semantik
+
+Eine Required Dependency muss in der vom Aufrufer bereitgestellten Menge vorhanden
+und versionskompatibel sein. Fehlt sie, entsteht ein
+`MissingModuleDependencyError`; bei falscher Version ein
+`ModuleDependencyVersionError`.
+
+Eine Optional Dependency darf fehlen. Ist sie vorhanden, muss ihre Version zur
+deklarierten Range passen; eine inkompatible vorhandene Version ist ebenfalls ein
+Fehler. Optional bedeutet nur, dass ein Modul zusätzliche Funktionalität nutzen
+kann. Es aktiviert oder lädt kein anderes Modul.
+
+Der Validator kennt keinen Enable/Disable-Zustand. #94/#112 übergeben ausschließlich
+die für den jeweiligen Bootstrap verfügbaren beziehungsweise aktiven Manifeste.
+Required und optional Self Dependencies sind verboten. Modulabhängigkeiten müssen
+deklariert sein; Host und SDK sind separate Compatibility Targets und werden nicht
+als künstliche Module modelliert.
+
+## Graph und Load Order
+
+`resolve_module_order()` führt einen topologischen Sort auf validierten Manifesten
+aus. Dependencies stehen stets vor ihren Consumern. Sind mehrere Module gleichzeitig
+ladbar, entscheidet die Modul-ID lexikografisch. Dadurch bleiben Startreihenfolge,
+Logs und Tests unabhängig von Discovery- oder Dateisystemreihenfolge reproduzierbar.
+
+Vorhandene optionale Dependencies bilden ebenfalls eine Sortierkante. Duplicate IDs,
+Self Dependencies, fehlende Required Dependencies und direkte oder indirekte Zyklen
+schlagen hart fehl. Ein Zyklusfehler enthält einen konkreten, deterministischen Pfad,
+zum Beispiel:
+
+```text
+module-a -> module-b -> module-c -> module-a
+```
+
+## Strukturierte Fehler
+
+- `ModuleManifestError`
+- `UnsupportedManifestVersionError`
+- `InvalidRuntimeVersionError`
+- `DuplicateModuleIdError`
+- `DuplicateConfigNamespaceError`
+- `ModuleCompatibilityError`
+- `MissingModuleDependencyError`
+- `ModuleDependencyVersionError`
+- `ModuleSelfDependencyError`
+- `ModuleDependencyCycleError`
+
+Die Fehler tragen je nach Fall Modul-ID, erwartete und gefundene Version,
+Dependency-ID, bekannte Origins oder den Cycle-Pfad. Sie benötigen weder FastAPI,
+Datenbank, Redis, globale Settings noch Netzwerk.
+
+## Beispiele
+
+Die Dateien unter [`examples/`](examples/) sind reine Dokumentations- und
+Test-Fixtures. Sie aktivieren oder migrieren keine bestehende Fachdomäne:
+
+- `example-pois.module.json`: unabhängiges Backend-Modul;
+- `example-layer-catalog.module.json`: unabhängiges Frontend-Modul;
+- `example-biotopes.module.json`: kombiniertes Modul mit erforderlichem
+  `example-layer-catalog` und optionalem `example-statistics`.
+
+Mit den vorhandenen Beispielen ergibt sich die Reihenfolge
+`example-layer-catalog`, `example-biotopes`, `example-pois`.

--- a/docs/modules/schema/module-manifest-v1.schema.json
+++ b/docs/modules/schema/module-manifest-v1.schema.json
@@ -1,0 +1,250 @@
+{
+  "$defs": {
+    "ModuleBackendPackage": {
+      "additionalProperties": false,
+      "description": "Deklarativer Python-Distributionsname; keine Import-Anweisung.",
+      "properties": {
+        "package": {
+          "maxLength": 214,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$",
+          "title": "Package",
+          "type": "string"
+        }
+      },
+      "required": [
+        "package"
+      ],
+      "title": "ModuleBackendPackage",
+      "type": "object"
+    },
+    "ModuleConfig": {
+      "additionalProperties": false,
+      "description": "Stabile Identität für das spätere Settings-Namespace aus #99.",
+      "properties": {
+        "namespace": {
+          "$ref": "#/$defs/ModuleId"
+        }
+      },
+      "required": [
+        "namespace"
+      ],
+      "title": "ModuleConfig",
+      "type": "object"
+    },
+    "ModuleFrontendPackage": {
+      "additionalProperties": false,
+      "description": "Deklarativer npm-Paketname; kein Runtime-Bundle oder Download-Endpunkt.",
+      "properties": {
+        "package": {
+          "maxLength": 214,
+          "minLength": 1,
+          "pattern": "^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$",
+          "title": "Package",
+          "type": "string"
+        }
+      },
+      "required": [
+        "package"
+      ],
+      "title": "ModuleFrontendPackage",
+      "type": "object"
+    },
+    "ModuleId": {
+      "maxLength": 63,
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+      "type": "string"
+    },
+    "ModuleOptionalRequirements": {
+      "additionalProperties": false,
+      "description": "Optionale Module, deren vorhandene Version dennoch kompatibel sein muss.",
+      "properties": {
+        "modules": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SemanticVersionRange"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/ModuleId"
+          },
+          "title": "Modules",
+          "type": "object"
+        }
+      },
+      "title": "ModuleOptionalRequirements",
+      "type": "object"
+    },
+    "ModulePersistence": {
+      "additionalProperties": false,
+      "description": "Deklarative Metadaten für das spätere Migrations-Ownership aus #97.",
+      "properties": {
+        "migrations": {
+          "default": false,
+          "title": "Migrations",
+          "type": "boolean"
+        },
+        "schema": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "title": "Schema",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema"
+      ],
+      "title": "ModulePersistence",
+      "type": "object"
+    },
+    "ModuleRequirements": {
+      "additionalProperties": false,
+      "description": "Pflichtkompatibilität und erforderliche Modulabhängigkeiten.",
+      "properties": {
+        "host": {
+          "$ref": "#/$defs/SemanticVersionRange"
+        },
+        "modules": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SemanticVersionRange"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/ModuleId"
+          },
+          "title": "Modules",
+          "type": "object"
+        },
+        "sdk": {
+          "$ref": "#/$defs/SemanticVersionRange"
+        }
+      },
+      "required": [
+        "host",
+        "sdk"
+      ],
+      "title": "ModuleRequirements",
+      "type": "object"
+    },
+    "NamespacedId": {
+      "maxLength": 127,
+      "minLength": 3,
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$",
+      "type": "string"
+    },
+    "SemanticVersion": {
+      "examples": [
+        "1.2.3"
+      ],
+      "format": "semver",
+      "maxLength": 128,
+      "minLength": 1,
+      "type": "string"
+    },
+    "SemanticVersionRange": {
+      "examples": [
+        ">=1.2.0,<2.0.0"
+      ],
+      "format": "semver-range",
+      "maxLength": 512,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Versionierter, deklarativer Kernvertrag eines Open-City-Planner-Moduls.",
+  "properties": {
+    "backend": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModuleBackendPackage"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "capabilities": {
+      "items": {
+        "$ref": "#/$defs/NamespacedId"
+      },
+      "title": "Capabilities",
+      "type": "array",
+      "uniqueItems": true
+    },
+    "config": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModuleConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "frontend": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModuleFrontendPackage"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "id": {
+      "$ref": "#/$defs/ModuleId"
+    },
+    "manifest_version": {
+      "const": 1,
+      "title": "Manifest Version",
+      "type": "integer"
+    },
+    "name": {
+      "maxLength": 120,
+      "minLength": 1,
+      "title": "Name",
+      "type": "string"
+    },
+    "optional": {
+      "$ref": "#/$defs/ModuleOptionalRequirements"
+    },
+    "permissions": {
+      "items": {
+        "$ref": "#/$defs/NamespacedId"
+      },
+      "title": "Permissions",
+      "type": "array",
+      "uniqueItems": true
+    },
+    "persistence": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModulePersistence"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "requires": {
+      "$ref": "#/$defs/ModuleRequirements"
+    },
+    "version": {
+      "$ref": "#/$defs/SemanticVersion"
+    }
+  },
+  "required": [
+    "manifest_version",
+    "id",
+    "name",
+    "version",
+    "requires"
+  ],
+  "title": "ModuleManifestV1",
+  "type": "object"
+}


### PR DESCRIPTION
## Ausgangslage

Im Rahmen von Epic #91 wurde mit #92 beziehungsweise PR #114 die Architektur für den modularen Open City Planner Host festgelegt.

Dieser Pull Request implementiert darauf aufbauend den ersten maschinenlesbaren Kernvertrag für Module. Er beschränkt sich bewusst auf Manifest-, Compatibility- und Dependency-Validierung und führt noch keine Module Runtime ein.

## Umsetzung

Implementiert wurden:

- versioniertes Module Manifest Schema V1;
- stark typisierte und strikt validierte Pydantic-Modelle;
- getrennte Versionen für Manifest-Schema, Modul und Host-/SDK-Kompatibilität;
- kanonische SemVer-Ranges wie `>=1.2.0,<2.0.0`;
- Validierung von Host- und SDK-Kompatibilität;
- Required und Optional Module Dependencies;
- Prüfung von Dependency-Versionen;
- Duplicate-Module-ID-Erkennung mit optionalen Manifestquellen;
- Erkennung doppelter Config-Namespaces;
- Ablehnung von Self Dependencies;
- direkte und indirekte Cycle Detection mit verständlichem Cycle-Pfad;
- deterministische topologische Load Order mit lexikografischem Tie-Breaking;
- Validierung und Deduplizierung offener Capability-IDs;
- modulbezogene Permission-IDs;
- deklarative Backend-, Frontend-, Config- und Persistence-Metadaten;
- strukturierte Fehlerklassen;
- committed JSON Schema mit Synchronitätstest gegen die Pydantic-Modelle;
- drei passive Beispielmanifeste;
- technische Contract-Dokumentation.

Für die SemVer-Auswertung wird die kleine, etablierte Bibliothek `python-semanticversion` verwendet. Das Lockfile wurde entsprechend aktualisiert.

## Dependency-Semantik

Required Dependencies müssen vorhanden und versionskompatibel sein.

Optional Dependencies dürfen fehlen. Wenn sie vorhanden sind, muss ihre Version jedoch ebenfalls kompatibel sein.

Vorhandene optionale Dependencies werden bei der Load Order vor ihrem Consumer eingeordnet.

## Abgrenzung

Dieser Pull Request implementiert ausdrücklich keine:

- FastAPI Module Runtime oder automatische Discovery;
- Router-Registrierung;
- Entry-Point-Ausführung;
- ModuleContext- oder Service Registry;
- Event-Bus- oder Job-Runtime;
- modulbezogenen Alembic Runner;
- Settings Runtime;
- Permission Engine;
- Nuxt-Layer oder Frontend Module Discovery;
- Map Extension Runtime;
- dynamische Installation oder Aktivierung von Modulen.

Manifestdaten werden nicht als Python-Imports, Shell-Befehle, SQL oder Templates ausgeführt. Package-Referenzen sind in #93 ausschließlich deklarative Strings.

## Production-Kompatibilität

Es wurden keine Änderungen an bestehenden:

- API-URLs oder Response-Verträgen;
- Authentifizierungs-, Cookie- oder CSRF-Abläufen;
- SSR- oder Kartenfunktionen;
- Datenbankmodellen oder Alembic-Migrationen;
- Redis-, Notification- oder Social-Publishing-Flows;
- Deployment- oder Observability-Abläufen

vorgenommen.

Der neue Contract liegt zunächst ungenutzt neben der bestehenden Anwendung.

## Tests

- `uv run pytest tests/test_module_manifest.py` – 58 Tests bestanden
- `uv run pytest` – 664 Tests bestanden
- `uv run ruff check app tests` – erfolgreich
- `uv lock --check` – erfolgreich
- FastAPI-Import-Smoke-Test – erfolgreich
- `git diff --check` – erfolgreich
- lokale Markdown-Links – erfolgreich

## Migration und Betrieb

Datenbankmigrationen: keine  
Konfigurationsänderungen: keine  
API-Änderungen: keine  
Rollout-/Rollback-Besonderheiten: keine

Basiert auf dem ADR aus #92 / PR #114.

Part of #91  
Closes #93