### PR TITLE
Feat/94 backend module runtime

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,8 @@ OTEL_TRACES_SAMPLER=parentbased_traceidratio
 OTEL_TRACES_SAMPLER_ARG=0.1
 APP_BASE_URL=http://localhost:3000
 API_BASE_URL=http://localhost:8000
+# Komma-separierte deploy-time Modul-IDs. Leer lässt alle neuen Module deaktiviert.
+ENABLED_MODULES=
 MAP_PREVIEW_RENDERER_URL=http://127.0.0.1:3020
 MAP_PREVIEW_RENDERER_TIMEOUT_SECONDS=20
 MAP_PREVIEW_CACHE_DIR=data/map-previews

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,6 +15,7 @@ MINIMUM_JWT_SECRET_LENGTH = 32
 
 class Settings(BaseSettings):
     api_version: str = "0.2.0"
+    enabled_modules: str = ""
     database_url: str = Field(
         default="postgresql+asyncpg://postgres:postgres@localhost:5432/open_city_map"
     )
@@ -227,6 +228,10 @@ class Settings(BaseSettings):
     @property
     def trusted_proxy_list(self) -> list[str]:
         return [value.strip() for value in self.trusted_proxies.split(",") if value.strip()]
+
+    @property
+    def enabled_module_list(self) -> list[str]:
+        return [value.strip() for value in self.enabled_modules.split(",") if value.strip()]
 
     def validate_security(self) -> None:
         if not self.metrics_path.startswith("/") or "?" in self.metrics_path:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,11 +20,21 @@ from app.observability.logging import configure_logging
 from app.observability.metrics import REDIS_AVAILABLE, REGISTRY, set_build_info
 from app.observability.middleware import ObservabilityMiddleware
 from app.observability.tracing import configure_tracing
+from app.platform.modules import (
+    EntryPointModuleDiscovery,
+    FirstPartyModuleDiscovery,
+    create_module_runtime,
+)
 from app.security.request_limits import RequestBodyLimitMiddleware
 from app.services.assistant_provider import close_assistant_provider
 from app.services.map_previews import MapPreviewError, map_preview_service
 
 settings = get_settings()
+module_runtime = create_module_runtime(
+    enabled_module_ids=settings.enabled_module_list,
+    discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
+    host_version=settings.api_version,
+)
 configure_logging(
     level=settings.log_level,
     service="stadtplaner-api",
@@ -49,11 +59,15 @@ else:
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     await initialize_redis()
     try:
+        await module_runtime.startup()
         yield
     finally:
-        await close_assistant_provider()
-        await close_redis()
-        tracing_runtime.shutdown()
+        try:
+            await module_runtime.shutdown()
+        finally:
+            await close_assistant_provider()
+            await close_redis()
+            tracing_runtime.shutdown()
 
 
 OPENAPI_TAGS = [
@@ -125,6 +139,7 @@ app.add_middleware(
 )
 
 app.include_router(api_router)
+module_runtime.register(app)
 
 
 @app.exception_handler(RequestValidationError)

--- a/backend/app/platform/__init__.py
+++ b/backend/app/platform/__init__.py
@@ -1,0 +1,1 @@
+"""Fachneutrale Plattformverträge des Open City Planner Hosts."""

--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -1,0 +1,55 @@
+"""Öffentlicher Contract für Modulmanifeste und Abhängigkeitsauflösung."""
+
+from app.platform.modules.dependency_graph import resolve_module_order
+from app.platform.modules.errors import (
+    DuplicateConfigNamespaceError,
+    DuplicateModuleIdError,
+    InvalidRuntimeVersionError,
+    MissingModuleDependencyError,
+    ModuleCompatibilityError,
+    ModuleDependencyCycleError,
+    ModuleDependencyError,
+    ModuleDependencyVersionError,
+    ModuleManifestError,
+    ModuleSelfDependencyError,
+    UnsupportedManifestVersionError,
+)
+from app.platform.modules.manifest import (
+    ModuleBackendPackage,
+    ModuleConfig,
+    ModuleFrontendPackage,
+    ModuleManifestV1,
+    ModuleOptionalRequirements,
+    ModulePersistence,
+    ModuleRequirements,
+    module_manifest_json_schema,
+    parse_manifest,
+    validate_manifest,
+    validate_manifests,
+)
+
+__all__ = [
+    "DuplicateConfigNamespaceError",
+    "DuplicateModuleIdError",
+    "InvalidRuntimeVersionError",
+    "MissingModuleDependencyError",
+    "ModuleBackendPackage",
+    "ModuleCompatibilityError",
+    "ModuleConfig",
+    "ModuleDependencyCycleError",
+    "ModuleDependencyError",
+    "ModuleDependencyVersionError",
+    "ModuleFrontendPackage",
+    "ModuleManifestError",
+    "ModuleManifestV1",
+    "ModuleOptionalRequirements",
+    "ModulePersistence",
+    "ModuleRequirements",
+    "ModuleSelfDependencyError",
+    "UnsupportedManifestVersionError",
+    "module_manifest_json_schema",
+    "parse_manifest",
+    "resolve_module_order",
+    "validate_manifest",
+    "validate_manifests",
+]

--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -1,6 +1,18 @@
-"""Öffentlicher Contract für Modulmanifeste und Abhängigkeitsauflösung."""
+"""Öffentliche Contracts der Backend-Module-Plattform."""
 
+from app.platform.modules.contracts import (
+    BackendModule,
+    ModuleDefinition,
+    ModuleDiscoveryProvider,
+    ModuleLifecycleHook,
+    ModuleRegistrationContext,
+)
 from app.platform.modules.dependency_graph import resolve_module_order
+from app.platform.modules.discovery import (
+    ENTRY_POINT_GROUP,
+    EntryPointModuleDiscovery,
+    FirstPartyModuleDiscovery,
+)
 from app.platform.modules.errors import (
     DuplicateConfigNamespaceError,
     DuplicateModuleIdError,
@@ -10,8 +22,15 @@ from app.platform.modules.errors import (
     ModuleDependencyCycleError,
     ModuleDependencyError,
     ModuleDependencyVersionError,
+    ModuleDiscoveryError,
+    ModuleLoadError,
     ModuleManifestError,
+    ModuleRegistrationError,
+    ModuleRuntimeError,
     ModuleSelfDependencyError,
+    ModuleShutdownError,
+    ModuleStartupError,
+    ModuleValidationError,
     UnsupportedManifestVersionError,
 )
 from app.platform.modules.manifest import (
@@ -27,26 +46,53 @@ from app.platform.modules.manifest import (
     validate_manifest,
     validate_manifests,
 )
+from app.platform.modules.runtime import (
+    MODULE_SDK_VERSION,
+    ModuleRecord,
+    ModuleRegistry,
+    ModuleRuntime,
+    create_module_runtime,
+)
 
 __all__ = [
+    "ENTRY_POINT_GROUP",
+    "MODULE_SDK_VERSION",
+    "BackendModule",
     "DuplicateConfigNamespaceError",
     "DuplicateModuleIdError",
+    "EntryPointModuleDiscovery",
+    "FirstPartyModuleDiscovery",
     "InvalidRuntimeVersionError",
     "MissingModuleDependencyError",
     "ModuleBackendPackage",
     "ModuleCompatibilityError",
     "ModuleConfig",
+    "ModuleDefinition",
     "ModuleDependencyCycleError",
     "ModuleDependencyError",
     "ModuleDependencyVersionError",
+    "ModuleDiscoveryError",
+    "ModuleDiscoveryProvider",
     "ModuleFrontendPackage",
+    "ModuleLifecycleHook",
+    "ModuleLoadError",
     "ModuleManifestError",
     "ModuleManifestV1",
     "ModuleOptionalRequirements",
     "ModulePersistence",
+    "ModuleRecord",
+    "ModuleRegistrationContext",
+    "ModuleRegistrationError",
+    "ModuleRegistry",
     "ModuleRequirements",
+    "ModuleRuntime",
+    "ModuleRuntimeError",
     "ModuleSelfDependencyError",
+    "ModuleShutdownError",
+    "ModuleStartupError",
+    "ModuleValidationError",
     "UnsupportedManifestVersionError",
+    "create_module_runtime",
     "module_manifest_json_schema",
     "parse_manifest",
     "resolve_module_order",

--- a/backend/app/platform/modules/contracts.py
+++ b/backend/app/platform/modules/contracts.py
@@ -1,0 +1,98 @@
+"""Kleine öffentliche Registrierungsverträge der Backend-Module-Runtime."""
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from fastapi import APIRouter
+
+from app.platform.modules.manifest import ManifestInput, ModuleManifestV1
+
+type ModuleLifecycleHook = Callable[[], Awaitable[None]]
+type ModuleLoader = Callable[[], "BackendModule"]
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleDefinition:
+    """Passive Discovery-Metadaten und verzögerte Modulinstanziierung."""
+
+    manifest: ManifestInput | ModuleManifestV1
+    loader: ModuleLoader
+    origin: str
+    declared_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class RouterContribution:
+    """Vom Host kontrolliert einzubindender FastAPI-Router."""
+
+    router: APIRouter
+    prefix: str = ""
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleContribution:
+    """Zusammengehörige asynchrone Startup-/Shutdown-Beiträge."""
+
+    startup: ModuleLifecycleHook | None = None
+    shutdown: ModuleLifecycleHook | None = None
+
+
+class ModuleRegistrationContext:
+    """Minimaler Context für Router und asynchrone Lifecycle-Beiträge."""
+
+    def __init__(self) -> None:
+        self._routers: list[RouterContribution] = []
+        self._lifecycle: list[LifecycleContribution] = []
+        self._open = True
+
+    @property
+    def routers(self) -> Sequence[RouterContribution]:
+        return tuple(self._routers)
+
+    @property
+    def lifecycle(self) -> Sequence[LifecycleContribution]:
+        return tuple(self._lifecycle)
+
+    def include_router(
+        self,
+        router: APIRouter,
+        *,
+        prefix: str = "",
+        tags: Sequence[str] = (),
+    ) -> None:
+        self._ensure_open()
+        self._routers.append(RouterContribution(router, prefix, tuple(tags)))
+
+    def add_lifecycle(
+        self,
+        *,
+        startup: ModuleLifecycleHook | None = None,
+        shutdown: ModuleLifecycleHook | None = None,
+    ) -> None:
+        self._ensure_open()
+        if startup is None and shutdown is None:
+            raise ValueError("A lifecycle contribution requires a startup or shutdown hook.")
+        self._lifecycle.append(LifecycleContribution(startup, shutdown))
+
+    def close(self) -> None:
+        self._open = False
+
+    def _ensure_open(self) -> None:
+        if not self._open:
+            raise RuntimeError("The module registration context is closed.")
+
+
+class BackendModule(Protocol):
+    """Öffentlicher, bewusst kleiner Backend-Modulvertrag."""
+
+    manifest: ModuleManifestV1
+
+    def register(self, context: ModuleRegistrationContext) -> None: ...
+
+
+class ModuleDiscoveryProvider(Protocol):
+    """Liefert nur Definitionen explizit aktivierter deploy-time Module."""
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]: ...

--- a/backend/app/platform/modules/dependency_graph.py
+++ b/backend/app/platform/modules/dependency_graph.py
@@ -1,0 +1,99 @@
+"""Reine, deterministische Auflösung des Modulabhängigkeitsgraphen."""
+
+import heapq
+from collections.abc import Sequence
+
+from app.platform.modules.errors import (
+    DuplicateModuleIdError,
+    MissingModuleDependencyError,
+    ModuleDependencyCycleError,
+    ModuleSelfDependencyError,
+)
+from app.platform.modules.manifest import ModuleManifestV1
+
+
+def _available_dependencies(
+    manifest: ModuleManifestV1,
+    modules_by_id: dict[str, ModuleManifestV1],
+) -> set[str]:
+    dependencies = set(manifest.requires.modules)
+    dependencies.update(
+        dependency_id
+        for dependency_id in manifest.optional.modules
+        if dependency_id in modules_by_id
+    )
+    return dependencies
+
+
+def _find_cycle(
+    modules_by_id: dict[str, ModuleManifestV1],
+) -> tuple[str, ...]:
+    state: dict[str, int] = {module_id: 0 for module_id in modules_by_id}
+    stack: list[str] = []
+    stack_positions: dict[str, int] = {}
+
+    def visit(module_id: str) -> tuple[str, ...] | None:
+        state[module_id] = 1
+        stack_positions[module_id] = len(stack)
+        stack.append(module_id)
+        dependencies = _available_dependencies(modules_by_id[module_id], modules_by_id)
+        for dependency_id in sorted(dependencies):
+            if state[dependency_id] == 0:
+                cycle = visit(dependency_id)
+                if cycle is not None:
+                    return cycle
+            elif state[dependency_id] == 1:
+                start = stack_positions[dependency_id]
+                return tuple(stack[start:] + [dependency_id])
+        stack.pop()
+        stack_positions.pop(module_id)
+        state[module_id] = 2
+        return None
+
+    for module_id in sorted(modules_by_id):
+        if state[module_id] == 0:
+            cycle = visit(module_id)
+            if cycle is not None:
+                return cycle
+    return ()
+
+
+def resolve_module_order(manifests: Sequence[ModuleManifestV1]) -> tuple[ModuleManifestV1, ...]:
+    """Sortiere Dependencies vor Consumer; gleiche Kandidaten lexikografisch nach ID."""
+
+    modules_by_id: dict[str, ModuleManifestV1] = {}
+    for manifest in manifests:
+        if manifest.id in modules_by_id:
+            raise DuplicateModuleIdError(manifest.id)
+        modules_by_id[manifest.id] = manifest
+
+    dependents: dict[str, set[str]] = {module_id: set() for module_id in modules_by_id}
+    indegree: dict[str, int] = {module_id: 0 for module_id in modules_by_id}
+    for manifest in manifests:
+        dependencies = _available_dependencies(manifest, modules_by_id)
+        for dependency_id in sorted(dependencies):
+            if dependency_id == manifest.id:
+                raise ModuleSelfDependencyError(
+                    manifest.id,
+                    optional=dependency_id in manifest.optional.modules,
+                )
+            if dependency_id not in modules_by_id:
+                expected = manifest.requires.modules[dependency_id]
+                raise MissingModuleDependencyError(manifest.id, dependency_id, expected)
+            dependents[dependency_id].add(manifest.id)
+            indegree[manifest.id] += 1
+
+    ready = [module_id for module_id, degree in indegree.items() if degree == 0]
+    heapq.heapify(ready)
+    order: list[ModuleManifestV1] = []
+    while ready:
+        module_id = heapq.heappop(ready)
+        order.append(modules_by_id[module_id])
+        for dependent_id in sorted(dependents[module_id]):
+            indegree[dependent_id] -= 1
+            if indegree[dependent_id] == 0:
+                heapq.heappush(ready, dependent_id)
+
+    if len(order) != len(manifests):
+        raise ModuleDependencyCycleError(_find_cycle(modules_by_id))
+    return tuple(order)

--- a/backend/app/platform/modules/discovery.py
+++ b/backend/app/platform/modules/discovery.py
@@ -1,0 +1,85 @@
+"""Kontrollierte First-Party- und Python-Entry-Point-Discovery."""
+
+from collections.abc import Callable, Mapping, Sequence
+from importlib import metadata
+from types import MappingProxyType
+
+from app.platform.modules.contracts import ModuleDefinition
+from app.platform.modules.errors import ModuleDiscoveryError
+
+ENTRY_POINT_GROUP = "open_city_planner.modules"
+type DefinitionSource = ModuleDefinition | Callable[[], ModuleDefinition]
+
+# First-Party-Module werden hier später deklarativ ergänzt. Leer bedeutet, dass die
+# produktive Legacy-Anwendung ohne neue Module unverändert startet.
+FIRST_PARTY_MODULES: Mapping[str, DefinitionSource] = MappingProxyType({})
+
+
+class FirstPartyModuleDiscovery:
+    """Discovery aus einem fachneutralen, deploy-time kontrollierten Katalog."""
+
+    def __init__(self, catalog: Mapping[str, DefinitionSource] = FIRST_PARTY_MODULES) -> None:
+        self._catalog = catalog
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        definitions: list[ModuleDefinition] = []
+        for module_id in sorted(enabled_module_ids.intersection(self._catalog)):
+            source = self._catalog[module_id]
+            try:
+                definition = source() if callable(source) else source
+            except Exception as exc:
+                raise ModuleDiscoveryError(
+                    "The first-party module definition could not be loaded.",
+                    module_id=module_id,
+                    origin="first-party",
+                ) from exc
+            if not isinstance(definition, ModuleDefinition):
+                raise ModuleDiscoveryError(
+                    "The first-party catalog entry is not a ModuleDefinition.",
+                    module_id=module_id,
+                    origin="first-party",
+                )
+            definitions.append(
+                ModuleDefinition(
+                    manifest=definition.manifest,
+                    loader=definition.loader,
+                    origin=definition.origin,
+                    declared_id=module_id,
+                )
+            )
+        return tuple(definitions)
+
+
+class EntryPointModuleDiscovery:
+    """Discovery vertrauenswürdiger installierter Python-Distributionen."""
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        definitions: list[ModuleDefinition] = []
+        entry_points = metadata.entry_points().select(group=ENTRY_POINT_GROUP)
+        for entry_point in sorted(entry_points, key=lambda candidate: candidate.name):
+            if entry_point.name not in enabled_module_ids:
+                continue
+            origin = f"entry-point:{entry_point.name}={entry_point.value}"
+            try:
+                definition = entry_point.load()
+            except Exception as exc:
+                raise ModuleDiscoveryError(
+                    "The enabled Python entry point could not be loaded.",
+                    module_id=entry_point.name,
+                    origin=origin,
+                ) from exc
+            if not isinstance(definition, ModuleDefinition):
+                raise ModuleDiscoveryError(
+                    "The Python entry point does not expose a ModuleDefinition.",
+                    module_id=entry_point.name,
+                    origin=origin,
+                )
+            definitions.append(
+                ModuleDefinition(
+                    manifest=definition.manifest,
+                    loader=definition.loader,
+                    origin=origin,
+                    declared_id=entry_point.name,
+                )
+            )
+        return tuple(definitions)

--- a/backend/app/platform/modules/errors.py
+++ b/backend/app/platform/modules/errors.py
@@ -1,0 +1,155 @@
+"""Strukturierte Fehler des Modulmanifest-Contracts."""
+
+from collections.abc import Sequence
+from typing import Any
+
+
+class ModuleManifestError(ValueError):
+    """Basisklasse für ungültige Manifestdaten."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        module_id: str | None = None,
+        origin: str | None = None,
+        details: list[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.module_id = module_id
+        self.origin = origin
+        self.details = details or []
+
+
+class UnsupportedManifestVersionError(ModuleManifestError):
+    """Die angegebene Manifest-Schemaversion wird nicht unterstützt."""
+
+    def __init__(self, manifest_version: object, *, origin: str | None = None) -> None:
+        super().__init__(
+            f"Unsupported module manifest version: {manifest_version!r}; supported version is 1.",
+            origin=origin,
+        )
+        self.manifest_version = manifest_version
+
+
+class InvalidRuntimeVersionError(ModuleManifestError):
+    """Host oder SDK haben keine gültige SemVer-Version übergeben."""
+
+    def __init__(self, target: str, version: str) -> None:
+        super().__init__(f"Current {target} version {version!r} is not valid SemVer.")
+        self.target = target
+        self.version = version
+
+
+class DuplicateModuleIdError(ModuleManifestError):
+    """Mehrere verfügbare Manifeste verwenden dieselbe Modul-ID."""
+
+    def __init__(
+        self,
+        module_id: str,
+        *,
+        origins: Sequence[str | None] = (),
+    ) -> None:
+        known_origins = [origin for origin in origins if origin]
+        origin_suffix = f" Origins: {', '.join(known_origins)}." if known_origins else ""
+        super().__init__(
+            f'Duplicate module ID "{module_id}".{origin_suffix}',
+            module_id=module_id,
+        )
+        self.origins = tuple(origins)
+
+
+class DuplicateConfigNamespaceError(ModuleManifestError):
+    """Zwei Module beanspruchen denselben Konfigurations-Namespace."""
+
+    def __init__(self, namespace: str, module_ids: Sequence[str]) -> None:
+        joined_ids = ", ".join(module_ids)
+        super().__init__(
+            f'Config namespace "{namespace}" is used by multiple modules: {joined_ids}.'
+        )
+        self.namespace = namespace
+        self.module_ids = tuple(module_ids)
+
+
+class ModuleCompatibilityError(ModuleManifestError):
+    """Ein Modul ist mit der aktuellen Host- oder SDK-Version inkompatibel."""
+
+    def __init__(
+        self,
+        module_id: str,
+        module_version: str,
+        target: str,
+        expected: str,
+        found: str,
+    ) -> None:
+        super().__init__(
+            f'Module "{module_id}" {module_version} requires {target} {expected}, '
+            f"current {target} is {found}.",
+            module_id=module_id,
+        )
+        self.module_version = module_version
+        self.target = target
+        self.expected = expected
+        self.found = found
+
+
+class ModuleDependencyError(ModuleManifestError):
+    """Basisklasse für ungültige Modulabhängigkeiten."""
+
+
+class MissingModuleDependencyError(ModuleDependencyError):
+    """Eine erforderliche Modulabhängigkeit ist nicht verfügbar."""
+
+    def __init__(self, module_id: str, dependency_id: str, expected: str) -> None:
+        super().__init__(
+            f'Module "{module_id}" requires module "{dependency_id}" {expected}, '
+            "but it is not available.",
+            module_id=module_id,
+        )
+        self.dependency_id = dependency_id
+        self.expected = expected
+
+
+class ModuleDependencyVersionError(ModuleDependencyError):
+    """Eine vorhandene required/optional Dependency hat die falsche Version."""
+
+    def __init__(
+        self,
+        module_id: str,
+        dependency_id: str,
+        expected: str,
+        found: str,
+        *,
+        optional: bool,
+    ) -> None:
+        dependency_kind = "optional module" if optional else "module"
+        super().__init__(
+            f'Module "{module_id}" requires {dependency_kind} "{dependency_id}" '
+            f"{expected}, found {found}.",
+            module_id=module_id,
+        )
+        self.dependency_id = dependency_id
+        self.expected = expected
+        self.found = found
+        self.optional = optional
+
+
+class ModuleSelfDependencyError(ModuleDependencyError):
+    """Ein Modul darf weder required noch optional von sich selbst abhängen."""
+
+    def __init__(self, module_id: str, *, optional: bool) -> None:
+        dependency_kind = "optional" if optional else "required"
+        super().__init__(
+            f'Module "{module_id}" has a {dependency_kind} dependency on itself.',
+            module_id=module_id,
+        )
+        self.optional = optional
+
+
+class ModuleDependencyCycleError(ModuleDependencyError):
+    """Der Modulgraph enthält einen Zyklus."""
+
+    def __init__(self, cycle: Sequence[str]) -> None:
+        cycle_path = tuple(cycle)
+        super().__init__(f"Module dependency cycle detected: {' -> '.join(cycle_path)}.")
+        self.cycle = cycle_path

--- a/backend/app/platform/modules/errors.py
+++ b/backend/app/platform/modules/errors.py
@@ -153,3 +153,73 @@ class ModuleDependencyCycleError(ModuleDependencyError):
         cycle_path = tuple(cycle)
         super().__init__(f"Module dependency cycle detected: {' -> '.join(cycle_path)}.")
         self.cycle = cycle_path
+
+
+class ModuleRuntimeError(RuntimeError):
+    """Basisklasse für Fehler während einer Phase der Module Runtime."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        phase: str,
+        module_id: str | None = None,
+        origin: str | None = None,
+    ) -> None:
+        context = [f"phase={phase}"]
+        if module_id is not None:
+            context.append(f"module_id={module_id}")
+        if origin is not None:
+            context.append(f"origin={origin}")
+        super().__init__(f"Module runtime error ({', '.join(context)}): {message}")
+        self.phase = phase
+        self.module_id = module_id
+        self.origin = origin
+
+
+class ModuleDiscoveryError(ModuleRuntimeError):
+    """Discovery eines aktivierten Moduls ist fehlgeschlagen."""
+
+    def __init__(
+        self, message: str, *, module_id: str | None = None, origin: str | None = None
+    ) -> None:
+        super().__init__(message, phase="discovery", module_id=module_id, origin=origin)
+
+
+class ModuleValidationError(ModuleRuntimeError):
+    """Ein entdecktes Modul konnte nicht validiert werden."""
+
+    def __init__(
+        self, message: str, *, module_id: str | None = None, origin: str | None = None
+    ) -> None:
+        super().__init__(message, phase="validation", module_id=module_id, origin=origin)
+
+
+class ModuleLoadError(ModuleRuntimeError):
+    """Die Instanziierung eines validierten Moduls ist fehlgeschlagen."""
+
+    def __init__(self, message: str, *, module_id: str, origin: str | None = None) -> None:
+        super().__init__(message, phase="import", module_id=module_id, origin=origin)
+
+
+class ModuleRegistrationError(ModuleRuntimeError):
+    """Die deklarative Registrierung eines Moduls ist fehlgeschlagen."""
+
+    def __init__(
+        self, message: str, *, module_id: str | None = None, origin: str | None = None
+    ) -> None:
+        super().__init__(message, phase="registration", module_id=module_id, origin=origin)
+
+
+class ModuleStartupError(ModuleRuntimeError):
+    """Ein Modul konnte nicht vollständig gestartet werden."""
+
+    def __init__(self, message: str, *, module_id: str | None = None) -> None:
+        super().__init__(message, phase="startup", module_id=module_id)
+
+
+class ModuleShutdownError(ModuleRuntimeError):
+    """Mindestens ein Modul konnte nicht sauber beendet werden."""
+
+    def __init__(self, message: str, *, module_id: str | None = None) -> None:
+        super().__init__(message, phase="shutdown", module_id=module_id)

--- a/backend/app/platform/modules/manifest.py
+++ b/backend/app/platform/modules/manifest.py
@@ -1,0 +1,378 @@
+"""Manifest Schema V1 und reine Compatibility-Validierung.
+
+Der Contract verarbeitet bereits dekodierte Mappings. Dateizugriff, YAML-Loader,
+Package-Discovery und Runtime-Aktivierung gehören bewusst nicht in dieses Modul.
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import Annotated, Any, Literal
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+    WithJsonSchema,
+    field_validator,
+    model_validator,
+)
+from semantic_version import SimpleSpec, Version
+
+from app.platform.modules.errors import (
+    DuplicateConfigNamespaceError,
+    DuplicateModuleIdError,
+    InvalidRuntimeVersionError,
+    MissingModuleDependencyError,
+    ModuleCompatibilityError,
+    ModuleDependencyVersionError,
+    ModuleManifestError,
+    ModuleSelfDependencyError,
+    UnsupportedManifestVersionError,
+)
+
+MANIFEST_VERSION = 1
+MODULE_ID_PATTERN = r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+NAMESPACED_ID_PATTERN = (
+    r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$"
+)
+PYTHON_PACKAGE_PATTERN = r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$"
+NPM_PACKAGE_PATTERN = r"^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$"
+POSTGRES_IDENTIFIER_PATTERN = r"^[a-z][a-z0-9_]*$"
+VERSION_OPERATORS = (">=", "<=", "==", "!=", ">", "<")
+
+
+def _validate_semver(value: str) -> str:
+    try:
+        Version(value)
+    except ValueError as exc:
+        raise ValueError("must be a complete SemVer version such as 1.2.3") from exc
+    return value
+
+
+def _validate_version_range(value: str) -> str:
+    if value != value.strip() or not value:
+        raise ValueError("must be a non-empty canonical SemVer range without outer whitespace")
+
+    clauses = value.split(",")
+    for clause in clauses:
+        if not clause or clause != clause.strip():
+            raise ValueError("range clauses must be comma-separated without whitespace")
+        operator = next(
+            (candidate for candidate in VERSION_OPERATORS if clause.startswith(candidate)), None
+        )
+        if operator is None:
+            raise ValueError(
+                "range clauses must use one of >=, <=, ==, !=, > or < with a complete SemVer"
+            )
+        version_text = clause[len(operator) :]
+        try:
+            Version(version_text)
+        except ValueError as exc:
+            raise ValueError(
+                f"range clause {clause!r} must contain a complete SemVer version"
+            ) from exc
+
+    try:
+        SimpleSpec(value)
+    except ValueError as exc:
+        raise ValueError("must be a valid canonical SemVer range") from exc
+    return value
+
+
+type ModuleId = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=False,
+        min_length=1,
+        max_length=63,
+        pattern=MODULE_ID_PATTERN,
+    ),
+]
+type NamespacedId = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=False,
+        min_length=3,
+        max_length=127,
+        pattern=NAMESPACED_ID_PATTERN,
+    ),
+]
+type SemanticVersion = Annotated[
+    str,
+    StringConstraints(strip_whitespace=False, min_length=1, max_length=128),
+    AfterValidator(_validate_semver),
+    WithJsonSchema(
+        {
+            "type": "string",
+            "format": "semver",
+            "minLength": 1,
+            "maxLength": 128,
+            "examples": ["1.2.3"],
+        }
+    ),
+]
+type SemanticVersionRange = Annotated[
+    str,
+    StringConstraints(strip_whitespace=False, min_length=1, max_length=512),
+    AfterValidator(_validate_version_range),
+    WithJsonSchema(
+        {
+            "type": "string",
+            "format": "semver-range",
+            "minLength": 1,
+            "maxLength": 512,
+            "examples": [">=1.2.0,<2.0.0"],
+        }
+    ),
+]
+
+
+class StrictManifestModel(BaseModel):
+    """Gemeinsame Strictness-Regeln aller Manifest-V1-Objekte."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class ModuleRequirements(StrictManifestModel):
+    """Pflichtkompatibilität und erforderliche Modulabhängigkeiten."""
+
+    host: SemanticVersionRange
+    sdk: SemanticVersionRange
+    modules: dict[ModuleId, SemanticVersionRange] = Field(default_factory=dict)
+
+
+class ModuleOptionalRequirements(StrictManifestModel):
+    """Optionale Module, deren vorhandene Version dennoch kompatibel sein muss."""
+
+    modules: dict[ModuleId, SemanticVersionRange] = Field(default_factory=dict)
+
+
+class ModuleBackendPackage(StrictManifestModel):
+    """Deklarativer Python-Distributionsname; keine Import-Anweisung."""
+
+    package: str = Field(min_length=1, max_length=214, pattern=PYTHON_PACKAGE_PATTERN)
+
+
+class ModuleFrontendPackage(StrictManifestModel):
+    """Deklarativer npm-Paketname; kein Runtime-Bundle oder Download-Endpunkt."""
+
+    package: str = Field(min_length=1, max_length=214, pattern=NPM_PACKAGE_PATTERN)
+
+
+class ModuleConfig(StrictManifestModel):
+    """Stabile Identität für das spätere Settings-Namespace aus #99."""
+
+    namespace: ModuleId
+
+
+class ModulePersistence(StrictManifestModel):
+    """Deklarative Metadaten für das spätere Migrations-Ownership aus #97."""
+
+    schema_name: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=63,
+        pattern=POSTGRES_IDENTIFIER_PATTERN,
+    )
+    migrations: bool = False
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        strict=True,
+        validate_by_alias=True,
+        validate_by_name=False,
+    )
+
+
+class ModuleManifestV1(StrictManifestModel):
+    """Versionierter, deklarativer Kernvertrag eines Open-City-Planner-Moduls."""
+
+    manifest_version: Literal[1]
+    id: ModuleId
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=120)]
+    version: SemanticVersion
+    requires: ModuleRequirements
+    optional: ModuleOptionalRequirements = Field(default_factory=ModuleOptionalRequirements)
+    backend: ModuleBackendPackage | None = None
+    frontend: ModuleFrontendPackage | None = None
+    capabilities: list[NamespacedId] = Field(
+        default_factory=list, json_schema_extra={"uniqueItems": True}
+    )
+    permissions: list[NamespacedId] = Field(
+        default_factory=list, json_schema_extra={"uniqueItems": True}
+    )
+    config: ModuleConfig | None = None
+    persistence: ModulePersistence | None = None
+
+    @field_validator("capabilities", "permissions")
+    @classmethod
+    def identifiers_must_be_unique(cls, values: list[str]) -> list[str]:
+        duplicates = sorted({value for value in values if values.count(value) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate identifiers are forbidden: {', '.join(duplicates)}")
+        return values
+
+    @model_validator(mode="after")
+    def validate_owned_identifiers(self) -> "ModuleManifestV1":
+        permission_prefix = f"{self.id}."
+        invalid_permissions = [
+            permission for permission in self.permissions if not permission.startswith(permission_prefix)
+        ]
+        if invalid_permissions:
+            raise ValueError(
+                f'module permissions must start with "{permission_prefix}": '
+                f"{', '.join(invalid_permissions)}"
+            )
+        overlapping_dependencies = sorted(
+            set(self.requires.modules).intersection(self.optional.modules)
+        )
+        if overlapping_dependencies:
+            raise ValueError(
+                "module dependencies cannot be both required and optional: "
+                f"{', '.join(overlapping_dependencies)}"
+            )
+        return self
+
+
+type ManifestInput = Mapping[str, Any]
+
+
+def parse_manifest(data: ManifestInput, *, origin: str | None = None) -> ModuleManifestV1:
+    """Parse ein bereits sicher dekodiertes Mapping als Manifest Schema V1."""
+
+    if not isinstance(data, Mapping):
+        raise ModuleManifestError("Invalid module manifest: expected a decoded mapping.")
+    manifest_version = data.get("manifest_version")
+    if type(manifest_version) is not int or manifest_version != MANIFEST_VERSION:
+        raise UnsupportedManifestVersionError(manifest_version, origin=origin)
+    try:
+        return ModuleManifestV1.model_validate(data)
+    except ValidationError as exc:
+        module_id = data.get("id") if isinstance(data.get("id"), str) else None
+        location = f" from {origin}" if origin else ""
+        raise ModuleManifestError(
+            f"Invalid module manifest{location}: {exc}",
+            module_id=module_id,
+            origin=origin,
+            details=exc.errors(include_url=False),
+        ) from exc
+
+
+def _runtime_version(value: str, target: str) -> Version:
+    try:
+        return Version(value)
+    except ValueError as exc:
+        raise InvalidRuntimeVersionError(target, value) from exc
+
+
+def _matches(version: str, expected: str) -> bool:
+    return Version(version) in SimpleSpec(expected)
+
+
+def validate_manifest(
+    manifest: ModuleManifestV1,
+    *,
+    host_version: str,
+    sdk_version: str,
+) -> ModuleManifestV1:
+    """Prüfe ein Manifest isoliert gegen explizit übergebene Host-/SDK-Versionen."""
+
+    if manifest.id in manifest.requires.modules:
+        raise ModuleSelfDependencyError(manifest.id, optional=False)
+    if manifest.id in manifest.optional.modules:
+        raise ModuleSelfDependencyError(manifest.id, optional=True)
+
+    host = _runtime_version(host_version, "host")
+    sdk = _runtime_version(sdk_version, "sdk")
+    for target, current, expected in (
+        ("host", host, manifest.requires.host),
+        ("sdk", sdk, manifest.requires.sdk),
+    ):
+        if current not in SimpleSpec(expected):
+            raise ModuleCompatibilityError(
+                manifest.id,
+                manifest.version,
+                target,
+                expected,
+                str(current),
+            )
+    return manifest
+
+
+def validate_manifests(
+    manifests: Sequence[ModuleManifestV1],
+    *,
+    host_version: str,
+    sdk_version: str,
+    origins: Sequence[str | None] | None = None,
+) -> tuple[ModuleManifestV1, ...]:
+    """Prüfe Compatibility und Dependencies einer verfügbaren/aktiven Modulmenge."""
+
+    if origins is not None and len(origins) != len(manifests):
+        raise ValueError("origins must have the same length as manifests")
+
+    modules_by_id: dict[str, ModuleManifestV1] = {}
+    first_index_by_id: dict[str, int] = {}
+    for index, manifest in enumerate(manifests):
+        if manifest.id in modules_by_id:
+            duplicate_origins: tuple[str | None, ...] = ()
+            if origins is not None:
+                duplicate_origins = (origins[first_index_by_id[manifest.id]], origins[index])
+            raise DuplicateModuleIdError(manifest.id, origins=duplicate_origins)
+        modules_by_id[manifest.id] = manifest
+        first_index_by_id[manifest.id] = index
+
+    config_owners: dict[str, str] = {}
+    for manifest in manifests:
+        if manifest.config is None:
+            continue
+        namespace = manifest.config.namespace
+        if namespace in config_owners:
+            raise DuplicateConfigNamespaceError(
+                namespace, (config_owners[namespace], manifest.id)
+            )
+        config_owners[namespace] = manifest.id
+
+    for manifest in manifests:
+        validate_manifest(
+            manifest,
+            host_version=host_version,
+            sdk_version=sdk_version,
+        )
+        for dependency_id, expected in manifest.requires.modules.items():
+            if dependency_id == manifest.id:
+                raise ModuleSelfDependencyError(manifest.id, optional=False)
+            dependency = modules_by_id.get(dependency_id)
+            if dependency is None:
+                raise MissingModuleDependencyError(manifest.id, dependency_id, expected)
+            if not _matches(dependency.version, expected):
+                raise ModuleDependencyVersionError(
+                    manifest.id,
+                    dependency_id,
+                    expected,
+                    dependency.version,
+                    optional=False,
+                )
+        for dependency_id, expected in manifest.optional.modules.items():
+            if dependency_id == manifest.id:
+                raise ModuleSelfDependencyError(manifest.id, optional=True)
+            dependency = modules_by_id.get(dependency_id)
+            if dependency is not None and not _matches(dependency.version, expected):
+                raise ModuleDependencyVersionError(
+                    manifest.id,
+                    dependency_id,
+                    expected,
+                    dependency.version,
+                    optional=True,
+                )
+    return tuple(manifests)
+
+
+def module_manifest_json_schema() -> dict[str, Any]:
+    """Liefere das deterministische JSON Schema des Manifest-V1-Single-Source-of-Truth."""
+
+    schema = ModuleManifestV1.model_json_schema(by_alias=True)
+    return {"$schema": "https://json-schema.org/draft/2020-12/schema", **schema}

--- a/backend/app/platform/modules/manifest.py
+++ b/backend/app/platform/modules/manifest.py
@@ -278,7 +278,7 @@ def validate_manifest(
     host_version: str,
     sdk_version: str,
 ) -> ModuleManifestV1:
-    """Prüfe ein Manifest isoliert gegen explizit übergebene Host-/SDK-Versionen."""
+    """Isolierte Validierung eines Manifests gegen übergebene Host-/SDK-Versionen."""
 
     if manifest.id in manifest.requires.modules:
         raise ModuleSelfDependencyError(manifest.id, optional=False)
@@ -309,7 +309,7 @@ def validate_manifests(
     sdk_version: str,
     origins: Sequence[str | None] | None = None,
 ) -> tuple[ModuleManifestV1, ...]:
-    """Prüfe Compatibility und Dependencies einer verfügbaren/aktiven Modulmenge."""
+    """Validierung von Kompatibilität und Abhängigkeiten einer verfügbaren Modulmenge."""
 
     if origins is not None and len(origins) != len(manifests):
         raise ValueError("origins must have the same length as manifests")

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -1,0 +1,290 @@
+"""Deterministische Backend-Module-Registry und Lifecycle-Orchestrierung."""
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from fastapi import FastAPI
+
+from app.platform.modules.contracts import (
+    BackendModule,
+    LifecycleContribution,
+    ModuleDefinition,
+    ModuleDiscoveryProvider,
+    ModuleRegistrationContext,
+)
+from app.platform.modules.dependency_graph import resolve_module_order
+from app.platform.modules.errors import (
+    ModuleDiscoveryError,
+    ModuleLoadError,
+    ModuleManifestError,
+    ModuleRegistrationError,
+    ModuleShutdownError,
+    ModuleStartupError,
+    ModuleValidationError,
+)
+from app.platform.modules.manifest import ModuleManifestV1, parse_manifest, validate_manifests
+
+logger = logging.getLogger(__name__)
+MODULE_SDK_VERSION = "1.0.0"
+
+
+@dataclass(slots=True)
+class ModuleRecord:
+    """Kompakter interner Runtime-Eintrag ohne vollständige Lifecycle-State-Machine."""
+
+    manifest: ModuleManifestV1
+    module: BackendModule
+    origin: str
+    load_index: int
+    context: ModuleRegistrationContext
+    registered: bool = False
+
+    @property
+    def capabilities(self) -> tuple[str, ...]:
+        return tuple(self.manifest.capabilities)
+
+
+class ModuleRegistry:
+    """Hält validierte Module in ihrer deterministischen Load Order."""
+
+    def __init__(self, records: Sequence[ModuleRecord] = ()) -> None:
+        self._records = list(records)
+
+    @property
+    def records(self) -> tuple[ModuleRecord, ...]:
+        return tuple(self._records)
+
+    def get(self, module_id: str) -> ModuleRecord:
+        for record in self._records:
+            if record.manifest.id == module_id:
+                return record
+        raise KeyError(module_id)
+
+    def capabilities(self, module_id: str) -> tuple[str, ...]:
+        return self.get(module_id).capabilities
+
+
+class ModuleRuntime:
+    """Registriert Router und orchestriert asynchrone Module-Lifecycles."""
+
+    def __init__(self, registry: ModuleRegistry) -> None:
+        self.registry = registry
+        self._attached_app: FastAPI | None = None
+        self._started: list[tuple[ModuleRecord, LifecycleContribution]] = []
+        self._running = False
+
+    @property
+    def module_ids(self) -> tuple[str, ...]:
+        return tuple(record.manifest.id for record in self.registry.records)
+
+    def register(self, app: FastAPI) -> None:
+        """Deklariere Beiträge einmalig und binde Router kontrolliert an den Host."""
+
+        if self._attached_app is not None:
+            raise ModuleRegistrationError("The module runtime is already attached to an app.")
+
+        for record in self.registry.records:
+            fields = _log_fields(record, "registration")
+            logger.info("Module registration started", extra=fields)
+            try:
+                record.module.register(record.context)
+                record.context.close()
+            except Exception as exc:
+                record.context.close()
+                raise ModuleRegistrationError(
+                    "The module register() hook failed.",
+                    module_id=record.manifest.id,
+                    origin=record.origin,
+                ) from exc
+            record.registered = True
+            logger.info("Module registration completed", extra=fields)
+
+        for record in self.registry.records:
+            for contribution in record.context.routers:
+                try:
+                    app.include_router(
+                        contribution.router,
+                        prefix=contribution.prefix,
+                        tags=list(contribution.tags) or None,
+                    )
+                except Exception as exc:
+                    raise ModuleRegistrationError(
+                        "A module router could not be attached to the host.",
+                        module_id=record.manifest.id,
+                        origin=record.origin,
+                    ) from exc
+        self._attached_app = app
+
+    async def startup(self) -> None:
+        """Starte Beiträge in Load Order und räume Teilstarts bei Fehlern auf."""
+
+        if self._attached_app is None:
+            raise ModuleStartupError("The module runtime is not attached to an app.")
+        if self._running:
+            raise ModuleStartupError("The module runtime has already been started.")
+
+        for record in self.registry.records:
+            for contribution in record.context.lifecycle:
+                try:
+                    if contribution.startup is not None:
+                        await contribution.startup()
+                    self._started.append((record, contribution))
+                except Exception as exc:
+                    await self._cleanup_after_startup_failure()
+                    raise ModuleStartupError(
+                        "A module startup hook failed.", module_id=record.manifest.id
+                    ) from exc
+        self._running = True
+
+    async def shutdown(self) -> None:
+        """Beende gestartete Beiträge vollständig in umgekehrter Load Order."""
+
+        first_failure: tuple[ModuleRecord, Exception] | None = None
+        while self._started:
+            record, contribution = self._started.pop()
+            if contribution.shutdown is None:
+                continue
+            try:
+                await contribution.shutdown()
+            except Exception as exc:
+                if first_failure is None:
+                    first_failure = (record, exc)
+                logger.exception("Module shutdown failed", extra=_log_fields(record, "shutdown"))
+        self._running = False
+        if first_failure is not None:
+            record, exc = first_failure
+            raise ModuleShutdownError(
+                "A module shutdown hook failed.", module_id=record.manifest.id
+            ) from exc
+
+    async def _cleanup_after_startup_failure(self) -> None:
+        while self._started:
+            record, contribution = self._started.pop()
+            if contribution.shutdown is None:
+                continue
+            try:
+                await contribution.shutdown()
+            except Exception:
+                logger.exception(
+                    "Module cleanup after startup failure failed",
+                    extra=_log_fields(record, "shutdown"),
+                )
+
+
+def create_module_runtime(
+    *,
+    enabled_module_ids: Sequence[str],
+    discovery_providers: Sequence[ModuleDiscoveryProvider],
+    host_version: str,
+    sdk_version: str = MODULE_SDK_VERSION,
+) -> ModuleRuntime:
+    """Discover, validiere, sortiere und instanziiere aktivierte Module fail-fast."""
+
+    enabled = frozenset(enabled_module_ids)
+    definitions: list[ModuleDefinition] = []
+    for provider in discovery_providers:
+        try:
+            definitions.extend(
+                definition
+                for definition in provider.discover(enabled)
+                if definition.declared_id in enabled
+            )
+        except ModuleDiscoveryError:
+            raise
+        except Exception as exc:
+            raise ModuleDiscoveryError(
+                f"Discovery provider {type(provider).__name__} failed."
+            ) from exc
+
+    parsed: list[tuple[ModuleDefinition, ModuleManifestV1]] = []
+    for definition in definitions:
+        try:
+            manifest = (
+                definition.manifest
+                if isinstance(definition.manifest, ModuleManifestV1)
+                else parse_manifest(definition.manifest, origin=definition.origin)
+            )
+            if definition.declared_id != manifest.id:
+                raise ModuleValidationError(
+                    "The discovery ID does not match the manifest ID.",
+                    module_id=definition.declared_id,
+                    origin=definition.origin,
+                )
+        except ModuleValidationError:
+            raise
+        except ModuleManifestError as exc:
+            raise ModuleValidationError(
+                str(exc), module_id=exc.module_id, origin=definition.origin
+            ) from exc
+        parsed.append((definition, manifest))
+
+    discovered_ids = {manifest.id for _, manifest in parsed}
+    missing_ids = sorted(enabled.difference(discovered_ids))
+    if missing_ids:
+        module_id = missing_ids[0]
+        raise ModuleDiscoveryError(
+            "The enabled module was not found in a configured discovery source.",
+            module_id=module_id,
+        )
+
+    manifests = [manifest for _, manifest in parsed]
+    origins = [definition.origin for definition, _ in parsed]
+    try:
+        validated = validate_manifests(
+            manifests,
+            host_version=host_version,
+            sdk_version=sdk_version,
+            origins=origins,
+        )
+        ordered = resolve_module_order(validated)
+    except ModuleManifestError as exc:
+        origin = exc.origin
+        if origin is None and exc.module_id is not None:
+            origin = next(
+                (
+                    definition.origin
+                    for definition, manifest in parsed
+                    if manifest.id == exc.module_id
+                ),
+                None,
+            )
+        raise ModuleValidationError(
+            str(exc), module_id=exc.module_id, origin=origin
+        ) from exc
+
+    definitions_by_id = {manifest.id: definition for definition, manifest in parsed}
+    records: list[ModuleRecord] = []
+    for load_index, manifest in enumerate(ordered):
+        definition = definitions_by_id[manifest.id]
+        try:
+            module = definition.loader()
+            if module.manifest != manifest:
+                raise ValueError("loaded module manifest does not match its validated definition")
+            register = module.register
+            if not callable(register):
+                raise TypeError("loaded module has no callable register hook")
+        except Exception as exc:
+            raise ModuleLoadError(
+                "The validated module could not be instantiated.",
+                module_id=manifest.id,
+                origin=definition.origin,
+            ) from exc
+        records.append(
+            ModuleRecord(
+                manifest=manifest,
+                module=module,
+                origin=definition.origin,
+                load_index=load_index,
+                context=ModuleRegistrationContext(),
+            )
+        )
+    return ModuleRuntime(ModuleRegistry(records))
+
+
+def _log_fields(record: ModuleRecord, phase: str) -> dict[str, str]:
+    return {
+        "module_id": record.manifest.id,
+        "module_version": record.manifest.version,
+        "module_phase": phase,
+    }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "pyotp>=2.9.0",
   "python-multipart>=0.0.20",
   "redis>=5.2,<9",
+  "semantic-version>=2.10.0,<3",
   "shapely>=2.1.1",
   "sqlalchemy>=2.0.42",
   "uvicorn[standard]>=0.35.0",

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Backend-Testsuite."""

--- a/backend/tests/fixtures/__init__.py
+++ b/backend/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Python-Fixtures für Backend-Tests."""

--- a/backend/tests/fixtures/example_backend_module.py
+++ b/backend/tests/fixtures/example_backend_module.py
@@ -1,0 +1,39 @@
+"""Bewusst kleines, ausschließlich in Tests aktiviertes Runtime-Modul."""
+
+from fastapi import APIRouter
+
+from app.platform.modules import ModuleDefinition, ModuleManifestV1, ModuleRegistrationContext
+from app.platform.modules.manifest import parse_manifest
+
+MANIFEST = parse_manifest(
+    {
+        "manifest_version": 1,
+        "id": "test-example-module",
+        "name": "Runtime-Testmodul",
+        "version": "1.0.0",
+        "requires": {"host": ">=0.2.0,<1.0.0", "sdk": ">=1.0.0,<2.0.0"},
+        "capabilities": ["test.ping"],
+    },
+    origin="tests.fixtures.example_backend_module",
+)
+
+
+class ExampleBackendModule:
+    manifest: ModuleManifestV1 = MANIFEST
+
+    def register(self, context: ModuleRegistrationContext) -> None:
+        router = APIRouter()
+
+        @router.get("/ping")
+        async def ping() -> dict[str, str]:
+            return {"status": "ok"}
+
+        context.include_router(router, prefix="/api/v1/module-test", tags=("Module test",))
+
+
+DEFINITION = ModuleDefinition(
+    manifest=MANIFEST,
+    loader=ExampleBackendModule,
+    origin="tests.fixtures.example_backend_module",
+    declared_id=MANIFEST.id,
+)

--- a/backend/tests/test_config_strictness.py
+++ b/backend/tests/test_config_strictness.py
@@ -9,3 +9,9 @@ def test_unknown_environment_setting_remains_forbidden(tmp_path) -> None:
     env_file.write_text("STADTPLANER_UNKNOWN_DEPLOYMENT_SETTING=typo\n", encoding="utf-8")
     with pytest.raises(ValidationError, match="extra_forbidden"):
         Settings(_env_file=env_file)
+
+
+def test_enabled_modules_are_optional_and_comma_separated() -> None:
+    assert Settings(_env_file=None).enabled_module_list == []
+    settings = Settings(_env_file=None, enabled_modules="module-b, module-a")
+    assert settings.enabled_module_list == ["module-b", "module-a"]

--- a/backend/tests/test_module_manifest.py
+++ b/backend/tests/test_module_manifest.py
@@ -1,0 +1,474 @@
+import itertools
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.platform.modules import (
+    DuplicateConfigNamespaceError,
+    DuplicateModuleIdError,
+    InvalidRuntimeVersionError,
+    MissingModuleDependencyError,
+    ModuleCompatibilityError,
+    ModuleDependencyCycleError,
+    ModuleDependencyVersionError,
+    ModuleManifestError,
+    ModuleSelfDependencyError,
+    UnsupportedManifestVersionError,
+    module_manifest_json_schema,
+    parse_manifest,
+    resolve_module_order,
+    validate_manifest,
+    validate_manifests,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "docs/modules/schema/module-manifest-v1.schema.json"
+EXAMPLES_PATH = ROOT / "docs/modules/examples"
+
+
+def manifest_data(
+    module_id: str = "example-module",
+    *,
+    version: str = "1.0.0",
+    required_modules: dict[str, str] | None = None,
+    optional_modules: dict[str, str] | None = None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "manifest_version": 1,
+        "id": module_id,
+        "name": module_id.replace("-", " ").title(),
+        "version": version,
+        "requires": {
+            "host": ">=1.0.0,<2.0.0",
+            "sdk": ">=1.0.0,<2.0.0",
+            "modules": required_modules or {},
+        },
+    }
+    if optional_modules is not None:
+        data["optional"] = {"modules": optional_modules}
+    data.update(overrides)
+    return data
+
+
+def parsed_manifest(module_id: str = "example-module", **kwargs: Any):
+    return parse_manifest(manifest_data(module_id, **kwargs))
+
+
+def module_ids(manifests) -> list[str]:
+    return [manifest.id for manifest in manifests]
+
+
+def test_parse_minimal_manifest() -> None:
+    manifest = parsed_manifest()
+
+    assert manifest.id == "example-module"
+    assert manifest.version == "1.0.0"
+    assert manifest.backend is None
+    assert manifest.frontend is None
+    assert manifest.optional.modules == {}
+
+
+def test_parse_full_manifest() -> None:
+    manifest = parse_manifest(
+        manifest_data(
+            "example-biotopes",
+            version="2.3.1",
+            required_modules={"example-layer-catalog": ">=1.0.0,<2.0.0"},
+            optional_modules={"example-statistics": ">=1.0.0"},
+            backend={"package": "open_city_planner_biotopes"},
+            frontend={"package": "@open-city-planner/biotopes"},
+            capabilities=["map.layer", "map.feature-info", "analysis.provider"],
+            permissions=["example-biotopes.read", "example-biotopes.admin"],
+            config={"namespace": "example-biotopes"},
+            persistence={"schema": "example_biotopes", "migrations": True},
+        )
+    )
+
+    assert manifest.backend and manifest.backend.package == "open_city_planner_biotopes"
+    assert manifest.frontend and manifest.frontend.package == "@open-city-planner/biotopes"
+    assert manifest.persistence and manifest.persistence.schema_name == "example_biotopes"
+    assert manifest.model_dump(by_alias=True)["persistence"]["schema"] == "example_biotopes"
+
+
+@pytest.mark.parametrize(
+    ("backend", "frontend"),
+    [
+        ({"package": "example_backend"}, None),
+        (None, {"package": "@open-city-planner/example"}),
+        ({"package": "example_backend"}, {"package": "example-frontend"}),
+    ],
+)
+def test_backend_only_frontend_only_and_combined_manifests(backend, frontend) -> None:
+    manifest = parse_manifest(manifest_data(backend=backend, frontend=frontend))
+
+    assert (manifest.backend is not None) == (backend is not None)
+    assert (manifest.frontend is not None) == (frontend is not None)
+
+
+@pytest.mark.parametrize(
+    "module_id",
+    ["Analysis-Areas", "analysis_areas", "analysis--areas", "analysis-", "1-analysis"],
+)
+def test_invalid_module_id_is_rejected(module_id: str) -> None:
+    with pytest.raises(ModuleManifestError, match="Invalid module manifest"):
+        parse_manifest(manifest_data(module_id))
+
+
+@pytest.mark.parametrize("version", ["1.0", "v1.0.0", "1.0.0.0", "latest"])
+def test_invalid_module_version_is_rejected(version: str) -> None:
+    with pytest.raises(ModuleManifestError, match="complete SemVer"):
+        parsed_manifest(version=version)
+
+
+@pytest.mark.parametrize(
+    "version_range",
+    ["^1.2.0", "~1.2.0", ">=1.2", ">=1.2.0, <2.0.0", "*"],
+)
+def test_only_canonical_explicit_version_ranges_are_accepted(version_range: str) -> None:
+    data = manifest_data()
+    data["requires"]["host"] = version_range
+
+    with pytest.raises(ModuleManifestError, match="SemVer|range clauses"):
+        parse_manifest(data)
+
+
+def test_unsupported_manifest_version_has_structured_error() -> None:
+    with pytest.raises(UnsupportedManifestVersionError) as exc_info:
+        parse_manifest({**manifest_data(), "manifest_version": 999}, origin="module.json")
+
+    assert exc_info.value.manifest_version == 999
+    assert exc_info.value.origin == "module.json"
+
+
+def test_unknown_manifest_field_is_rejected() -> None:
+    with pytest.raises(ModuleManifestError) as exc_info:
+        parse_manifest({**manifest_data(), "permisions": ["example-module.read"]})
+
+    assert any(detail["type"] == "extra_forbidden" for detail in exc_info.value.details)
+
+
+def test_persistence_internal_field_name_is_not_accepted_as_manifest_alias() -> None:
+    with pytest.raises(ModuleManifestError):
+        parse_manifest(manifest_data(persistence={"schema_name": "example_module"}))
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"manifest_version": True},
+        {"version": 1},
+        {"persistence": {"schema": "example_module", "migrations": "true"}},
+    ],
+)
+def test_manifest_values_are_not_coerced(overrides: dict[str, Any]) -> None:
+    with pytest.raises(ModuleManifestError):
+        parse_manifest(manifest_data(**overrides))
+
+
+@pytest.mark.parametrize(
+    ("field", "values"),
+    [
+        ("capabilities", ["map.layer", "map.layer"]),
+        ("permissions", ["example-module.read", "example-module.read"]),
+    ],
+)
+def test_duplicate_capabilities_and_permissions_are_rejected(field, values) -> None:
+    with pytest.raises(ModuleManifestError, match="duplicate identifiers"):
+        parse_manifest(manifest_data(**{field: values}))
+
+
+def test_unknown_well_formed_capability_is_forward_compatible() -> None:
+    manifest = parse_manifest(manifest_data(capabilities=["future.unlisted-capability"]))
+
+    assert manifest.capabilities == ["future.unlisted-capability"]
+
+
+def test_permissions_must_be_owned_by_the_module_namespace() -> None:
+    with pytest.raises(ModuleManifestError, match="example-module\\."):
+        parse_manifest(manifest_data(permissions=["other-module.admin"]))
+
+
+@pytest.mark.parametrize("namespace", ["Example", "example_namespace", "example--config"])
+def test_invalid_config_namespace_is_rejected(namespace: str) -> None:
+    with pytest.raises(ModuleManifestError):
+        parse_manifest(manifest_data(config={"namespace": namespace}))
+
+
+def test_compatible_host_and_sdk_versions_are_accepted() -> None:
+    manifest = parsed_manifest()
+
+    assert validate_manifest(manifest, host_version="1.5.0", sdk_version="1.9.9") is manifest
+
+
+@pytest.mark.parametrize(
+    ("target", "host_version", "sdk_version", "found"),
+    [
+        ("host", "0.9.9", "1.0.0", "0.9.9"),
+        ("host", "2.0.0", "1.0.0", "2.0.0"),
+        ("sdk", "1.0.0", "2.0.0", "2.0.0"),
+    ],
+)
+def test_incompatible_host_or_sdk_version_has_structured_error(
+    target: str, host_version: str, sdk_version: str, found: str
+) -> None:
+    with pytest.raises(ModuleCompatibilityError) as exc_info:
+        validate_manifest(
+            parsed_manifest(),
+            host_version=host_version,
+            sdk_version=sdk_version,
+        )
+
+    assert exc_info.value.target == target
+    assert exc_info.value.expected == ">=1.0.0,<2.0.0"
+    assert exc_info.value.found == found
+
+
+def test_invalid_runtime_version_is_rejected() -> None:
+    with pytest.raises(InvalidRuntimeVersionError, match="host"):
+        validate_manifest(parsed_manifest(), host_version="latest", sdk_version="1.0.0")
+
+
+def test_required_dependency_is_validated() -> None:
+    dependency = parsed_manifest("example-layer-catalog", version="1.5.0")
+    consumer = parsed_manifest(
+        "example-biotopes",
+        required_modules={"example-layer-catalog": ">=1.0.0,<2.0.0"},
+    )
+
+    assert validate_manifests(
+        [consumer, dependency], host_version="1.0.0", sdk_version="1.0.0"
+    ) == (consumer, dependency)
+
+
+def test_missing_required_dependency_has_structured_error() -> None:
+    consumer = parsed_manifest(
+        "example-biotopes",
+        required_modules={"example-layer-catalog": ">=1.0.0,<2.0.0"},
+    )
+
+    with pytest.raises(MissingModuleDependencyError) as exc_info:
+        validate_manifests([consumer], host_version="1.0.0", sdk_version="1.0.0")
+
+    assert exc_info.value.dependency_id == "example-layer-catalog"
+    assert exc_info.value.expected == ">=1.0.0,<2.0.0"
+
+
+def test_incompatible_required_dependency_has_structured_error() -> None:
+    dependency = parsed_manifest("example-layer-catalog", version="2.1.0")
+    consumer = parsed_manifest(
+        "example-biotopes",
+        required_modules={"example-layer-catalog": ">=1.0.0,<2.0.0"},
+    )
+
+    with pytest.raises(ModuleDependencyVersionError) as exc_info:
+        validate_manifests(
+            [consumer, dependency], host_version="1.0.0", sdk_version="1.0.0"
+        )
+
+    assert exc_info.value.optional is False
+    assert exc_info.value.found == "2.1.0"
+
+
+def test_missing_optional_dependency_is_accepted() -> None:
+    consumer = parsed_manifest(
+        "example-biotopes",
+        optional_modules={"example-statistics": ">=1.0.0,<2.0.0"},
+    )
+
+    validate_manifests([consumer], host_version="1.0.0", sdk_version="1.0.0")
+
+
+def test_present_compatible_optional_dependency_is_accepted() -> None:
+    dependency = parsed_manifest("example-statistics", version="1.5.0")
+    consumer = parsed_manifest(
+        "example-biotopes",
+        optional_modules={"example-statistics": ">=1.0.0,<2.0.0"},
+    )
+
+    validate_manifests(
+        [consumer, dependency], host_version="1.0.0", sdk_version="1.0.0"
+    )
+
+
+def test_present_incompatible_optional_dependency_is_rejected() -> None:
+    dependency = parsed_manifest("example-statistics", version="2.0.0")
+    consumer = parsed_manifest(
+        "example-biotopes",
+        optional_modules={"example-statistics": ">=1.0.0,<2.0.0"},
+    )
+
+    with pytest.raises(ModuleDependencyVersionError) as exc_info:
+        validate_manifests(
+            [consumer, dependency], host_version="1.0.0", sdk_version="1.0.0"
+        )
+
+    assert exc_info.value.optional is True
+
+
+def test_dependency_cannot_be_both_required_and_optional() -> None:
+    with pytest.raises(ModuleManifestError, match="both required and optional"):
+        parsed_manifest(
+            required_modules={"example-statistics": ">=1.0.0"},
+            optional_modules={"example-statistics": ">=1.0.0"},
+        )
+
+
+@pytest.mark.parametrize("optional", [False, True])
+def test_self_dependency_is_rejected(optional: bool) -> None:
+    kwargs = (
+        {"optional_modules": {"example-module": ">=1.0.0"}}
+        if optional
+        else {"required_modules": {"example-module": ">=1.0.0"}}
+    )
+
+    with pytest.raises(ModuleSelfDependencyError) as exc_info:
+        validate_manifest(
+            parsed_manifest(**kwargs), host_version="1.0.0", sdk_version="1.0.0"
+        )
+
+    assert exc_info.value.optional is optional
+
+
+def test_duplicate_module_ids_fail_fast_and_include_origins() -> None:
+    first = parsed_manifest("example-module")
+    second = parsed_manifest("example-module", version="2.0.0")
+
+    with pytest.raises(DuplicateModuleIdError) as exc_info:
+        validate_manifests(
+            [first, second],
+            host_version="1.0.0",
+            sdk_version="1.0.0",
+            origins=["first.json", "second.json"],
+        )
+
+    assert exc_info.value.origins == ("first.json", "second.json")
+    assert "first.json" in str(exc_info.value)
+
+
+def test_duplicate_config_namespaces_are_rejected() -> None:
+    first = parsed_manifest("module-a", config={"namespace": "shared-config"})
+    second = parsed_manifest("module-b", config={"namespace": "shared-config"})
+
+    with pytest.raises(DuplicateConfigNamespaceError):
+        validate_manifests([first, second], host_version="1.0.0", sdk_version="1.0.0")
+
+
+def test_graph_without_dependencies_is_lexicographic() -> None:
+    manifests = [parsed_manifest("module-c"), parsed_manifest("module-a"), parsed_manifest("module-b")]
+
+    assert module_ids(resolve_module_order(manifests)) == ["module-a", "module-b", "module-c"]
+
+
+def test_linear_dependency_order() -> None:
+    first = parsed_manifest("module-a")
+    second = parsed_manifest("module-b", required_modules={"module-a": ">=1.0.0"})
+    third = parsed_manifest("module-c", required_modules={"module-b": ">=1.0.0"})
+
+    assert module_ids(resolve_module_order([third, first, second])) == [
+        "module-a",
+        "module-b",
+        "module-c",
+    ]
+
+
+def test_diamond_dependency_order_is_deterministic() -> None:
+    root = parsed_manifest("module-a")
+    left = parsed_manifest("module-b", required_modules={"module-a": ">=1.0.0"})
+    right = parsed_manifest("module-c", required_modules={"module-a": ">=1.0.0"})
+    tip = parsed_manifest(
+        "module-d",
+        required_modules={"module-b": ">=1.0.0", "module-c": ">=1.0.0"},
+    )
+
+    assert module_ids(resolve_module_order([tip, right, left, root])) == [
+        "module-a",
+        "module-b",
+        "module-c",
+        "module-d",
+    ]
+
+
+def test_load_order_is_independent_of_input_order() -> None:
+    manifests = [
+        parsed_manifest("module-a"),
+        parsed_manifest("module-b"),
+        parsed_manifest("module-c", required_modules={"module-a": ">=1.0.0"}),
+    ]
+
+    orders = {
+        tuple(module_ids(resolve_module_order(permutation)))
+        for permutation in itertools.permutations(manifests)
+    }
+
+    assert orders == {("module-a", "module-b", "module-c")}
+
+
+def test_present_optional_dependency_loads_before_consumer() -> None:
+    dependency = parsed_manifest("module-b")
+    consumer = parsed_manifest("module-a", optional_modules={"module-b": ">=1.0.0"})
+
+    assert module_ids(resolve_module_order([consumer, dependency])) == ["module-b", "module-a"]
+
+
+@pytest.mark.parametrize(
+    ("manifests", "cycle"),
+    [
+        (
+            [
+                parsed_manifest("module-a", required_modules={"module-b": ">=1.0.0"}),
+                parsed_manifest("module-b", required_modules={"module-a": ">=1.0.0"}),
+            ],
+            ("module-a", "module-b", "module-a"),
+        ),
+        (
+            [
+                parsed_manifest("module-a", required_modules={"module-b": ">=1.0.0"}),
+                parsed_manifest("module-b", required_modules={"module-c": ">=1.0.0"}),
+                parsed_manifest("module-c", required_modules={"module-a": ">=1.0.0"}),
+            ],
+            ("module-a", "module-b", "module-c", "module-a"),
+        ),
+    ],
+)
+def test_direct_and_indirect_cycles_report_the_cycle_path(manifests, cycle) -> None:
+    with pytest.raises(ModuleDependencyCycleError) as exc_info:
+        resolve_module_order(manifests)
+
+    assert exc_info.value.cycle == cycle
+    assert " -> ".join(cycle) in str(exc_info.value)
+
+
+def test_graph_rejects_duplicate_module_ids() -> None:
+    manifest = parsed_manifest()
+
+    with pytest.raises(DuplicateModuleIdError):
+        resolve_module_order([manifest, manifest])
+
+
+def test_committed_json_schema_matches_pydantic_source_of_truth() -> None:
+    committed_schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert committed_schema == module_manifest_json_schema()
+
+
+def test_documentation_examples_match_schema_v1() -> None:
+    manifests = [
+        parse_manifest(json.loads(path.read_text(encoding="utf-8")), origin=str(path))
+        for path in sorted(EXAMPLES_PATH.glob("*.module.json"))
+    ]
+
+    validated = validate_manifests(
+        manifests,
+        host_version="1.0.0",
+        sdk_version="1.0.0",
+        origins=[str(path) for path in sorted(EXAMPLES_PATH.glob("*.module.json"))],
+    )
+
+    assert module_ids(resolve_module_order(validated)) == [
+        "example-layer-catalog",
+        "example-biotopes",
+        "example-pois",
+    ]

--- a/backend/tests/test_module_runtime.py
+++ b/backend/tests/test_module_runtime.py
@@ -1,0 +1,468 @@
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.api.router import api_router
+from app.platform.modules import (
+    DuplicateModuleIdError,
+    EntryPointModuleDiscovery,
+    FirstPartyModuleDiscovery,
+    MissingModuleDependencyError,
+    ModuleCompatibilityError,
+    ModuleDefinition,
+    ModuleDependencyCycleError,
+    ModuleDiscoveryError,
+    ModuleLoadError,
+    ModuleManifestV1,
+    ModuleRegistrationContext,
+    ModuleRegistrationError,
+    ModuleShutdownError,
+    ModuleStartupError,
+    ModuleValidationError,
+    create_module_runtime,
+    parse_manifest,
+)
+from app.platform.modules import discovery as discovery_module
+from app.platform.modules.contracts import ModuleDiscoveryProvider
+from app.platform.modules.discovery import ENTRY_POINT_GROUP
+from tests.fixtures.example_backend_module import DEFINITION as EXAMPLE_DEFINITION
+
+
+def manifest_data(
+    module_id: str,
+    *,
+    required: dict[str, str] | None = None,
+    optional: dict[str, str] | None = None,
+    host: str = ">=0.2.0,<1.0.0",
+    sdk: str = ">=1.0.0,<2.0.0",
+    capabilities: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "manifest_version": 1,
+        "id": module_id,
+        "name": module_id,
+        "version": "1.0.0",
+        "requires": {"host": host, "sdk": sdk, "modules": required or {}},
+        "optional": {"modules": optional or {}},
+        "capabilities": capabilities or [],
+    }
+
+
+class RecordingModule:
+    def __init__(
+        self,
+        manifest: ModuleManifestV1,
+        *,
+        events: list[str] | None = None,
+        registration_error: Exception | None = None,
+        startup_error: Exception | None = None,
+    ) -> None:
+        self.manifest = manifest
+        self.events = events
+        self.registration_error = registration_error
+        self.startup_error = startup_error
+
+    def register(self, context: ModuleRegistrationContext) -> None:
+        if self.registration_error is not None:
+            raise self.registration_error
+        if self.events is None:
+            return
+
+        async def startup() -> None:
+            self.events.append(f"start:{self.manifest.id}")
+            if self.startup_error is not None:
+                raise self.startup_error
+
+        async def shutdown() -> None:
+            self.events.append(f"stop:{self.manifest.id}")
+
+        context.add_lifecycle(startup=startup, shutdown=shutdown)
+
+
+def definition(
+    module_id: str,
+    *,
+    required: dict[str, str] | None = None,
+    optional: dict[str, str] | None = None,
+    host: str = ">=0.2.0,<1.0.0",
+    sdk: str = ">=1.0.0,<2.0.0",
+    events: list[str] | None = None,
+    registration_error: Exception | None = None,
+    startup_error: Exception | None = None,
+    capabilities: list[str] | None = None,
+) -> ModuleDefinition:
+    manifest = parse_manifest(
+        manifest_data(
+            module_id,
+            required=required,
+            optional=optional,
+            host=host,
+            sdk=sdk,
+            capabilities=capabilities,
+        )
+    )
+    return ModuleDefinition(
+        manifest=manifest,
+        loader=lambda: RecordingModule(
+            manifest,
+            events=events,
+            registration_error=registration_error,
+            startup_error=startup_error,
+        ),
+        origin=f"test:{module_id}",
+        declared_id=module_id,
+    )
+
+
+@dataclass
+class FakeDiscovery(ModuleDiscoveryProvider):
+    definitions: Sequence[ModuleDefinition]
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        return self.definitions
+
+
+def runtime_for(
+    definitions: Sequence[ModuleDefinition],
+    *,
+    enabled: Sequence[str] | None = None,
+    host_version: str = "0.2.0",
+    sdk_version: str = "1.0.0",
+):
+    enabled_module_ids = (
+        [definition.declared_id for definition in definitions] if enabled is None else enabled
+    )
+    return create_module_runtime(
+        enabled_module_ids=enabled_module_ids,
+        discovery_providers=(FakeDiscovery(definitions),),
+        host_version=host_version,
+        sdk_version=sdk_version,
+    )
+
+
+def test_no_enabled_module_creates_empty_runtime() -> None:
+    runtime = runtime_for([], enabled=[])
+    assert runtime.module_ids == ()
+
+
+def test_first_party_discovery_loads_only_enabled_definitions() -> None:
+    loaded: list[str] = []
+
+    def source(module_id: str) -> Callable[[], ModuleDefinition]:
+        def load() -> ModuleDefinition:
+            loaded.append(module_id)
+            return definition(module_id)
+
+        return load
+
+    provider = FirstPartyModuleDiscovery(
+        {"module-a": source("module-a"), "module-b": source("module-b")}
+    )
+    runtime = create_module_runtime(
+        enabled_module_ids=("module-b",),
+        discovery_providers=(provider,),
+        host_version="0.2.0",
+    )
+
+    assert runtime.module_ids == ("module-b",)
+    assert loaded == ["module-b"]
+
+
+def test_runtime_ignores_disabled_definition_returned_by_provider() -> None:
+    disabled = ModuleDefinition(
+        manifest={"manifest_version": 1, "id": "INVALID"},
+        loader=lambda: None,  # type: ignore[arg-type,return-value]
+        origin="test:disabled",
+        declared_id="disabled-module",
+    )
+    runtime = runtime_for([disabled], enabled=[])
+    assert runtime.module_ids == ()
+
+
+def test_multiple_modules_use_lexicographic_tie_breaking() -> None:
+    runtime = runtime_for([definition("module-z"), definition("module-a")])
+    assert runtime.module_ids == ("module-a", "module-z")
+
+
+def test_duplicate_module_id_preserves_manifest_error_as_cause() -> None:
+    duplicate = definition("duplicate-module")
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([duplicate, duplicate])
+
+    assert error.value.phase == "validation"
+    assert error.value.module_id == "duplicate-module"
+    assert isinstance(error.value.__cause__, DuplicateModuleIdError)
+
+
+def test_invalid_manifest_is_reported_in_validation_phase() -> None:
+    invalid = ModuleDefinition(
+        manifest={"manifest_version": 1, "id": "INVALID"},
+        loader=lambda: None,  # type: ignore[arg-type,return-value]
+        origin="test:invalid",
+        declared_id="invalid",
+    )
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([invalid], enabled=("invalid",))
+
+    assert error.value.phase == "validation"
+    assert error.value.origin == "test:invalid"
+
+
+@pytest.mark.parametrize(
+    ("target", "definition_value", "host_version", "sdk_version"),
+    [
+        ("host", definition("host-incompatible", host=">=2.0.0,<3.0.0"), "0.2.0", "1.0.0"),
+        ("sdk", definition("sdk-incompatible", sdk=">=2.0.0,<3.0.0"), "0.2.0", "1.0.0"),
+    ],
+)
+def test_incompatible_runtime_version_is_fail_fast(
+    target: str,
+    definition_value: ModuleDefinition,
+    host_version: str,
+    sdk_version: str,
+) -> None:
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([definition_value], host_version=host_version, sdk_version=sdk_version)
+
+    assert isinstance(error.value.__cause__, ModuleCompatibilityError)
+    assert error.value.__cause__.target == target
+
+
+def test_required_dependency_and_optional_dependency_define_load_order() -> None:
+    runtime = runtime_for(
+        [
+            definition(
+                "consumer",
+                required={"required-base": ">=1.0.0,<2.0.0"},
+                optional={"optional-base": ">=1.0.0,<2.0.0"},
+            ),
+            definition("required-base"),
+            definition("optional-base"),
+        ]
+    )
+    assert runtime.module_ids == ("optional-base", "required-base", "consumer")
+
+
+def test_required_dependency_on_disabled_module_fails() -> None:
+    consumer = definition("consumer", required={"disabled-base": ">=1.0.0,<2.0.0"})
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([consumer], enabled=("consumer",))
+
+    assert isinstance(error.value.__cause__, MissingModuleDependencyError)
+
+
+def test_dependency_cycle_is_reported_by_manifest_graph() -> None:
+    module_a = definition("module-a", required={"module-b": ">=1.0.0,<2.0.0"})
+    module_b = definition("module-b", required={"module-a": ">=1.0.0,<2.0.0"})
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([module_a, module_b])
+
+    assert isinstance(error.value.__cause__, ModuleDependencyCycleError)
+
+
+def test_enabled_unknown_module_fails_discovery() -> None:
+    with pytest.raises(ModuleDiscoveryError, match="module_id=missing-module"):
+        runtime_for([], enabled=("missing-module",))
+
+
+def test_loader_failure_contains_import_phase_and_module_id() -> None:
+    manifest = parse_manifest(manifest_data("broken-module"))
+
+    def broken_loader():
+        raise ImportError("broken import")
+
+    broken = ModuleDefinition(manifest, broken_loader, "test:broken", "broken-module")
+    with pytest.raises(ModuleLoadError) as error:
+        runtime_for([broken])
+
+    assert error.value.phase == "import"
+    assert error.value.module_id == "broken-module"
+    assert isinstance(error.value.__cause__, ImportError)
+
+
+def test_registry_exposes_manifest_capabilities() -> None:
+    runtime = runtime_for([definition("capable-module", capabilities=["map.layer"])])
+    assert runtime.registry.capabilities("capable-module") == ("map.layer",)
+
+
+def test_registration_failure_is_fail_fast_and_registration_is_single_use() -> None:
+    broken = runtime_for(
+        [definition("broken-module", registration_error=RuntimeError("register failed"))]
+    )
+    with pytest.raises(ModuleRegistrationError, match="module_id=broken-module"):
+        broken.register(FastAPI())
+
+    runtime = runtime_for([])
+    app = FastAPI()
+    runtime.register(app)
+    with pytest.raises(ModuleRegistrationError, match="already attached"):
+        runtime.register(app)
+
+
+@pytest.mark.asyncio
+async def test_router_registration_coexists_with_legacy_router() -> None:
+    runtime = runtime_for([EXAMPLE_DEFINITION])
+    app = FastAPI()
+    app.include_router(api_router)
+    runtime.register(app)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        module_response = await client.get("/api/v1/module-test/ping")
+        legacy_response = await client.get("/api/v1/auth/providers")
+
+    assert module_response.status_code == 200
+    assert module_response.json() == {"status": "ok"}
+    assert legacy_response.status_code == 200
+    assert "providers" in legacy_response.json()
+
+
+@pytest.mark.asyncio
+async def test_disabled_fixture_module_has_no_route() -> None:
+    runtime = runtime_for([], enabled=[])
+    app = FastAPI()
+    runtime.register(app)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/v1/module-test/ping")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_uses_load_order_and_reverse_shutdown_order() -> None:
+    events: list[str] = []
+    runtime = runtime_for(
+        [
+            definition("consumer", required={"base-module": ">=1.0.0,<2.0.0"}, events=events),
+            definition("base-module", events=events),
+        ]
+    )
+    runtime.register(FastAPI())
+    await runtime.startup()
+    await runtime.shutdown()
+
+    assert events == [
+        "start:base-module",
+        "start:consumer",
+        "stop:consumer",
+        "stop:base-module",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_cleans_up_already_started_modules() -> None:
+    events: list[str] = []
+    runtime = runtime_for(
+        [
+            definition("module-a", events=events),
+            definition("module-b", events=events, startup_error=RuntimeError("startup failed")),
+        ]
+    )
+    runtime.register(FastAPI())
+
+    with pytest.raises(ModuleStartupError) as error:
+        await runtime.startup()
+
+    assert error.value.module_id == "module-b"
+    assert events == ["start:module-a", "start:module-b", "stop:module-a"]
+    await runtime.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_failure_does_not_skip_earlier_modules() -> None:
+    events: list[str] = []
+    module_a = definition("module-a", events=events)
+    manifest_b = parse_manifest(manifest_data("module-b"))
+
+    class FailingShutdownModule(RecordingModule):
+        def register(self, context: ModuleRegistrationContext) -> None:
+            async def startup() -> None:
+                events.append("start:module-b")
+
+            async def shutdown() -> None:
+                events.append("stop:module-b")
+                raise RuntimeError("shutdown failed")
+
+            context.add_lifecycle(startup=startup, shutdown=shutdown)
+
+    module_b = ModuleDefinition(
+        manifest=manifest_b,
+        loader=lambda: FailingShutdownModule(manifest_b),
+        origin="test:module-b",
+        declared_id="module-b",
+    )
+    runtime = runtime_for([module_a, module_b])
+    runtime.register(FastAPI())
+    await runtime.startup()
+
+    with pytest.raises(ModuleShutdownError) as error:
+        await runtime.shutdown()
+
+    assert error.value.module_id == "module-b"
+    assert events == ["start:module-a", "start:module-b", "stop:module-b", "stop:module-a"]
+
+
+class FakeEntryPoints(list):
+    def select(self, *, group: str):
+        assert group == ENTRY_POINT_GROUP
+        return self
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, value: str, result: object) -> None:
+        self.name = name
+        self.value = value
+        self.result = result
+        self.load_count = 0
+
+    def load(self) -> object:
+        self.load_count += 1
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def test_entry_point_discovery_loads_only_enabled_group_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enabled = FakeEntryPoint("test-example-module", "package:definition", EXAMPLE_DEFINITION)
+    disabled = FakeEntryPoint("disabled-module", "other:definition", RuntimeError("must not load"))
+    monkeypatch.setattr(
+        discovery_module.metadata, "entry_points", lambda: FakeEntryPoints([disabled, enabled])
+    )
+
+    runtime = create_module_runtime(
+        enabled_module_ids=("test-example-module",),
+        discovery_providers=(EntryPointModuleDiscovery(),),
+        host_version="0.2.0",
+    )
+
+    assert runtime.module_ids == ("test-example-module",)
+    assert enabled.load_count == 1
+    assert disabled.load_count == 0
+
+
+def test_broken_enabled_entry_point_has_discovery_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broken = FakeEntryPoint("broken-module", "broken:definition", ImportError("broken"))
+    monkeypatch.setattr(
+        discovery_module.metadata, "entry_points", lambda: FakeEntryPoints([broken])
+    )
+
+    with pytest.raises(ModuleDiscoveryError) as error:
+        create_module_runtime(
+            enabled_module_ids=("broken-module",),
+            discovery_providers=(EntryPointModuleDiscovery(),),
+            host_version="0.2.0",
+        )
+
+    assert error.value.module_id == "broken-module"
+    assert error.value.phase == "discovery"
+    assert isinstance(error.value.__cause__, ImportError)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -657,6 +657,7 @@ dependencies = [
     { name = "pyotp" },
     { name = "python-multipart" },
     { name = "redis" },
+    { name = "semantic-version" },
     { name = "shapely" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
@@ -706,6 +707,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'security'", specifier = "==6.0.3" },
     { name = "redis", specifier = ">=5.2,<9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.8" },
+    { name = "semantic-version", specifier = ">=2.10.0,<3" },
     { name = "shapely", specifier = ">=2.1.1" },
     { name = "sqlalchemy", specifier = ">=2.0.42" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.35.0" },
@@ -1334,6 +1336,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
     { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
     { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
+name = "semantic-version"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
 ]
 
 [[package]]

--- a/deploy/ansible/vault.example.yml
+++ b/deploy/ansible/vault.example.yml
@@ -28,6 +28,7 @@ stadtplaner_backend_env_content: |
   APP_ENVIRONMENT=production
   APP_BASE_URL=https://stadtplaner.oklabflensburg.de
   API_BASE_URL=https://api.stadtplaner.oklabflensburg.de
+  ENABLED_MODULES=
   MAP_PREVIEW_RENDERER_URL=http://127.0.0.1:3020
   MAP_PREVIEW_RENDERER_TIMEOUT_SECONDS=20
   MAP_PREVIEW_CACHE_DIR=/data/stadtplaner/previews

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 
 ## Architektur und Frontend
 
+- [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)
 - [Intelligente Suche](intelligent-search.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 
 - [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
 - [Module Manifest Schema V1](modules/module-manifest-v1.md)
+- [Backend-Module-Runtime](modules/backend-module-runtime.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)
 - [Intelligente Suche](intelligent-search.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 ## Architektur und Frontend
 
 - [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
+- [Module Manifest Schema V1](modules/module-manifest-v1.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)
 - [Intelligente Suche](intelligent-search.md)

--- a/docs/architecture/adr-modular-host-and-module-boundaries.md
+++ b/docs/architecture/adr-modular-host-and-module-boundaries.md
@@ -1,0 +1,548 @@
+# ADR: Modularer Host und Grenzen von Fachmodulen
+
+- Status: Angenommen
+- Datum: 2026-08-25
+- Entscheidung: [Issue #92](https://github.com/oklabflensburg/open-city-planner/issues/92)
+- Epic: [Issue #91](https://github.com/oklabflensburg/open-city-planner/issues/91)
+
+## Kontext
+
+Open City Planner ist heute eine produktiv eingesetzte Web-GIS-Anwendung. Backend und
+Frontend sind überwiegend nach technischen Schichten organisiert:
+
+```text
+backend/app/{api,models,schemas,services,integrations}
+frontend/app/{pages,components,composables,stores}
+```
+
+Diese Struktur ist für eine einzelne Anwendung nachvollziehbar und bleibt der
+funktionierende Ausgangspunkt. Mit wachsender Zahl an Fachfunktionen führt sie jedoch
+dazu, dass neue Domänen häufig zentrale Dateien und globale Strukturen erweitern:
+
+- `backend/app/api/router.py` importiert und registriert alle Fachrouter zentral.
+- `backend/alembic/env.py` lädt fachliche ORM-Modelle für ein gemeinsames
+  `Base.metadata` zentral.
+- `backend/app/core/config.py` enthält Plattform- und Fachkonfiguration in einem
+  Settings-Schema.
+- `backend/app/services/assistant.py` orchestriert unter anderem Intent-Erkennung,
+  Gebietsauflösung, Provider, Tools, Antwortdarstellung und Telemetrie.
+- `frontend/app/composables/useSiteNavigation.ts` definiert die Navigation zentral.
+- `frontend/app/components/map/MapCanvas.vue` vereint MapLibre-Lifecycle,
+  Fach-Layer, Viewport-Laden, Interaktionen, Auswahl und Performance-Verhalten.
+- `frontend/app/stores/auth.ts` bündelt Session, Login, Refresh, OAuth, MFA,
+  Passkeys und Profiloperationen.
+
+Das ist keine pauschale Abwertung der bestehenden Architektur. Das ADR legt die
+Grenzen für ihre inkrementelle Weiterentwicklung fest und setzt noch keine neue
+Modulruntime um.
+
+Die Entscheidung stimmt mit den bestehenden Vorhaben überein:
+
+- [#21](https://github.com/oklabflensburg/open-city-planner/issues/21) fordert
+  testbare Grenzen für Assistant, Karte und Auth.
+- [#33](https://github.com/oklabflensburg/open-city-planner/issues/33) trennt
+  generische Civic-Geodatenmodelle von lokalen Annahmen und schützt Provenienz und
+  Lizenzen.
+- [#34](https://github.com/oklabflensburg/open-city-planner/issues/34) entwickelt
+  versionierte, interoperable Geo-APIs und Exportverträge.
+- [#35](https://github.com/oklabflensburg/open-city-planner/issues/35) trennt
+  OSM-/Open-Data-Importer, kanonisches Modell und Präsentation.
+- [#83](https://github.com/oklabflensburg/open-city-planner/issues/83) ist ein
+  künftiger Consumer der Modul- und Karten-Extension-Points, keine parallele
+  Plugin-Architektur.
+
+## Entscheidung
+
+Open City Planner wird als **modularer Monolith aus Host, öffentlichem Module SDK und
+Fachmodulen** weiterentwickelt. Nuxt, FastAPI und die gemeinsam betriebenen
+Infrastrukturkomponenten bleiben Composition Roots. Module erweitern den Host über
+deklarative Manifeste und stabile Registrierungsverträge; der Host importiert keine
+konkrete Fachdomäne.
+
+```mermaid
+flowchart TB
+    Deploy[Gemeinsames Deployment<br/>Nuxt + FastAPI]
+    Host[Host / Core<br/>Lifecycle, UI Shell, Map Runtime,<br/>Plattform-Primitives]
+    SDK[Öffentliches Module SDK<br/>Contracts und Registries]
+    Registry[Module Registry<br/>Manifest und Bootstrap]
+    Modules[Fachmodule<br/>Polygons, Analysis Areas, OSM,<br/>Statistics, Notifications, Assistant, Social]
+    Infra[(PostgreSQL / PostGIS<br/>Redis / Storage)]
+
+    Deploy --> Host
+    Host -->|stellt bereit| SDK
+    SDK -->|Extension Points für| Modules
+    Host --> Registry
+    Registry -->|komponiert deklarativ| Modules
+    Host --> Infra
+    Modules -->|über SDK-Primitives| Infra
+```
+
+Dies ist weder eine Microservice-Migration noch ein Runtime-Microfrontend-System.
+Module ändern standardmäßig nicht die Prozessarchitektur und werden vor dem Build
+installiert und aktiviert. Die Kerntechnologien bleiben:
+
+- Frontend: Nuxt 4, Vue, TypeScript, Pinia, Tailwind und MapLibre;
+- Backend: FastAPI, Python, SQLAlchemy, Alembic, PostgreSQL/PostGIS und Redis;
+- Betrieb: GitHub Actions, Ansible und die bestehende Observability.
+
+## Begriffe und harte Grenzen
+
+**Host/Core** bezeichnet ausschließlich dauerhaft fachneutrale
+Plattformverantwortung. **Module SDK** bezeichnet die versionierte öffentliche
+Oberfläche des Hosts, die Module verwenden dürfen. **Fachmodul** bezeichnet einen
+fachlich abgegrenzten Besitzer von Verhalten, Daten, Verträgen und Beiträgen.
+
+Der Host ist kein Ablageort für schwer einzuordnenden Code. Code wird nur dann Host,
+wenn er fachneutral ist, von mehreren unabhängigen Modulen benötigt wird und als
+stabiler Plattformvertrag verantwortet werden kann. Wiederverwendung allein macht
+Fachlogik nicht zum Host-Service.
+
+### Abhängigkeitsrichtung
+
+Die Pfeile im folgenden Diagramm bedeuten „darf zur Build-/Importzeit abhängen von“:
+
+```mermaid
+flowchart BT
+    HostInternal[Host internals]
+    HostSDK[Host Public SDK / Contracts]
+    ModuleA[Modul A]
+    ModuleBContracts[Öffentliche Contracts von Modul B]
+    ModuleBInternal[Interna von Modul B]
+
+    HostInternal --> HostSDK
+    ModuleA --> HostSDK
+    ModuleA -->|nur bei deklarierter Abhängigkeit| ModuleBContracts
+    ModuleBInternal --> ModuleBContracts
+    ModuleBInternal --> HostSDK
+```
+
+Verbindlich gilt:
+
+- Der Host kennt kein konkretes Fachmodul und importiert keines.
+- Module dürfen nur das öffentliche Host-SDK verwenden, nicht Host-Interna.
+- Ein Modul darf öffentliche Contracts eines anderen Moduls nur über eine im
+  Manifest deklarierte Abhängigkeit verwenden.
+- Ein Modul darf keine internen APIs, Persistence-Pakete oder ORM-Modelle eines
+  anderen Moduls importieren.
+- Zirkuläre Modulabhängigkeiten sind verboten.
+- Bootstrap und Discovery erfolgen durch die Host-Registry aus deklarativer
+  Konfiguration beziehungsweise Packaging-Metadaten, nicht durch fachliche Imports
+  im Host.
+
+### Public API und Interna
+
+Konzeptionelle Namenskonvention für Python ist
+`modules.<module_id>.contracts` als einziger modulübergreifend importierbarer
+Namensraum. `modules.<module_id>.internal`, `.persistence`, `.application` und
+`.integrations` bleiben intern. Frontend-Pakete exportieren modulübergreifende Typen
+und Beiträge ausschließlich über einen expliziten `contracts`-/Public-Entry-Point;
+Deep Imports in interne Pfade sind verboten. Die endgültige Paket- und
+Manifest-Syntax wird in #93 festgelegt.
+
+## Ownership Matrix
+
+| Capability | Host/Core besitzt | Fachmodul besitzt |
+|---|---|---|
+| Application Lifecycle | Startup, Shutdown, Composition Roots, Bootstrap-Reihenfolge | registrierte Lifecycle-Beiträge |
+| Health | Liveness-/Readiness-Aggregation und Basiszustand | eigener Health-Beitrag ohne globale Route zu patchen |
+| Configuration | Laden, Validieren, Namespacing, Secret-Zugriffsmechanismus | Settings-Schema, Defaults und fachliche Werte |
+| Datenbank | Engine, Session Factory, Transaktionen, DB Health | fachliche Tabellen, Repositories und Datenregeln |
+| PostGIS | Extension und gemeinsame räumliche Primitives | fachliche Geometrien und Abfragen |
+| Migrationen | Koordination, Reihenfolge und Alembic-Lifecycle | Migrationen der eigenen Tabellen |
+| Identity/Auth | aktuelle Identity, Session-/Auth-Kontext, CSRF und etablierte OAuth-/Passkey-/MFA-Infrastruktur | fachliche Nutzung des Auth-Kontexts |
+| Permissions | Permission Engine und Auswertung | stabile fachliche Permission-IDs und Regeln |
+| Events/Outbox | Transport, Dispatch und transaktionale Mechanik | Domain Events und Handler der eigenen Domäne |
+| Cache | Redis-Verbindung und sichere Cache-Primitives | Keys, TTLs, Cache Policy und Invalidierung |
+| Observability | Logging, Metrics, Tracing, Request IDs und Build Info | fachliche Logs, Metriken und Spans über das SDK |
+| Storage | abstrahierte Storage-Primitives und Sicherheitsgrenzen | Dateien, Medien und Aufbewahrungsregeln der Domäne |
+| Jobs | Registry, Scheduling-/Execution-Primitives und Beobachtbarkeit | Job-Definitionen, fachliche Retries und Idempotenz |
+| HTTP Clients | sichere Clients, Timeouts, Telemetrie und Basis-Policies | Provider-Adapter, Endpunkte und fachliche Fehlerbehandlung |
+| Module Registry | Discovery, Validierung, Kompatibilität und Enablement | Manifest und deklarierte Beiträge |
+| UI Shell | App Shell, Basislayout, globale Accessibility, Branding und Error Boundary | fachliche Seiten, Ansichten und UI-Beiträge |
+| Navigation | Registries, Sortierung, Sichtbarkeitsauswertung | Navigationseinträge mit stabilen IDs |
+| Map Runtime | MapLibre-Lifecycle, Registries, Selection-/Interaction-Primitives, Rendering-Basis | konkrete Fachdaten-Layer, Controls und Interaktionen |
+| API | Router-Registry, gemeinsame Middleware und Fehler-Primitives | Routen und fachliche Request-/Response-Verträge |
+| Fachliche Datenprovenienz | technische Transportmöglichkeit | Quelle, Lizenz, Datenstand und Transformationssemantik |
+
+### Dauerhafte Host-Verantwortung
+
+Der Host verantwortet:
+
+1. **Application Lifecycle:** FastAPI-/Nuxt-Composition-Root, Startup, Shutdown,
+   Module Bootstrap und Health-Lifecycle.
+2. **Configuration Framework:** typsicheres Laden, Namespacing, Validierung und
+   kontrollierter Secret-Zugriff. Fachliche Settings wachsen nicht weiter in ein
+   globales Core-Schema.
+3. **Database Primitives:** Engine, Session Factory, Transaktionsgrenzen, PostGIS-
+   Extension-Ownership und grundlegende DB-Health-Prüfung.
+4. **Identity-/Authentication-Primitives:** aktuelle Identity, Auth-Kontext,
+   Sessions und die bestehende Sicherheitsinfrastruktur für Cookies, CSRF, OAuth,
+   Passkeys und MFA, soweit sie plattformweit ist. Fachliche Rollen und Permissions
+   werden registrierbar.
+5. **Permission Engine:** Registrierung und einheitliche serverseitige Auswertung;
+   die Semantik fachlicher Permissions bleibt beim Modul.
+6. **Event-/Outbox-Infrastruktur:** Publisher-/Subscriber-Verträge, Dispatch und
+   transaktionale Zustellung, nicht die fachlichen Ereignisse.
+7. **Cache, Storage, Jobs und HTTP-Client-Infrastruktur:** robuste Primitives und
+   Registries, nicht fachliche Policies oder Providerlogik.
+8. **Observability:** strukturierte Logs, Metriken, Tracing, Request-/Correlation-ID,
+   Build-Information und fehlertolerante Telemetrie.
+9. **Module Registry:** Discovery, deterministischer Bootstrap, Validierung,
+   Kompatibilitätsprüfung, Status und Capabilities.
+10. **UI Shell:** globale App Shell, Basislayout, Branding-Primitives, globale
+    Accessibility und Error Boundary.
+11. **Map Runtime:** gemeinsame MapLibre-Instanz und deren Lebenszyklus,
+    Extension-Registries, Selection-/Interaction-Primitives und Rendering-Basis.
+
+Auth ist sicherheitskritisch, umfasst bereits viele öffentliche und interne Verträge
+und wird ausdrücklich **nicht als erste Domäne migriert**. Verstecken von UI-Beiträgen
+ersetzt niemals die serverseitige Autorisierung.
+
+### Was nicht zum Host gehört
+
+Folgende Fachlichkeiten bleiben beziehungsweise werden Module oder klar abgegrenzte
+Adapter; sie werden nicht zu Core umetikettiert:
+
+- User Polygons und Verkaufsflächen;
+- Analysis Areas und kommunale Statistik;
+- OSM-Fachlogik und konkrete Open-Data-Importer;
+- Layer Catalog als Fachfunktion sowie konkrete Biotop-, ALKIS- und Denkmal-Layer;
+- Assistant-Planung, Tools und Antwortlogik;
+- Social Publishing und Mastodon-Fachintegration;
+- Notification Business Logic und E-Mail-Kampagnen;
+- konkrete Provider-, Provenienz- und Transformationsregeln.
+
+## Modulinterne Architektur
+
+Ein ausreichend großes Modul darf langfristig folgende Schichten besitzen:
+
+```text
+module/
+├── api/
+├── application/
+├── domain/
+├── persistence/
+├── integrations/
+├── contracts/
+└── tests/
+```
+
+Nicht jedes kleine Modul benötigt jedes Verzeichnis. Die bevorzugte Richtung ist
+`API -> Application -> Domain`. Persistence und Integrationen implementieren Ports
+beziehungsweise Contracts, die von innen definiert werden. Die Domain bleibt, wo
+sinnvoll, frei von FastAPI-, Vue- und SQLAlchemy-Abhängigkeiten. Dies ist eine
+pragmatische Trennungsregel und keine Pflicht zu dogmatischer Clean-Architecture-
+Zerlegung.
+
+Ein Modul besitzt:
+
+- seine fachlichen Begriffe, Use Cases und Validierung;
+- seine öffentlichen Service-/Query-Contracts und Domain Events;
+- seine API-Routen und Response-Verträge;
+- seine Tabellen, Repositories, Migrationen und Cache Policy;
+- seine Provider-Adapter und fachlichen Jobs;
+- seine Permissions, Capabilities, UI- und Kartenbeiträge;
+- seine Tests, Dokumentation, Version und Kompatibilitätsangaben.
+
+## Cross-Module-Kommunikation
+
+Es gibt drei bevorzugte Mechanismen:
+
+1. **Query-/Service-Contracts** für synchrone fachliche Abfragen, zum Beispiel ein
+   `AnalysisAreaQueryService`. Contracts transportieren DTOs oder Protokolle, keine
+   SQLAlchemy-Modelle und keine interne Session.
+2. **Domain Events** für lose gekoppelte Reaktionen. Ein `PolygonCreated` gehört dem
+   Polygon-Modul; Notifications, Social oder Analytics dürfen reagieren, ohne dass
+   der Producer sie kennt. Der Host stellt nur Transport und Zustellung bereit.
+3. **Shared Platform Services** ausschließlich für echte Plattformkonzepte wie
+   Cache, Storage, Events, Metrics, Settings und DB-/Transaktionsprimitives.
+
+Die Service Registry ist nur für öffentliche Cross-Module-Contracts vorgesehen. Sie
+ist kein allgemeiner Service Locator und keine Möglichkeit, Abhängigkeiten zu
+verbergen. Events repräsentieren relevante, abgeschlossene fachliche Tatsachen; nicht
+jeder interne Methodenaufruf wird zu einem Event.
+
+## Geplante Backend-Extension-Points
+
+Die folgenden Extension-Points sind verbindliches Zielbild, werden in diesem ADR
+aber noch nicht implementiert:
+
+| Extension Point | Verantwortung des Moduls | Verantwortung des Hosts |
+|---|---|---|
+| API router | Router, Prefix-/Tag-Metadaten und fachliche Abhängigkeiten liefern | validieren und ohne Patch am zentralen Router registrieren |
+| Lifecycle hook | idempotenten Startup-/Shutdown-Beitrag deklarieren | Reihenfolge, Fehlerisolation und Shutdown koordinieren |
+| Public service contract | Contract-ID, Version und Implementierung bereitstellen | Eindeutigkeit, Auflösung und deklarierte Dependencies prüfen |
+| Event publisher/subscriber | eigenes Event publizieren oder Handler registrieren | Dispatch, Transaktionsbezug, Retry und Beobachtbarkeit stellen |
+| Permission | stabile ID und fachliche Beschreibung definieren | Duplikate verhindern und Auswertung bereitstellen |
+| Job | Job-ID, Handler, Schedule-Anforderung und Idempotenz definieren | Registry, Ausführung, Locking und Telemetrie koordinieren |
+| Health/readiness | begrenzten, timeoutfähigen Status beitragen | Beiträge aggregieren, ohne Liveness unnötig zu koppeln |
+| Settings schema | namespaced Schema samt Defaults/Validierung liefern | laden, Secrets schützen und Fehler beim Bootstrap melden |
+| Persistence metadata/migrations | eigene Metadata und Migrationen liefern | Reihenfolge und Alembic-Ausführung koordinieren |
+| Capability | stabile Capability-ID und Status deklarieren | Eindeutigkeit und Abfrage über Registry bereitstellen |
+
+Die konkreten APIs entstehen in #94 bis #100, #104 und #111. Ein neues
+Backend-Modul muss danach ohne Änderung an `backend/app/main.py` und
+`backend/app/api/router.py` registrierbar sein.
+
+## Geplante Frontend-Extension-Points
+
+Das Build-Time-Modell bietet langfristig Registries für:
+
+- `pages/routes`;
+- `navigation.primary`, `navigation.user` und `navigation.admin`;
+- `header.actions`, `sidebar`, `dashboard.widgets` und `profile.sections`;
+- `map.controls`, `map.layers`, `map.interactions`, `map.feature-info`,
+  `map.analysis-provider`, `map.context-menu` und `map.bottom-sheet`.
+
+Für jeden Beitrag gelten folgende Regeln:
+
+- Er hat eine über Builds stabile, global eindeutige und vom Modul namespacete ID.
+- Sortierung ist deterministisch über definierte Gruppen/Prioritäten; Reihenfolge
+  darf nicht von Discovery- oder Importreihenfolge abhängen.
+- Sichtbarkeit kann von Capabilities und Permissions abhängen. Die UI verwendet den
+  zentralen Auth-Kontext; Autorisierung bleibt trotzdem serverseitig.
+- Registrierung liefert einen Lifecycle beziehungsweise eine Unregister-Möglichkeit,
+  damit Deaktivierung, Tests und Hot Reload keine doppelten Beiträge hinterlassen.
+- Beiträge müssen SSR-kompatibel sein. Browser-only Code und MapLibre-Zugriff werden
+  erst clientseitig im dafür vorgesehenen Lifecycle ausgeführt.
+- Unbekannte oder deaktivierte Beiträge dürfen SSR und die globale App Shell nicht
+  beschädigen; Registrierungsfehler sind beobachtbar.
+
+Die genaue Nuxt-Integration und Distribution werden in #101, UI-Registries in #102
+bestimmt. Es werden keine beliebigen Vue-Bundles zur Laufzeit von externen URLs
+geladen und keine Runtime-Microfrontends eingeführt.
+
+## Map Runtime
+
+`MapCanvas.vue` wird langfristig zum kleinen Composition Root. Die Zielzerlegung ist:
+
+```mermaid
+flowchart TB
+    MapHost[MapHost / Composition Root]
+    Lifecycle[MapLifecycle]
+    Layers[LayerRegistry]
+    Controls[ControlRegistry]
+    Interactions[InteractionRegistry]
+    Selection[SelectionManager]
+    Draw[DrawManager]
+    FeatureInfo[FeatureInfoRegistry]
+    Telemetry[Telemetry]
+
+    MapHost --> Lifecycle
+    MapHost --> Layers
+    MapHost --> Controls
+    MapHost --> Interactions
+    MapHost --> Selection
+    MapHost --> Draw
+    MapHost --> FeatureInfo
+    MapHost --> Telemetry
+```
+
+Der Host besitzt MapLibre-Lifecycle, stabile Registries, gemeinsame Auswahl- und
+Interaktionsregeln sowie die Rendering-Basis. Fachmodule besitzen ihre Sources,
+Layer, Controls, Feature-Info-Provider und fachlichen Interaktionen. Konflikte wie
+Layer-Reihenfolge, exklusive Interaktionsmodi, Cleanup und Telemetrie werden durch
+Map-Runtime-Verträge gelöst, nicht durch gegenseitige Modulimporte.
+
+Diese Zerlegung gehört zu #103 und setzt die Characterization-Tests aus #21 voraus.
+Dieses ADR ändert `MapCanvas.vue` nicht. Der Layer-Katalog aus #83 konsumiert später
+dieselben Extension-Points.
+
+## Datenbank- und Migrationsgrenzen
+
+- PostgreSQL/PostGIS bleibt eine gemeinsame Datenbank. Eine Datenbank pro Modul ist
+  kein Ziel.
+- Jedes Modul besitzt seine fachlichen Tabellen, Geometrien und Migrationen.
+- Der Host koordiniert Migrationen, Reihenfolge, Transaktionen und den bestehenden
+  Alembic-Lifecycle.
+- Kein Modul verändert Tabellen eines fremden Moduls.
+- Die veröffentlichte Alembic-Historie bleibt intakt; es gibt weder Neuaufbau noch
+  Neuinitialisierung der Production-Datenbank.
+- Cross-Module-Foreign-Keys sind bewusste, seltene Ausnahmen. Cross-Module-
+  Geospatial-Queries bleiben möglich, werden aber über Application-/Query-Services
+  angeboten statt durch fremde ORM-Imports.
+
+Als bevorzugte Richtung wird ein PostgreSQL-Schema pro Modul evaluiert, weil es
+Ownership sichtbar macht und Namenskollisionen reduziert. Falls Alembic-, PostGIS-
+oder Betriebsanforderungen dagegen sprechen, ist ein konsistentes Tabellen-Namespace
+die Alternative. Die endgültige Wahl, Legacy-Zuordnung und Migrationsmechanik trifft
+#97; dieses ADR nimmt keine Schemaänderung vor.
+
+## Konfiguration, Events und Manifest
+
+Der Host stellt den Konfigurationsmechanismus bereit; jedes Modul registriert ein
+namespaced Settings-Schema und besitzt seine fachlichen Werte. Module erhalten nur
+die benötigten Secrets über kontrollierte SDK-Primitives. Details folgen in #99.
+
+Ein Domain Event gehört immer dem Modul, das den fachlichen Zustand besitzt. Der
+Name `PolygonCreated` ist deshalb korrekt, `CorePolygonCreated` nicht. Payloads sind
+versionierte Contracts und enthalten keine ORM-Instanzen oder unnötigen
+personenbezogenen Daten. Zustellungs- und Outbox-Semantik folgen in #96.
+
+Das Modulmanifest ist die zentrale deklarative Identität. Es wird mindestens ID,
+Version, Host-/SDK-Kompatibilität, Dependencies, Capabilities und Permissions
+beschreiben. Exaktes Format, SemVer-Regeln und Dependency-Auflösung gehören zu #93;
+das Manifest bleibt kompakt und wird nicht zum imperativen Bootstrap-Skript.
+
+## Trust, Distribution und Kompatibilität
+
+Installierte Python- und Nuxt-Module laufen im Prozess mit Host-Rechten. Sie sind
+**trusted code und nicht sandboxed**. Es wird keine Sicherheitsisolation behauptet,
+die der Prozess nicht erzwingt. Untrusted Integrationen laufen out-of-process und
+verwenden begrenzte Verträge wie HTTP, OGC, Tiles, Webhooks oder Events. Die genaue
+Klassifizierung und Review-/Signaturregeln folgen in #109.
+
+Frontend-Module werden vor dem Build installiert und aktiviert. Es gibt im ersten
+System keinen Runtime-Download von Plugin-Code. Nuxt Layers/Modules werden in #101
+evaluiert.
+
+Host, SDK und Module werden langfristig separat mit SemVer versioniert. Ein Modul
+deklariert unterstützte Host-/SDK-Versionen; „latest funktioniert immer“ ist kein
+Vertrag. Breaking Changes benötigen eine neue Major-Version. Deprecations müssen
+dokumentiert, beobachtbar und für mindestens einen angekündigten Migrationszeitraum
+parallel nutzbar sein. Details und die genaue Compatibility-Matrix gehören zu #93.
+
+## Compatibility Invariants
+
+Die Modularisierung darf ohne eigenes explizites Issue und Migrationskonzept keine
+der folgenden Production-Verträge brechen:
+
+- bestehende API-URLs und JSON-Response-Contracts;
+- Authentication Behaviour sowie Cookie-/CSRF-Verhalten;
+- SSR-URLs, Canonicals, öffentliche Seiten und Map-URLs;
+- bestehende DB-Daten und veröffentlichte Migrationen;
+- E-Mail-, Notification- und Social-Flows;
+- Deployment Health, Rollback-Fähigkeit und Observability.
+
+Legacy-Adapter dürfen intern neue Contracts bedienen, während die öffentlichen
+Verträge unverändert bleiben. Provenienz, Lizenz und Attribution externer Daten
+bleiben bei Modulgrenzen erhalten.
+
+## Inkrementelle Migration
+
+Die Migration folgt einem Strangler-Muster. Bestehende Implementierungen bleiben
+zunächst aktiv:
+
+```mermaid
+flowchart LR
+    Contracts[1. Neue Contracts]
+    Adapter[2. Legacy-Adapter]
+    Domain[3. Eine Domäne migrieren]
+    Verify[4. Production verifizieren]
+    Remove[5. Legacy entfernen]
+
+    Contracts --> Adapter --> Domain --> Verify --> Remove
+    Verify -. bei Regression .-> Adapter
+```
+
+Es werden nicht zuerst Verzeichnisse massenhaft verschoben. Jede Stufe bleibt
+deploybar und bewahrt bestehende API-, SSR-, Auth-, Daten- und Betriebsverträge.
+Neue Modulpfade sind kontrolliert aktivierbar; eine Pilotmigration kann, soweit
+sinnvoll, auf den Legacy-Pfad zurückschalten. Enable/Disable-, Upgrade- und
+Datenhaltungsregeln werden in #112 festgelegt.
+
+### Temporäre Git-Integrationslinie für Epic #91
+
+Während des Epics gilt:
+
+```text
+main (Production/stabile Hauptlinie)
+  └─ staging/epic-91-modular-host (temporäre Epic-Integration)
+       └─ feat/<issue>-... oder docs/<issue>-...
+            └─ Pull Request zurück auf staging/epic-91-modular-host
+```
+
+- Kein Epic-Feature-PR zielt direkt auf `main`.
+- Pro Issue wird ein kurzer Feature-Branch von der aktuellen Staging-Branch erstellt
+  und nach dem Merge nicht weiterverwendet.
+- Nach jedem Merge bleiben Backend- und Frontendtests, Typecheck, Build,
+  Security-/Architecture-Gates und relevante E2E-Tests grün.
+- Die Staging-Branch nimmt regelmäßig `main` auf, damit Production-Fixes nicht
+  auseinanderlaufen.
+- Erst wenn die Gates aus #91 erfüllt sind, wird ein finaler Integrations-PR von
+  `staging/epic-91-modular-host` nach `main` erstellt. Danach wird die temporäre
+  Staging-Branch entfernt.
+
+## Pilotdomäne
+
+Für #107 werden **Analysis Areas** und **Statistics** als Kandidaten bewertet:
+
+| Kandidat | Eignung | Risiken |
+|---|---|---|
+| Analysis Areas | abgegrenzte, überwiegend lesende Domäne; prüft API, Persistence, Frontend und Map-Beitrag End-to-End | öffentliche URLs/Responses und räumliche Beziehungen müssen über Legacy-Adapter stabil bleiben |
+| Statistics | fachlich erkennbarer Datenbesitz und gute Query-Service-Grenze | lokale Importannahmen, Analytics-Kopplung und Provenienzarbeit aus #33/#34 erhöhen den Vorlauf |
+
+Empfohlen wird **Analysis Areas** als Pilot, weil die Domäne die wesentlichen
+Extension-Points repräsentativ validiert, ohne die gesamte Map Runtime zu migrieren.
+Die endgültige Auswahl erfolgt in #107 nach Characterization-Tests und einer
+Dependency-Inventur. Auth, Assistant und die komplette Karte sind wegen
+Sicherheitsrelevanz, Breite beziehungsweise zentraler Kopplung ausdrücklich keine
+ersten Pilotdomänen.
+
+## Automatisierbare Architektur-Invarianten
+
+#105 soll mindestens folgende Regeln als statische Tests, Contract-Tests oder
+Build-Fixtures durchsetzen:
+
+| Invariante | Erwarteter automatischer Nachweis |
+|---|---|
+| Host importiert keine Fachmodule | negativer Import-/Dependency-Test für Host-Pakete |
+| Module importieren keine Host-Interna | Allowlist ausschließlich öffentlicher SDK-Pfade |
+| Module importieren keine fremde Persistence/ORM | verbotene Pfadmuster und Dependency-Graph-Test |
+| Module haben eindeutige IDs | Manifest-Registry lehnt Duplikate ab |
+| Modulabhängigkeiten sind azyklisch | Zyklenerkennung über deklarierte Dependencies |
+| Abhängigkeiten sind deklariert und kompatibel | Manifest-/SemVer-Validierung vor Bootstrap und Build |
+| Neues Backend-Modul benötigt keinen Host-Patch | Referenzmodul registriert Router ohne Diff an `main.py`/`api/router.py` |
+| Neue Navigation benötigt keinen zentralen Patch | Frontend-Fixture registriert Beitrag ohne Diff an `useSiteNavigation.ts` |
+| Neue Map Extension benötigt keinen zentralen Patch | Fixture registriert Layer/Control ohne Diff an `MapCanvas.vue` |
+| Contributions sind eindeutig und deterministisch | Duplicate-ID- und Sortierungs-Contract-Tests |
+| Deaktivierung räumt Beiträge auf | Lifecycle-/Unregister-Test ohne doppelte Handler oder UI-Einträge |
+| Frontend-Beiträge bleiben SSR-fähig | SSR-Build-/Render-Test mit aktiviertem Referenzmodul |
+| Permission Visibility ersetzt keine Autorisierung | API-Contract-Test verweigert unberechtigte Requests unabhängig von UI |
+| Migrationen respektieren Ownership | Test verhindert Änderungen an fremden Modulobjekten und mehrere Heads ohne Koordination |
+
+Die Tests werden gegen eine dokumentierte Legacy-Baseline eingeführt. Sie dürfen
+bestehende Verstöße sichtbar machen, ohne die Migration durch einen Big-Bang-Fix zu
+erzwingen; neue Verstöße werden ab Einführung verhindert.
+
+## Anti-Patterns
+
+- **Shared everything:** Ein wachsendes `shared/` wird zum neuen Monolithen. Nur echte
+  Plattformprimitives gehören ins SDK; Fachlogik bleibt beim Owner.
+- **Event soup:** Nicht jede interne Operation ist ein Event. Events bilden relevante
+  fachliche Tatsachen und Integrationsgrenzen ab.
+- **Service locator abuse:** Die Registry löst nur öffentliche, typisierte Contracts
+  auf und versteckt keine beliebigen Implementierungen.
+- **ORM leakage:** Contracts enthalten DTOs/Protokolle, keine SQLAlchemy-Modelle,
+  Sessions oder Lazy-Loading-Annahmen.
+- **Circular module dependencies:** Zyklen sind verboten und werden beim Build
+  abgelehnt; gemeinsame Fachlichkeit wird nicht reflexartig in Core verschoben.
+- **Huge module manifests:** Das Manifest bleibt kompakt und deklarativ. Logik gehört
+  in versionierte Modul-Entry-Points.
+- **Runtime plugin download:** Beliebiger Code wird nicht zur Laufzeit nachgeladen.
+- **Plugin sandbox illusion:** In-process-Module sind trusted; Isolation erfordert
+  out-of-process-Verträge.
+- **Distributed monolith:** Microservices sind keine Voraussetzung und lösen
+  ungeklärte fachliche Grenzen nicht.
+
+## Folgen und offene Folgearbeit
+
+Positiv werden Ownership, Testbarkeit und unabhängige Erweiterbarkeit explizit. Neue
+Module können nach Umsetzung der Registries ohne Patches an zentralen Composition-
+Dateien beitragen. Das gemeinsame Deployment, transaktionale Datenmodell und die
+vorhandenen Betriebsabläufe bleiben erhalten.
+
+Als Kosten entstehen Versionierungs-, Registry-, Adapter- und Architecture-Test-
+Aufwand. Während der Strangler-Phase existieren zeitweise Legacy- und Modulpfade
+parallel. Das ist akzeptiert, solange Feature Flags, Observability und klare
+Entfernungsbedingungen die Übergänge kontrollieren.
+
+Dieses ADR implementiert keine Runtime, verschiebt keine Fachmodule, ändert keine
+API, erzeugt keine Migration und entscheidet keine Detail-Contracts vor. Folgearbeit:
+
+- #93 Manifest, SemVer und Dependencies;
+- #94/#95 Runtime und ModuleContext;
+- #96 Events/Outbox, #97 Datenbank/Migrationen, #98 Service Registry und #99 Config;
+- #101/#102 Frontend-Build und UI Contributions, #103 Map Runtime;
+- #104 Permissions/Capabilities und #105 Architecture Tests;
+- #107 Pilotmigration, #109 Trust-Modell und #112 Enablement/Lifecycle.

--- a/docs/modules/backend-module-runtime.md
+++ b/docs/modules/backend-module-runtime.md
@@ -1,0 +1,86 @@
+# Backend-Module-Runtime
+
+Die erste Module Runtime ergänzt den bestehenden FastAPI-Host während der
+inkrementellen Migration aus
+[ADR #92](../architecture/adr-modular-host-and-module-boundaries.md). Sie verwendet
+den bestehenden [Manifest-V1-Contract](module-manifest-v1.md) für Parsing,
+Compatibility, Dependencies und deterministische Load Order. Der zentrale Legacy-
+Router bleibt parallel eingebunden; keine bestehende Fachdomäne wurde migriert.
+
+## Bootstrap und Enablement
+
+`backend/app/main.py` erzeugt eine fachneutrale Runtime aus zwei Discovery-Providern
+und bindet deren Router zusätzlich zum Legacy-Router ein. `ENABLED_MODULES` enthält
+eine komma-separierte Liste aktivierter Modul-IDs. Der leere Default aktiviert kein
+neues Modul und bewahrt damit das bisherige Produktionsverhalten.
+
+Die API-Version aus `Settings.api_version` ist gleichzeitig die zentral gepflegte
+Host-Kompatibilitätsversion. Die öffentliche Backend-SDK-Version steht unabhängig
+davon als `MODULE_SDK_VERSION` in der Runtime. Release-SHA, Host-Version und
+SDK-Version sind unterschiedliche Werte.
+
+Aktivierung ist in dieser Ausbaustufe ausschließlich deploy-time Konfiguration. Ein
+aktiviertes, aber nicht auffindbares Modul stoppt den Bootstrap. Deaktivierte Module
+werden weder importiert noch instanziiert und stehen der Dependency-Auflösung nicht
+zur Verfügung. Dadurch schlägt eine Required Dependency auf ein deaktiviertes Modul
+mit der bestehenden Manifest-Fehlersemantik fehl. Eine optionale Dependency darf
+weiterhin fehlen.
+
+## Discovery-Quellen
+
+`FirstPartyModuleDiscovery` verwendet einen fachneutralen Katalog aus passiven
+`ModuleDefinition`-Objekten oder verzögerten Definition-Loadern. Ein neues
+First-Party-Modul benötigt dadurch keine Änderung an `main.py` oder
+`app/api/router.py`.
+
+`EntryPointModuleDiscovery` berücksichtigt ausschließlich die Python-Entry-Point-
+Gruppe `open_city_planner.modules`. Der Entry-Point-Name ist die aktivierbare
+Modul-ID. Nur Entry Points mit explizit aktivierter ID werden geladen; andere Gruppen
+und deaktivierte Einträge werden nicht ausgeführt. Ein Entry Point exportiert eine
+passive `ModuleDefinition`, deren Manifest vor dem eigentlichen Modul-Loader geprüft
+wird. Distribution und Installation werden von dieser Runtime nicht verändert.
+
+## Registrierungs- und Lifecycle-Reihenfolge
+
+Der Ablauf ist strikt getrennt:
+
+1. Definitionen aktivierter Module entdecken;
+2. Manifeste über `parse_manifest()` und `validate_manifests()` prüfen;
+3. Reihenfolge über `resolve_module_order()` bestimmen;
+4. validierte Module instanziieren;
+5. deklarative Router- und Lifecycle-Beiträge registrieren;
+6. Startup-Hooks in Load Order ausführen;
+7. Shutdown-Hooks in umgekehrter Reihenfolge ausführen.
+
+`ModuleRegistrationContext` enthält bewusst nur Router- und asynchrone Lifecycle-
+Registrierung. Datenbank, Redis, Storage, Events, Services, Jobs und Secrets sind
+nicht Teil dieses kleinen Vertrags. Capabilities stammen unverändert aus dem
+Manifest und sind über `ModuleRegistry.capabilities(module_id)` verfügbar.
+
+`ModuleRuntime.register(app)` darf genau einmal aufgerufen werden. Damit entstehen
+keine stillen Router-Duplikate. `register()` ist für deklarative Beiträge bestimmt;
+Verbindungen, Worker und andere externe Side Effects gehören in asynchrone Startup-
+Hooks.
+
+## Fehler und Cleanup
+
+Manifest-, Compatibility- und Dependency-Fehler bleiben als verkettete Ursachen der
+strukturierten Runtime-Fehler erhalten. Runtime-Fehler nennen die Phase
+`discovery`, `validation`, `import`, `registration`, `startup` oder `shutdown` sowie
+Modul-ID und Origin, soweit diese bekannt sind. Registrierungs- und Startup-Fehler
+stoppen den Host fail-fast.
+
+Schlägt ein Startup-Hook fehl, führt die Runtime die Shutdown-Hooks aller bereits
+erfolgreich gestarteten Beiträge in umgekehrter Reihenfolge aus. Cleanup-Fehler
+werden protokolliert, ohne den ursprünglichen Startup-Fehler zu verdecken. Beim
+regulären Shutdown werden trotz eines einzelnen Hook-Fehlers die übrigen Beiträge
+weiter beendet. Runtime-Logs tragen die strukturierten Felder `module_id`,
+`module_version` und `module_phase`.
+
+## Vertrauen und Sicherheit
+
+First-Party- und Entry-Point-Module sind installierter, vertrauenswürdiger
+In-Process-Code und nicht sandboxed. Die Runtime installiert keine Pakete, lädt keine
+URLs und akzeptiert keine Python-Modulnamen aus HTTP- oder sonstigen Nutzereingaben.
+Aktivierte IDs und installierte Entry Points werden ausschließlich durch Deployment
+und Packaging kontrolliert.

--- a/docs/modules/examples/example-biotopes.module.json
+++ b/docs/modules/examples/example-biotopes.module.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": 1,
+  "id": "example-biotopes",
+  "name": "Beispiel-Biotope",
+  "version": "1.0.0",
+  "requires": {
+    "host": ">=1.0.0,<2.0.0",
+    "sdk": ">=1.0.0,<2.0.0",
+    "modules": {
+      "example-layer-catalog": ">=1.0.0,<2.0.0"
+    }
+  },
+  "optional": {
+    "modules": {
+      "example-statistics": ">=1.0.0,<2.0.0"
+    }
+  },
+  "backend": {
+    "package": "open_city_planner_example_biotopes"
+  },
+  "frontend": {
+    "package": "@open-city-planner/example-biotopes"
+  },
+  "capabilities": [
+    "map.layer",
+    "map.feature-info",
+    "analysis.provider"
+  ],
+  "permissions": [
+    "example-biotopes.read",
+    "example-biotopes.admin"
+  ],
+  "config": {
+    "namespace": "example-biotopes"
+  },
+  "persistence": {
+    "schema": "example_biotopes",
+    "migrations": true
+  }
+}

--- a/docs/modules/examples/example-layer-catalog.module.json
+++ b/docs/modules/examples/example-layer-catalog.module.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 1,
+  "id": "example-layer-catalog",
+  "name": "Beispiel-Layerkatalog",
+  "version": "1.1.0",
+  "requires": {
+    "host": ">=1.0.0,<2.0.0",
+    "sdk": ">=1.0.0,<2.0.0"
+  },
+  "frontend": {
+    "package": "@open-city-planner/example-layer-catalog"
+  },
+  "capabilities": [
+    "map.layer",
+    "ui.navigation"
+  ],
+  "permissions": [
+    "example-layer-catalog.read"
+  ]
+}

--- a/docs/modules/examples/example-pois.module.json
+++ b/docs/modules/examples/example-pois.module.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 1,
+  "id": "example-pois",
+  "name": "Beispiel-POIs",
+  "version": "1.0.0",
+  "requires": {
+    "host": ">=1.0.0,<2.0.0",
+    "sdk": ">=1.0.0,<2.0.0"
+  },
+  "backend": {
+    "package": "open_city_planner_example_pois"
+  },
+  "capabilities": [
+    "map.layer",
+    "map.feature-info"
+  ],
+  "permissions": [
+    "example-pois.read"
+  ],
+  "config": {
+    "namespace": "example-pois"
+  },
+  "persistence": {
+    "schema": "example_pois",
+    "migrations": true
+  }
+}

--- a/docs/modules/module-manifest-v1.md
+++ b/docs/modules/module-manifest-v1.md
@@ -2,8 +2,9 @@
 
 Diese Dokumentation präzisiert den maschinenlesbaren Modulvertrag aus
 [ADR: Modularer Host und Grenzen von Fachmodulen](../architecture/adr-modular-host-and-module-boundaries.md).
-Sie führt keine Module Runtime ein. Discovery, Aktivierung und das Laden von Paketen
-folgen in #94, #112 und #113.
+Die darauf aufbauende Discovery und Registrierung beschreibt die
+[Backend-Module-Runtime](backend-module-runtime.md). Der vollständige
+Aktivierungs-Lifecycle und die Distribution bleiben Gegenstand von #112 und #113.
 
 ## Contract und Formate
 

--- a/docs/modules/module-manifest-v1.md
+++ b/docs/modules/module-manifest-v1.md
@@ -1,0 +1,176 @@
+# Module Manifest Schema V1
+
+Diese Dokumentation präzisiert den maschinenlesbaren Modulvertrag aus
+[ADR: Modularer Host und Grenzen von Fachmodulen](../architecture/adr-modular-host-and-module-boundaries.md).
+Sie führt keine Module Runtime ein. Discovery, Aktivierung und das Laden von Paketen
+folgen in #94, #112 und #113.
+
+## Contract und Formate
+
+`ModuleManifestV1` in `backend/app/platform/modules/manifest.py` ist die typisierte
+Single Source of Truth. Das daraus erzeugte, versionierte
+[JSON Schema](schema/module-manifest-v1.schema.json) ist für externe Werkzeuge
+committed. Ein Test verhindert Abweichungen zwischen Pydantic-Modell und Datei.
+
+Der Parser akzeptiert ein bereits dekodiertes Python-Mapping. JSON ist damit direkt
+nutzbar. YAML darf ein Authoring-Format sein, ist aber kein eigener Contract und wird
+vom Host in V1 nicht geladen. Ein späterer Dateiloader muss für YAML ausschließlich
+einen Safe Loader verwenden. Manifestwerte werden nicht als Python-Import,
+Shell-Befehl, SQL oder Template ausgeführt; Package-Referenzen sind nur Strings.
+
+Unbekannte Felder sind auf jeder Schemaebene verboten. Dadurch wird zum Beispiel
+`permisions` nicht stillschweigend ignoriert. Capability-IDs bleiben dagegen offen:
+Ein älterer Host darf eine syntaktisch gültige, ihm noch unbekannte Capability
+transportieren.
+
+## Versionen
+
+Der Contract unterscheidet drei Versionen:
+
+1. `manifest_version` versioniert das Schema. V1 akzeptiert ausschließlich den Wert
+   `1`; andere Werte schlagen mit `UnsupportedManifestVersionError` fehl.
+2. `version` ist die vollständige SemVer-Version des Moduls, zum Beispiel `2.3.1`.
+3. `requires.host`, `requires.sdk` und Modulabhängigkeiten sind Compatibility-Ranges.
+
+V1 verwendet genau eine Range-Sprache: komma-separierte, explizite Vergleiche mit
+vollständigen SemVer-Versionen, zum Beispiel `>=1.2.0,<2.0.0`. Erlaubte Operatoren
+sind `>=`, `<=`, `>`, `<`, `==` und `!=`. Npm-Kurzformen wie `^1.2.0`, `~1.4.0`,
+Wildcards und unvollständige Versionen sind nicht Teil des Contracts. Parsing und
+Vergleich erfolgen mit `python-semanticversion`; das Manifest verwendet weder
+PEP-440- noch npm-Range-Semantik.
+
+Die spätere Runtime übergibt ihre Versionen explizit:
+
+```python
+validated = validate_manifests(
+    manifests,
+    host_version="1.0.0",
+    sdk_version="1.0.0",
+)
+order = resolve_module_order(validated)
+```
+
+Der Validator sucht Versionen nicht selbst in Paketen, Settings oder im Netzwerk.
+Host, SDK und Module folgen langfristig SemVer; Details zu Compatibility und
+Deprecation bleiben Teil von #93/#94.
+
+## Identität und IDs
+
+Modul-IDs sind stabile ASCII-IDs in lowercase kebab-case. Sie erfüllen
+`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`, sind höchstens 63 Zeichen lang und hängen nicht
+vom Anzeigenamen ab:
+
+```json
+{
+  "id": "analysis-areas",
+  "name": "Analysegebiete"
+}
+```
+
+Eine ID darf nicht ohne eigenes Migrations- und Compatibility-Konzept umbenannt
+werden. Zwei verfügbare Manifeste mit derselben ID schlagen fail-fast fehl; bekannte
+Manifestquellen können für die Fehlermeldung separat an `validate_manifests`
+übergeben werden.
+
+Capability- und Permission-IDs verwenden mindestens zwei durch Punkte getrennte,
+ebenfalls kebab-case-formatierte Segmente. Capabilities wie `map.layer`,
+`map.feature-info`, `analysis.provider`, `ui.navigation`, `jobs.provider` und
+`events.publisher` werden nur validiert, dedupliziert und transportiert. V1 führt
+keine abschließende Capability-Registry ein.
+
+Moduldefinierte Permissions müssen mit `<module-id>.` beginnen, zum Beispiel
+`example-biotopes.read`. Host/Core-Permissions werden nicht über ein Fachmanifest
+definiert. Auswertung und Registrierung der Permissions folgen in #104.
+
+## Felder
+
+| Feld | Bedeutung |
+|---|---|
+| `manifest_version` | Version des Manifest-Schemas, in V1 exakt `1` |
+| `id` | stabile technische Modul-ID |
+| `name` | menschenlesbarer Anzeigename |
+| `version` | vollständige SemVer-Modulversion |
+| `requires.host` | kompatible Host-Versionen |
+| `requires.sdk` | kompatible Public-SDK-Versionen |
+| `requires.modules` | erforderliche Module und deren Ranges |
+| `optional.modules` | optionale Module und deren Ranges |
+| `backend.package` | optionaler Python-Distributionsbezeichner |
+| `frontend.package` | optionaler npm-Paketbezeichner |
+| `capabilities` | offene, stabile Capability-IDs |
+| `permissions` | stabile, vom Modul namespacete Permission-IDs |
+| `config.namespace` | eindeutige Identität für die spätere Config Runtime aus #99 |
+| `persistence.schema` | deklarativer, unquoted-sicherer PostgreSQL-Schemaname |
+| `persistence.migrations` | kündigt eigene Migrationen für #97 deklarativ an |
+
+Backend-only-, Frontend-only- und kombinierte Module sind darstellbar. Die
+Package-Felder lösen in #93 weder Imports noch Downloads aus. Das Manifest enthält
+keine Secrets, SQL-Anweisungen, Entry-Point-Ausführung oder Settingswerte.
+
+`config.namespace` ist über die validierte Manifestmenge eindeutig und stabil.
+Environment-Namen, Secret-Zugriff und Settings-Lifecycle werden erst in #99
+definiert. Persistence-Metadaten erzeugen weder DB-Schemas noch Migrationen; der
+Alembic-Runner bleibt bis #97 unverändert.
+
+## Dependency-Semantik
+
+Eine Required Dependency muss in der vom Aufrufer bereitgestellten Menge vorhanden
+und versionskompatibel sein. Fehlt sie, entsteht ein
+`MissingModuleDependencyError`; bei falscher Version ein
+`ModuleDependencyVersionError`.
+
+Eine Optional Dependency darf fehlen. Ist sie vorhanden, muss ihre Version zur
+deklarierten Range passen; eine inkompatible vorhandene Version ist ebenfalls ein
+Fehler. Optional bedeutet nur, dass ein Modul zusätzliche Funktionalität nutzen
+kann. Es aktiviert oder lädt kein anderes Modul.
+
+Der Validator kennt keinen Enable/Disable-Zustand. #94/#112 übergeben ausschließlich
+die für den jeweiligen Bootstrap verfügbaren beziehungsweise aktiven Manifeste.
+Required und optional Self Dependencies sind verboten. Modulabhängigkeiten müssen
+deklariert sein; Host und SDK sind separate Compatibility Targets und werden nicht
+als künstliche Module modelliert.
+
+## Graph und Load Order
+
+`resolve_module_order()` führt einen topologischen Sort auf validierten Manifesten
+aus. Dependencies stehen stets vor ihren Consumern. Sind mehrere Module gleichzeitig
+ladbar, entscheidet die Modul-ID lexikografisch. Dadurch bleiben Startreihenfolge,
+Logs und Tests unabhängig von Discovery- oder Dateisystemreihenfolge reproduzierbar.
+
+Vorhandene optionale Dependencies bilden ebenfalls eine Sortierkante. Duplicate IDs,
+Self Dependencies, fehlende Required Dependencies und direkte oder indirekte Zyklen
+schlagen hart fehl. Ein Zyklusfehler enthält einen konkreten, deterministischen Pfad,
+zum Beispiel:
+
+```text
+module-a -> module-b -> module-c -> module-a
+```
+
+## Strukturierte Fehler
+
+- `ModuleManifestError`
+- `UnsupportedManifestVersionError`
+- `InvalidRuntimeVersionError`
+- `DuplicateModuleIdError`
+- `DuplicateConfigNamespaceError`
+- `ModuleCompatibilityError`
+- `MissingModuleDependencyError`
+- `ModuleDependencyVersionError`
+- `ModuleSelfDependencyError`
+- `ModuleDependencyCycleError`
+
+Die Fehler tragen je nach Fall Modul-ID, erwartete und gefundene Version,
+Dependency-ID, bekannte Origins oder den Cycle-Pfad. Sie benötigen weder FastAPI,
+Datenbank, Redis, globale Settings noch Netzwerk.
+
+## Beispiele
+
+Die Dateien unter [`examples/`](examples/) sind reine Dokumentations- und
+Test-Fixtures. Sie aktivieren oder migrieren keine bestehende Fachdomäne:
+
+- `example-pois.module.json`: unabhängiges Backend-Modul;
+- `example-layer-catalog.module.json`: unabhängiges Frontend-Modul;
+- `example-biotopes.module.json`: kombiniertes Modul mit erforderlichem
+  `example-layer-catalog` und optionalem `example-statistics`.
+
+Mit den vorhandenen Beispielen ergibt sich die Reihenfolge
+`example-layer-catalog`, `example-biotopes`, `example-pois`.

--- a/docs/modules/schema/module-manifest-v1.schema.json
+++ b/docs/modules/schema/module-manifest-v1.schema.json
@@ -1,0 +1,250 @@
+{
+  "$defs": {
+    "ModuleBackendPackage": {
+      "additionalProperties": false,
+      "description": "Deklarativer Python-Distributionsname; keine Import-Anweisung.",
+      "properties": {
+        "package": {
+          "maxLength": 214,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$",
+          "title": "Package",
+          "type": "string"
+        }
+      },
+      "required": [
+        "package"
+      ],
+      "title": "ModuleBackendPackage",
+      "type": "object"
+    },
+    "ModuleConfig": {
+      "additionalProperties": false,
+      "description": "Stabile Identität für das spätere Settings-Namespace aus #99.",
+      "properties": {
+        "namespace": {
+          "$ref": "#/$defs/ModuleId"
+        }
+      },
+      "required": [
+        "namespace"
+      ],
+      "title": "ModuleConfig",
+      "type": "object"
+    },
+    "ModuleFrontendPackage": {
+      "additionalProperties": false,
+      "description": "Deklarativer npm-Paketname; kein Runtime-Bundle oder Download-Endpunkt.",
+      "properties": {
+        "package": {
+          "maxLength": 214,
+          "minLength": 1,
+          "pattern": "^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$",
+          "title": "Package",
+          "type": "string"
+        }
+      },
+      "required": [
+        "package"
+      ],
+      "title": "ModuleFrontendPackage",
+      "type": "object"
+    },
+    "ModuleId": {
+      "maxLength": 63,
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+      "type": "string"
+    },
+    "ModuleOptionalRequirements": {
+      "additionalProperties": false,
+      "description": "Optionale Module, deren vorhandene Version dennoch kompatibel sein muss.",
+      "properties": {
+        "modules": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SemanticVersionRange"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/ModuleId"
+          },
+          "title": "Modules",
+          "type": "object"
+        }
+      },
+      "title": "ModuleOptionalRequirements",
+      "type": "object"
+    },
+    "ModulePersistence": {
+      "additionalProperties": false,
+      "description": "Deklarative Metadaten für das spätere Migrations-Ownership aus #97.",
+      "properties": {
+        "migrations": {
+          "default": false,
+          "title": "Migrations",
+          "type": "boolean"
+        },
+        "schema": {
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "title": "Schema",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema"
+      ],
+      "title": "ModulePersistence",
+      "type": "object"
+    },
+    "ModuleRequirements": {
+      "additionalProperties": false,
+      "description": "Pflichtkompatibilität und erforderliche Modulabhängigkeiten.",
+      "properties": {
+        "host": {
+          "$ref": "#/$defs/SemanticVersionRange"
+        },
+        "modules": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SemanticVersionRange"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/ModuleId"
+          },
+          "title": "Modules",
+          "type": "object"
+        },
+        "sdk": {
+          "$ref": "#/$defs/SemanticVersionRange"
+        }
+      },
+      "required": [
+        "host",
+        "sdk"
+      ],
+      "title": "ModuleRequirements",
+      "type": "object"
+    },
+    "NamespacedId": {
+      "maxLength": 127,
+      "minLength": 3,
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$",
+      "type": "string"
+    },
+    "SemanticVersion": {
+      "examples": [
+        "1.2.3"
+      ],
+      "format": "semver",
+      "maxLength": 128,
+      "minLength": 1,
+      "type": "string"
+    },
+    "SemanticVersionRange": {
+      "examples": [
+        ">=1.2.0,<2.0.0"
+      ],
+      "format": "semver-range",
+      "maxLength": 512,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Versionierter, deklarativer Kernvertrag eines Open-City-Planner-Moduls.",
+  "properties": {
+    "backend": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModuleBackendPackage"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "capabilities": {
+      "items": {
+        "$ref": "#/$defs/NamespacedId"
+      },
+      "title": "Capabilities",
+      "type": "array",
+      "uniqueItems": true
+    },
+    "config": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModuleConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "frontend": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModuleFrontendPackage"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "id": {
+      "$ref": "#/$defs/ModuleId"
+    },
+    "manifest_version": {
+      "const": 1,
+      "title": "Manifest Version",
+      "type": "integer"
+    },
+    "name": {
+      "maxLength": 120,
+      "minLength": 1,
+      "title": "Name",
+      "type": "string"
+    },
+    "optional": {
+      "$ref": "#/$defs/ModuleOptionalRequirements"
+    },
+    "permissions": {
+      "items": {
+        "$ref": "#/$defs/NamespacedId"
+      },
+      "title": "Permissions",
+      "type": "array",
+      "uniqueItems": true
+    },
+    "persistence": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModulePersistence"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "requires": {
+      "$ref": "#/$defs/ModuleRequirements"
+    },
+    "version": {
+      "$ref": "#/$defs/SemanticVersion"
+    }
+  },
+  "required": [
+    "manifest_version",
+    "id",
+    "name",
+    "version",
+    "requires"
+  ],
+  "title": "ModuleManifestV1",
+  "type": "object"
+}


### PR DESCRIPTION
## Ausgangslage

Im Rahmen von Epic #91 wurde mit ADR #92 beziehungsweise PR #114 die Architektur für den modularen Open City Planner Host festgelegt. PR #115 / Issue #93 stellt den verbindlichen Manifest-, Compatibility- und Dependency-Contract bereit.

Dieser Pull Request setzt darauf aufbauend die erste Backend-Module-Runtime um. Neue Backend-Module können damit registriert werden, ohne den zentralen Legacy-Router um fachliche Imports zu erweitern.

## Umsetzung

Implementiert wurden:

- fachneutrale `ModuleRegistry` und `ModuleRuntime`;
- Wiederverwendung von `ModuleManifestV1`, `parse_manifest()`, `validate_manifests()` und `resolve_module_order()` aus #93;
- deterministische Registrierung in Dependency-Reihenfolge;
- deklarative First-Party-Discovery;
- Python-Entry-Point-Discovery über `open_city_planner.modules`;
- explizites Enablement über `ENABLED_MODULES`;
- verzögerte Instanziierung ausschließlich aktivierter Module;
- kontrollierte Registrierung von FastAPI-Routern;
- asynchrone Startup- und Shutdown-Hooks;
- Startup in Load Order und Shutdown in umgekehrter Reihenfolge;
- Cleanup bereits gestarteter Module bei einem späteren Startup-Fehler;
- strukturierte Runtime-Fehler für Discovery, Validation, Import, Registration, Startup und Shutdown;
- Capability-Metadaten über die Runtime-Registry;
- Schutz vor mehrfacher Router-Registrierung;
- strukturierte Logs mit `module_id`, `module_version` und `module_phase`;
- ein ausschließlich in Tests verwendetes Fixture-Modul mit `GET /api/v1/module-test/ping`;
- technische Dokumentation zu Bootstrap, Discovery, Enablement, Lifecycle und Trust-Modell.

## Kompatibilität

Der bestehende zentrale API-Router bleibt unverändert parallel aktiv. Ohne konfigurierte Module ist `ENABLED_MODULES` leer und das bisherige Produktionsverhalten bleibt erhalten.

Es wurden keine bestehenden API-Routen, OpenAPI-Pfade oder Response-Verträge geändert.

## Abgrenzung

Dieser Pull Request enthält ausdrücklich keine:

- Migration einer bestehenden Fachdomäne;
- vollständige `ModuleContext`- oder Host-Service-API;
- Event-Bus-, Outbox-, Service-, Permission- oder Job-Registry;
- modulare Alembic- oder Datenbankmigration;
- vollständige Settings- oder Lifecycle-State-Machine;
- Frontend-Module-Runtime;
- dynamische Installation fremden Codes;
- Sandbox für In-Process-Module.

First-Party- und Entry-Point-Module gelten als vertrauenswürdiger, deploy-time installierter Code.

## Tests

Ausgeführt:

- `ruff check app tests` – erfolgreich
- `pytest` – 687 Tests bestanden
- Manifest-, Runtime- und Config-Tests – 82 Tests bestanden
- FastAPI-Import-Smoke-Test – erfolgreich
- `pnpm audit:language` – 458 Ressourcen geprüft, 0 unerlaubte Treffer
- `git diff --check` – erfolgreich

`uv lock --check` konnte lokal nicht ausgeführt werden, da `uv` und `pip` in der verfügbaren Shell nicht installiert waren. Dependencies und Lockfiles wurden nicht verändert.

## Migration und Betrieb

- Datenbankmigrationen: keine
- Dependency-Änderungen: keine
- Produktionsmodule standardmäßig aktiviert: keine
- Neue optionale Konfiguration: `ENABLED_MODULES`
- Rollback: Rücknahme dieses Pull Requests; bestehende Legacy-Router bleiben unabhängig funktionsfähig

Basiert auf ADR #92 / PR #114 und dem Manifest-Contract #93 / PR #115.

Part of #91  
Closes #94