### PR TITLE
feat(modules): integrate backend module runtime into epic staging

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,8 @@ OTEL_TRACES_SAMPLER=parentbased_traceidratio
 OTEL_TRACES_SAMPLER_ARG=0.1
 APP_BASE_URL=http://localhost:3000
 API_BASE_URL=http://localhost:8000
+# Komma-separierte deploy-time Modul-IDs. Leer lässt alle neuen Module deaktiviert.
+ENABLED_MODULES=
 MAP_PREVIEW_RENDERER_URL=http://127.0.0.1:3020
 MAP_PREVIEW_RENDERER_TIMEOUT_SECONDS=20
 MAP_PREVIEW_CACHE_DIR=data/map-previews

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,6 +15,7 @@ MINIMUM_JWT_SECRET_LENGTH = 32
 
 class Settings(BaseSettings):
     api_version: str = "0.2.0"
+    enabled_modules: str = ""
     database_url: str = Field(
         default="postgresql+asyncpg://postgres:postgres@localhost:5432/open_city_map"
     )
@@ -227,6 +228,10 @@ class Settings(BaseSettings):
     @property
     def trusted_proxy_list(self) -> list[str]:
         return [value.strip() for value in self.trusted_proxies.split(",") if value.strip()]
+
+    @property
+    def enabled_module_list(self) -> list[str]:
+        return [value.strip() for value in self.enabled_modules.split(",") if value.strip()]
 
     def validate_security(self) -> None:
         if not self.metrics_path.startswith("/") or "?" in self.metrics_path:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,11 +20,21 @@ from app.observability.logging import configure_logging
 from app.observability.metrics import REDIS_AVAILABLE, REGISTRY, set_build_info
 from app.observability.middleware import ObservabilityMiddleware
 from app.observability.tracing import configure_tracing
+from app.platform.modules import (
+    EntryPointModuleDiscovery,
+    FirstPartyModuleDiscovery,
+    create_module_runtime,
+)
 from app.security.request_limits import RequestBodyLimitMiddleware
 from app.services.assistant_provider import close_assistant_provider
 from app.services.map_previews import MapPreviewError, map_preview_service
 
 settings = get_settings()
+module_runtime = create_module_runtime(
+    enabled_module_ids=settings.enabled_module_list,
+    discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
+    host_version=settings.api_version,
+)
 configure_logging(
     level=settings.log_level,
     service="stadtplaner-api",
@@ -49,11 +59,15 @@ else:
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     await initialize_redis()
     try:
+        await module_runtime.startup()
         yield
     finally:
-        await close_assistant_provider()
-        await close_redis()
-        tracing_runtime.shutdown()
+        try:
+            await module_runtime.shutdown()
+        finally:
+            await close_assistant_provider()
+            await close_redis()
+            tracing_runtime.shutdown()
 
 
 OPENAPI_TAGS = [
@@ -125,6 +139,7 @@ app.add_middleware(
 )
 
 app.include_router(api_router)
+module_runtime.register(app)
 
 
 @app.exception_handler(RequestValidationError)

--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -1,6 +1,18 @@
-"""Öffentlicher Contract für Modulmanifeste und Abhängigkeitsauflösung."""
+"""Öffentliche Contracts der Backend-Module-Plattform."""
 
+from app.platform.modules.contracts import (
+    BackendModule,
+    ModuleDefinition,
+    ModuleDiscoveryProvider,
+    ModuleLifecycleHook,
+    ModuleRegistrationContext,
+)
 from app.platform.modules.dependency_graph import resolve_module_order
+from app.platform.modules.discovery import (
+    ENTRY_POINT_GROUP,
+    EntryPointModuleDiscovery,
+    FirstPartyModuleDiscovery,
+)
 from app.platform.modules.errors import (
     DuplicateConfigNamespaceError,
     DuplicateModuleIdError,
@@ -10,8 +22,15 @@ from app.platform.modules.errors import (
     ModuleDependencyCycleError,
     ModuleDependencyError,
     ModuleDependencyVersionError,
+    ModuleDiscoveryError,
+    ModuleLoadError,
     ModuleManifestError,
+    ModuleRegistrationError,
+    ModuleRuntimeError,
     ModuleSelfDependencyError,
+    ModuleShutdownError,
+    ModuleStartupError,
+    ModuleValidationError,
     UnsupportedManifestVersionError,
 )
 from app.platform.modules.manifest import (
@@ -27,26 +46,53 @@ from app.platform.modules.manifest import (
     validate_manifest,
     validate_manifests,
 )
+from app.platform.modules.runtime import (
+    MODULE_SDK_VERSION,
+    ModuleRecord,
+    ModuleRegistry,
+    ModuleRuntime,
+    create_module_runtime,
+)
 
 __all__ = [
+    "ENTRY_POINT_GROUP",
+    "MODULE_SDK_VERSION",
+    "BackendModule",
     "DuplicateConfigNamespaceError",
     "DuplicateModuleIdError",
+    "EntryPointModuleDiscovery",
+    "FirstPartyModuleDiscovery",
     "InvalidRuntimeVersionError",
     "MissingModuleDependencyError",
     "ModuleBackendPackage",
     "ModuleCompatibilityError",
     "ModuleConfig",
+    "ModuleDefinition",
     "ModuleDependencyCycleError",
     "ModuleDependencyError",
     "ModuleDependencyVersionError",
+    "ModuleDiscoveryError",
+    "ModuleDiscoveryProvider",
     "ModuleFrontendPackage",
+    "ModuleLifecycleHook",
+    "ModuleLoadError",
     "ModuleManifestError",
     "ModuleManifestV1",
     "ModuleOptionalRequirements",
     "ModulePersistence",
+    "ModuleRecord",
+    "ModuleRegistrationContext",
+    "ModuleRegistrationError",
+    "ModuleRegistry",
     "ModuleRequirements",
+    "ModuleRuntime",
+    "ModuleRuntimeError",
     "ModuleSelfDependencyError",
+    "ModuleShutdownError",
+    "ModuleStartupError",
+    "ModuleValidationError",
     "UnsupportedManifestVersionError",
+    "create_module_runtime",
     "module_manifest_json_schema",
     "parse_manifest",
     "resolve_module_order",

--- a/backend/app/platform/modules/contracts.py
+++ b/backend/app/platform/modules/contracts.py
@@ -1,0 +1,98 @@
+"""Kleine öffentliche Registrierungsverträge der Backend-Module-Runtime."""
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from fastapi import APIRouter
+
+from app.platform.modules.manifest import ManifestInput, ModuleManifestV1
+
+type ModuleLifecycleHook = Callable[[], Awaitable[None]]
+type ModuleLoader = Callable[[], "BackendModule"]
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleDefinition:
+    """Passive Discovery-Metadaten und verzögerte Modulinstanziierung."""
+
+    manifest: ManifestInput | ModuleManifestV1
+    loader: ModuleLoader
+    origin: str
+    declared_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class RouterContribution:
+    """Vom Host kontrolliert einzubindender FastAPI-Router."""
+
+    router: APIRouter
+    prefix: str = ""
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleContribution:
+    """Zusammengehörige asynchrone Startup-/Shutdown-Beiträge."""
+
+    startup: ModuleLifecycleHook | None = None
+    shutdown: ModuleLifecycleHook | None = None
+
+
+class ModuleRegistrationContext:
+    """Minimaler Context für Router und asynchrone Lifecycle-Beiträge."""
+
+    def __init__(self) -> None:
+        self._routers: list[RouterContribution] = []
+        self._lifecycle: list[LifecycleContribution] = []
+        self._open = True
+
+    @property
+    def routers(self) -> Sequence[RouterContribution]:
+        return tuple(self._routers)
+
+    @property
+    def lifecycle(self) -> Sequence[LifecycleContribution]:
+        return tuple(self._lifecycle)
+
+    def include_router(
+        self,
+        router: APIRouter,
+        *,
+        prefix: str = "",
+        tags: Sequence[str] = (),
+    ) -> None:
+        self._ensure_open()
+        self._routers.append(RouterContribution(router, prefix, tuple(tags)))
+
+    def add_lifecycle(
+        self,
+        *,
+        startup: ModuleLifecycleHook | None = None,
+        shutdown: ModuleLifecycleHook | None = None,
+    ) -> None:
+        self._ensure_open()
+        if startup is None and shutdown is None:
+            raise ValueError("A lifecycle contribution requires a startup or shutdown hook.")
+        self._lifecycle.append(LifecycleContribution(startup, shutdown))
+
+    def close(self) -> None:
+        self._open = False
+
+    def _ensure_open(self) -> None:
+        if not self._open:
+            raise RuntimeError("The module registration context is closed.")
+
+
+class BackendModule(Protocol):
+    """Öffentlicher, bewusst kleiner Backend-Modulvertrag."""
+
+    manifest: ModuleManifestV1
+
+    def register(self, context: ModuleRegistrationContext) -> None: ...
+
+
+class ModuleDiscoveryProvider(Protocol):
+    """Liefert nur Definitionen explizit aktivierter deploy-time Module."""
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]: ...

--- a/backend/app/platform/modules/discovery.py
+++ b/backend/app/platform/modules/discovery.py
@@ -1,0 +1,85 @@
+"""Kontrollierte First-Party- und Python-Entry-Point-Discovery."""
+
+from collections.abc import Callable, Mapping, Sequence
+from importlib import metadata
+from types import MappingProxyType
+
+from app.platform.modules.contracts import ModuleDefinition
+from app.platform.modules.errors import ModuleDiscoveryError
+
+ENTRY_POINT_GROUP = "open_city_planner.modules"
+type DefinitionSource = ModuleDefinition | Callable[[], ModuleDefinition]
+
+# First-Party-Module werden hier später deklarativ ergänzt. Leer bedeutet, dass die
+# produktive Legacy-Anwendung ohne neue Module unverändert startet.
+FIRST_PARTY_MODULES: Mapping[str, DefinitionSource] = MappingProxyType({})
+
+
+class FirstPartyModuleDiscovery:
+    """Discovery aus einem fachneutralen, deploy-time kontrollierten Katalog."""
+
+    def __init__(self, catalog: Mapping[str, DefinitionSource] = FIRST_PARTY_MODULES) -> None:
+        self._catalog = catalog
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        definitions: list[ModuleDefinition] = []
+        for module_id in sorted(enabled_module_ids.intersection(self._catalog)):
+            source = self._catalog[module_id]
+            try:
+                definition = source() if callable(source) else source
+            except Exception as exc:
+                raise ModuleDiscoveryError(
+                    "The first-party module definition could not be loaded.",
+                    module_id=module_id,
+                    origin="first-party",
+                ) from exc
+            if not isinstance(definition, ModuleDefinition):
+                raise ModuleDiscoveryError(
+                    "The first-party catalog entry is not a ModuleDefinition.",
+                    module_id=module_id,
+                    origin="first-party",
+                )
+            definitions.append(
+                ModuleDefinition(
+                    manifest=definition.manifest,
+                    loader=definition.loader,
+                    origin=definition.origin,
+                    declared_id=module_id,
+                )
+            )
+        return tuple(definitions)
+
+
+class EntryPointModuleDiscovery:
+    """Discovery vertrauenswürdiger installierter Python-Distributionen."""
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        definitions: list[ModuleDefinition] = []
+        entry_points = metadata.entry_points().select(group=ENTRY_POINT_GROUP)
+        for entry_point in sorted(entry_points, key=lambda candidate: candidate.name):
+            if entry_point.name not in enabled_module_ids:
+                continue
+            origin = f"entry-point:{entry_point.name}={entry_point.value}"
+            try:
+                definition = entry_point.load()
+            except Exception as exc:
+                raise ModuleDiscoveryError(
+                    "The enabled Python entry point could not be loaded.",
+                    module_id=entry_point.name,
+                    origin=origin,
+                ) from exc
+            if not isinstance(definition, ModuleDefinition):
+                raise ModuleDiscoveryError(
+                    "The Python entry point does not expose a ModuleDefinition.",
+                    module_id=entry_point.name,
+                    origin=origin,
+                )
+            definitions.append(
+                ModuleDefinition(
+                    manifest=definition.manifest,
+                    loader=definition.loader,
+                    origin=origin,
+                    declared_id=entry_point.name,
+                )
+            )
+        return tuple(definitions)

--- a/backend/app/platform/modules/errors.py
+++ b/backend/app/platform/modules/errors.py
@@ -153,3 +153,73 @@ class ModuleDependencyCycleError(ModuleDependencyError):
         cycle_path = tuple(cycle)
         super().__init__(f"Module dependency cycle detected: {' -> '.join(cycle_path)}.")
         self.cycle = cycle_path
+
+
+class ModuleRuntimeError(RuntimeError):
+    """Basisklasse für Fehler während einer Phase der Module Runtime."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        phase: str,
+        module_id: str | None = None,
+        origin: str | None = None,
+    ) -> None:
+        context = [f"phase={phase}"]
+        if module_id is not None:
+            context.append(f"module_id={module_id}")
+        if origin is not None:
+            context.append(f"origin={origin}")
+        super().__init__(f"Module runtime error ({', '.join(context)}): {message}")
+        self.phase = phase
+        self.module_id = module_id
+        self.origin = origin
+
+
+class ModuleDiscoveryError(ModuleRuntimeError):
+    """Discovery eines aktivierten Moduls ist fehlgeschlagen."""
+
+    def __init__(
+        self, message: str, *, module_id: str | None = None, origin: str | None = None
+    ) -> None:
+        super().__init__(message, phase="discovery", module_id=module_id, origin=origin)
+
+
+class ModuleValidationError(ModuleRuntimeError):
+    """Ein entdecktes Modul konnte nicht validiert werden."""
+
+    def __init__(
+        self, message: str, *, module_id: str | None = None, origin: str | None = None
+    ) -> None:
+        super().__init__(message, phase="validation", module_id=module_id, origin=origin)
+
+
+class ModuleLoadError(ModuleRuntimeError):
+    """Die Instanziierung eines validierten Moduls ist fehlgeschlagen."""
+
+    def __init__(self, message: str, *, module_id: str, origin: str | None = None) -> None:
+        super().__init__(message, phase="import", module_id=module_id, origin=origin)
+
+
+class ModuleRegistrationError(ModuleRuntimeError):
+    """Die deklarative Registrierung eines Moduls ist fehlgeschlagen."""
+
+    def __init__(
+        self, message: str, *, module_id: str | None = None, origin: str | None = None
+    ) -> None:
+        super().__init__(message, phase="registration", module_id=module_id, origin=origin)
+
+
+class ModuleStartupError(ModuleRuntimeError):
+    """Ein Modul konnte nicht vollständig gestartet werden."""
+
+    def __init__(self, message: str, *, module_id: str | None = None) -> None:
+        super().__init__(message, phase="startup", module_id=module_id)
+
+
+class ModuleShutdownError(ModuleRuntimeError):
+    """Mindestens ein Modul konnte nicht sauber beendet werden."""
+
+    def __init__(self, message: str, *, module_id: str | None = None) -> None:
+        super().__init__(message, phase="shutdown", module_id=module_id)

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -1,0 +1,290 @@
+"""Deterministische Backend-Module-Registry und Lifecycle-Orchestrierung."""
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from fastapi import FastAPI
+
+from app.platform.modules.contracts import (
+    BackendModule,
+    LifecycleContribution,
+    ModuleDefinition,
+    ModuleDiscoveryProvider,
+    ModuleRegistrationContext,
+)
+from app.platform.modules.dependency_graph import resolve_module_order
+from app.platform.modules.errors import (
+    ModuleDiscoveryError,
+    ModuleLoadError,
+    ModuleManifestError,
+    ModuleRegistrationError,
+    ModuleShutdownError,
+    ModuleStartupError,
+    ModuleValidationError,
+)
+from app.platform.modules.manifest import ModuleManifestV1, parse_manifest, validate_manifests
+
+logger = logging.getLogger(__name__)
+MODULE_SDK_VERSION = "1.0.0"
+
+
+@dataclass(slots=True)
+class ModuleRecord:
+    """Kompakter interner Runtime-Eintrag ohne vollständige Lifecycle-State-Machine."""
+
+    manifest: ModuleManifestV1
+    module: BackendModule
+    origin: str
+    load_index: int
+    context: ModuleRegistrationContext
+    registered: bool = False
+
+    @property
+    def capabilities(self) -> tuple[str, ...]:
+        return tuple(self.manifest.capabilities)
+
+
+class ModuleRegistry:
+    """Hält validierte Module in ihrer deterministischen Load Order."""
+
+    def __init__(self, records: Sequence[ModuleRecord] = ()) -> None:
+        self._records = list(records)
+
+    @property
+    def records(self) -> tuple[ModuleRecord, ...]:
+        return tuple(self._records)
+
+    def get(self, module_id: str) -> ModuleRecord:
+        for record in self._records:
+            if record.manifest.id == module_id:
+                return record
+        raise KeyError(module_id)
+
+    def capabilities(self, module_id: str) -> tuple[str, ...]:
+        return self.get(module_id).capabilities
+
+
+class ModuleRuntime:
+    """Registriert Router und orchestriert asynchrone Module-Lifecycles."""
+
+    def __init__(self, registry: ModuleRegistry) -> None:
+        self.registry = registry
+        self._attached_app: FastAPI | None = None
+        self._started: list[tuple[ModuleRecord, LifecycleContribution]] = []
+        self._running = False
+
+    @property
+    def module_ids(self) -> tuple[str, ...]:
+        return tuple(record.manifest.id for record in self.registry.records)
+
+    def register(self, app: FastAPI) -> None:
+        """Deklariere Beiträge einmalig und binde Router kontrolliert an den Host."""
+
+        if self._attached_app is not None:
+            raise ModuleRegistrationError("The module runtime is already attached to an app.")
+
+        for record in self.registry.records:
+            fields = _log_fields(record, "registration")
+            logger.info("Module registration started", extra=fields)
+            try:
+                record.module.register(record.context)
+                record.context.close()
+            except Exception as exc:
+                record.context.close()
+                raise ModuleRegistrationError(
+                    "The module register() hook failed.",
+                    module_id=record.manifest.id,
+                    origin=record.origin,
+                ) from exc
+            record.registered = True
+            logger.info("Module registration completed", extra=fields)
+
+        for record in self.registry.records:
+            for contribution in record.context.routers:
+                try:
+                    app.include_router(
+                        contribution.router,
+                        prefix=contribution.prefix,
+                        tags=list(contribution.tags) or None,
+                    )
+                except Exception as exc:
+                    raise ModuleRegistrationError(
+                        "A module router could not be attached to the host.",
+                        module_id=record.manifest.id,
+                        origin=record.origin,
+                    ) from exc
+        self._attached_app = app
+
+    async def startup(self) -> None:
+        """Starte Beiträge in Load Order und räume Teilstarts bei Fehlern auf."""
+
+        if self._attached_app is None:
+            raise ModuleStartupError("The module runtime is not attached to an app.")
+        if self._running:
+            raise ModuleStartupError("The module runtime has already been started.")
+
+        for record in self.registry.records:
+            for contribution in record.context.lifecycle:
+                try:
+                    if contribution.startup is not None:
+                        await contribution.startup()
+                    self._started.append((record, contribution))
+                except Exception as exc:
+                    await self._cleanup_after_startup_failure()
+                    raise ModuleStartupError(
+                        "A module startup hook failed.", module_id=record.manifest.id
+                    ) from exc
+        self._running = True
+
+    async def shutdown(self) -> None:
+        """Beende gestartete Beiträge vollständig in umgekehrter Load Order."""
+
+        first_failure: tuple[ModuleRecord, Exception] | None = None
+        while self._started:
+            record, contribution = self._started.pop()
+            if contribution.shutdown is None:
+                continue
+            try:
+                await contribution.shutdown()
+            except Exception as exc:
+                if first_failure is None:
+                    first_failure = (record, exc)
+                logger.exception("Module shutdown failed", extra=_log_fields(record, "shutdown"))
+        self._running = False
+        if first_failure is not None:
+            record, exc = first_failure
+            raise ModuleShutdownError(
+                "A module shutdown hook failed.", module_id=record.manifest.id
+            ) from exc
+
+    async def _cleanup_after_startup_failure(self) -> None:
+        while self._started:
+            record, contribution = self._started.pop()
+            if contribution.shutdown is None:
+                continue
+            try:
+                await contribution.shutdown()
+            except Exception:
+                logger.exception(
+                    "Module cleanup after startup failure failed",
+                    extra=_log_fields(record, "shutdown"),
+                )
+
+
+def create_module_runtime(
+    *,
+    enabled_module_ids: Sequence[str],
+    discovery_providers: Sequence[ModuleDiscoveryProvider],
+    host_version: str,
+    sdk_version: str = MODULE_SDK_VERSION,
+) -> ModuleRuntime:
+    """Discover, validiere, sortiere und instanziiere aktivierte Module fail-fast."""
+
+    enabled = frozenset(enabled_module_ids)
+    definitions: list[ModuleDefinition] = []
+    for provider in discovery_providers:
+        try:
+            definitions.extend(
+                definition
+                for definition in provider.discover(enabled)
+                if definition.declared_id in enabled
+            )
+        except ModuleDiscoveryError:
+            raise
+        except Exception as exc:
+            raise ModuleDiscoveryError(
+                f"Discovery provider {type(provider).__name__} failed."
+            ) from exc
+
+    parsed: list[tuple[ModuleDefinition, ModuleManifestV1]] = []
+    for definition in definitions:
+        try:
+            manifest = (
+                definition.manifest
+                if isinstance(definition.manifest, ModuleManifestV1)
+                else parse_manifest(definition.manifest, origin=definition.origin)
+            )
+            if definition.declared_id != manifest.id:
+                raise ModuleValidationError(
+                    "The discovery ID does not match the manifest ID.",
+                    module_id=definition.declared_id,
+                    origin=definition.origin,
+                )
+        except ModuleValidationError:
+            raise
+        except ModuleManifestError as exc:
+            raise ModuleValidationError(
+                str(exc), module_id=exc.module_id, origin=definition.origin
+            ) from exc
+        parsed.append((definition, manifest))
+
+    discovered_ids = {manifest.id for _, manifest in parsed}
+    missing_ids = sorted(enabled.difference(discovered_ids))
+    if missing_ids:
+        module_id = missing_ids[0]
+        raise ModuleDiscoveryError(
+            "The enabled module was not found in a configured discovery source.",
+            module_id=module_id,
+        )
+
+    manifests = [manifest for _, manifest in parsed]
+    origins = [definition.origin for definition, _ in parsed]
+    try:
+        validated = validate_manifests(
+            manifests,
+            host_version=host_version,
+            sdk_version=sdk_version,
+            origins=origins,
+        )
+        ordered = resolve_module_order(validated)
+    except ModuleManifestError as exc:
+        origin = exc.origin
+        if origin is None and exc.module_id is not None:
+            origin = next(
+                (
+                    definition.origin
+                    for definition, manifest in parsed
+                    if manifest.id == exc.module_id
+                ),
+                None,
+            )
+        raise ModuleValidationError(
+            str(exc), module_id=exc.module_id, origin=origin
+        ) from exc
+
+    definitions_by_id = {manifest.id: definition for definition, manifest in parsed}
+    records: list[ModuleRecord] = []
+    for load_index, manifest in enumerate(ordered):
+        definition = definitions_by_id[manifest.id]
+        try:
+            module = definition.loader()
+            if module.manifest != manifest:
+                raise ValueError("loaded module manifest does not match its validated definition")
+            register = module.register
+            if not callable(register):
+                raise TypeError("loaded module has no callable register hook")
+        except Exception as exc:
+            raise ModuleLoadError(
+                "The validated module could not be instantiated.",
+                module_id=manifest.id,
+                origin=definition.origin,
+            ) from exc
+        records.append(
+            ModuleRecord(
+                manifest=manifest,
+                module=module,
+                origin=definition.origin,
+                load_index=load_index,
+                context=ModuleRegistrationContext(),
+            )
+        )
+    return ModuleRuntime(ModuleRegistry(records))
+
+
+def _log_fields(record: ModuleRecord, phase: str) -> dict[str, str]:
+    return {
+        "module_id": record.manifest.id,
+        "module_version": record.manifest.version,
+        "module_phase": phase,
+    }

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Backend-Testsuite."""

--- a/backend/tests/fixtures/__init__.py
+++ b/backend/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Python-Fixtures für Backend-Tests."""

--- a/backend/tests/fixtures/example_backend_module.py
+++ b/backend/tests/fixtures/example_backend_module.py
@@ -1,0 +1,39 @@
+"""Bewusst kleines, ausschließlich in Tests aktiviertes Runtime-Modul."""
+
+from fastapi import APIRouter
+
+from app.platform.modules import ModuleDefinition, ModuleManifestV1, ModuleRegistrationContext
+from app.platform.modules.manifest import parse_manifest
+
+MANIFEST = parse_manifest(
+    {
+        "manifest_version": 1,
+        "id": "test-example-module",
+        "name": "Runtime-Testmodul",
+        "version": "1.0.0",
+        "requires": {"host": ">=0.2.0,<1.0.0", "sdk": ">=1.0.0,<2.0.0"},
+        "capabilities": ["test.ping"],
+    },
+    origin="tests.fixtures.example_backend_module",
+)
+
+
+class ExampleBackendModule:
+    manifest: ModuleManifestV1 = MANIFEST
+
+    def register(self, context: ModuleRegistrationContext) -> None:
+        router = APIRouter()
+
+        @router.get("/ping")
+        async def ping() -> dict[str, str]:
+            return {"status": "ok"}
+
+        context.include_router(router, prefix="/api/v1/module-test", tags=("Module test",))
+
+
+DEFINITION = ModuleDefinition(
+    manifest=MANIFEST,
+    loader=ExampleBackendModule,
+    origin="tests.fixtures.example_backend_module",
+    declared_id=MANIFEST.id,
+)

--- a/backend/tests/test_config_strictness.py
+++ b/backend/tests/test_config_strictness.py
@@ -9,3 +9,9 @@ def test_unknown_environment_setting_remains_forbidden(tmp_path) -> None:
     env_file.write_text("STADTPLANER_UNKNOWN_DEPLOYMENT_SETTING=typo\n", encoding="utf-8")
     with pytest.raises(ValidationError, match="extra_forbidden"):
         Settings(_env_file=env_file)
+
+
+def test_enabled_modules_are_optional_and_comma_separated() -> None:
+    assert Settings(_env_file=None).enabled_module_list == []
+    settings = Settings(_env_file=None, enabled_modules="module-b, module-a")
+    assert settings.enabled_module_list == ["module-b", "module-a"]

--- a/backend/tests/test_module_runtime.py
+++ b/backend/tests/test_module_runtime.py
@@ -1,0 +1,468 @@
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.api.router import api_router
+from app.platform.modules import (
+    DuplicateModuleIdError,
+    EntryPointModuleDiscovery,
+    FirstPartyModuleDiscovery,
+    MissingModuleDependencyError,
+    ModuleCompatibilityError,
+    ModuleDefinition,
+    ModuleDependencyCycleError,
+    ModuleDiscoveryError,
+    ModuleLoadError,
+    ModuleManifestV1,
+    ModuleRegistrationContext,
+    ModuleRegistrationError,
+    ModuleShutdownError,
+    ModuleStartupError,
+    ModuleValidationError,
+    create_module_runtime,
+    parse_manifest,
+)
+from app.platform.modules import discovery as discovery_module
+from app.platform.modules.contracts import ModuleDiscoveryProvider
+from app.platform.modules.discovery import ENTRY_POINT_GROUP
+from tests.fixtures.example_backend_module import DEFINITION as EXAMPLE_DEFINITION
+
+
+def manifest_data(
+    module_id: str,
+    *,
+    required: dict[str, str] | None = None,
+    optional: dict[str, str] | None = None,
+    host: str = ">=0.2.0,<1.0.0",
+    sdk: str = ">=1.0.0,<2.0.0",
+    capabilities: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "manifest_version": 1,
+        "id": module_id,
+        "name": module_id,
+        "version": "1.0.0",
+        "requires": {"host": host, "sdk": sdk, "modules": required or {}},
+        "optional": {"modules": optional or {}},
+        "capabilities": capabilities or [],
+    }
+
+
+class RecordingModule:
+    def __init__(
+        self,
+        manifest: ModuleManifestV1,
+        *,
+        events: list[str] | None = None,
+        registration_error: Exception | None = None,
+        startup_error: Exception | None = None,
+    ) -> None:
+        self.manifest = manifest
+        self.events = events
+        self.registration_error = registration_error
+        self.startup_error = startup_error
+
+    def register(self, context: ModuleRegistrationContext) -> None:
+        if self.registration_error is not None:
+            raise self.registration_error
+        if self.events is None:
+            return
+
+        async def startup() -> None:
+            self.events.append(f"start:{self.manifest.id}")
+            if self.startup_error is not None:
+                raise self.startup_error
+
+        async def shutdown() -> None:
+            self.events.append(f"stop:{self.manifest.id}")
+
+        context.add_lifecycle(startup=startup, shutdown=shutdown)
+
+
+def definition(
+    module_id: str,
+    *,
+    required: dict[str, str] | None = None,
+    optional: dict[str, str] | None = None,
+    host: str = ">=0.2.0,<1.0.0",
+    sdk: str = ">=1.0.0,<2.0.0",
+    events: list[str] | None = None,
+    registration_error: Exception | None = None,
+    startup_error: Exception | None = None,
+    capabilities: list[str] | None = None,
+) -> ModuleDefinition:
+    manifest = parse_manifest(
+        manifest_data(
+            module_id,
+            required=required,
+            optional=optional,
+            host=host,
+            sdk=sdk,
+            capabilities=capabilities,
+        )
+    )
+    return ModuleDefinition(
+        manifest=manifest,
+        loader=lambda: RecordingModule(
+            manifest,
+            events=events,
+            registration_error=registration_error,
+            startup_error=startup_error,
+        ),
+        origin=f"test:{module_id}",
+        declared_id=module_id,
+    )
+
+
+@dataclass
+class FakeDiscovery(ModuleDiscoveryProvider):
+    definitions: Sequence[ModuleDefinition]
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        return self.definitions
+
+
+def runtime_for(
+    definitions: Sequence[ModuleDefinition],
+    *,
+    enabled: Sequence[str] | None = None,
+    host_version: str = "0.2.0",
+    sdk_version: str = "1.0.0",
+):
+    enabled_module_ids = (
+        [definition.declared_id for definition in definitions] if enabled is None else enabled
+    )
+    return create_module_runtime(
+        enabled_module_ids=enabled_module_ids,
+        discovery_providers=(FakeDiscovery(definitions),),
+        host_version=host_version,
+        sdk_version=sdk_version,
+    )
+
+
+def test_no_enabled_module_creates_empty_runtime() -> None:
+    runtime = runtime_for([], enabled=[])
+    assert runtime.module_ids == ()
+
+
+def test_first_party_discovery_loads_only_enabled_definitions() -> None:
+    loaded: list[str] = []
+
+    def source(module_id: str) -> Callable[[], ModuleDefinition]:
+        def load() -> ModuleDefinition:
+            loaded.append(module_id)
+            return definition(module_id)
+
+        return load
+
+    provider = FirstPartyModuleDiscovery(
+        {"module-a": source("module-a"), "module-b": source("module-b")}
+    )
+    runtime = create_module_runtime(
+        enabled_module_ids=("module-b",),
+        discovery_providers=(provider,),
+        host_version="0.2.0",
+    )
+
+    assert runtime.module_ids == ("module-b",)
+    assert loaded == ["module-b"]
+
+
+def test_runtime_ignores_disabled_definition_returned_by_provider() -> None:
+    disabled = ModuleDefinition(
+        manifest={"manifest_version": 1, "id": "INVALID"},
+        loader=lambda: None,  # type: ignore[arg-type,return-value]
+        origin="test:disabled",
+        declared_id="disabled-module",
+    )
+    runtime = runtime_for([disabled], enabled=[])
+    assert runtime.module_ids == ()
+
+
+def test_multiple_modules_use_lexicographic_tie_breaking() -> None:
+    runtime = runtime_for([definition("module-z"), definition("module-a")])
+    assert runtime.module_ids == ("module-a", "module-z")
+
+
+def test_duplicate_module_id_preserves_manifest_error_as_cause() -> None:
+    duplicate = definition("duplicate-module")
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([duplicate, duplicate])
+
+    assert error.value.phase == "validation"
+    assert error.value.module_id == "duplicate-module"
+    assert isinstance(error.value.__cause__, DuplicateModuleIdError)
+
+
+def test_invalid_manifest_is_reported_in_validation_phase() -> None:
+    invalid = ModuleDefinition(
+        manifest={"manifest_version": 1, "id": "INVALID"},
+        loader=lambda: None,  # type: ignore[arg-type,return-value]
+        origin="test:invalid",
+        declared_id="invalid",
+    )
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([invalid], enabled=("invalid",))
+
+    assert error.value.phase == "validation"
+    assert error.value.origin == "test:invalid"
+
+
+@pytest.mark.parametrize(
+    ("target", "definition_value", "host_version", "sdk_version"),
+    [
+        ("host", definition("host-incompatible", host=">=2.0.0,<3.0.0"), "0.2.0", "1.0.0"),
+        ("sdk", definition("sdk-incompatible", sdk=">=2.0.0,<3.0.0"), "0.2.0", "1.0.0"),
+    ],
+)
+def test_incompatible_runtime_version_is_fail_fast(
+    target: str,
+    definition_value: ModuleDefinition,
+    host_version: str,
+    sdk_version: str,
+) -> None:
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([definition_value], host_version=host_version, sdk_version=sdk_version)
+
+    assert isinstance(error.value.__cause__, ModuleCompatibilityError)
+    assert error.value.__cause__.target == target
+
+
+def test_required_dependency_and_optional_dependency_define_load_order() -> None:
+    runtime = runtime_for(
+        [
+            definition(
+                "consumer",
+                required={"required-base": ">=1.0.0,<2.0.0"},
+                optional={"optional-base": ">=1.0.0,<2.0.0"},
+            ),
+            definition("required-base"),
+            definition("optional-base"),
+        ]
+    )
+    assert runtime.module_ids == ("optional-base", "required-base", "consumer")
+
+
+def test_required_dependency_on_disabled_module_fails() -> None:
+    consumer = definition("consumer", required={"disabled-base": ">=1.0.0,<2.0.0"})
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([consumer], enabled=("consumer",))
+
+    assert isinstance(error.value.__cause__, MissingModuleDependencyError)
+
+
+def test_dependency_cycle_is_reported_by_manifest_graph() -> None:
+    module_a = definition("module-a", required={"module-b": ">=1.0.0,<2.0.0"})
+    module_b = definition("module-b", required={"module-a": ">=1.0.0,<2.0.0"})
+    with pytest.raises(ModuleValidationError) as error:
+        runtime_for([module_a, module_b])
+
+    assert isinstance(error.value.__cause__, ModuleDependencyCycleError)
+
+
+def test_enabled_unknown_module_fails_discovery() -> None:
+    with pytest.raises(ModuleDiscoveryError, match="module_id=missing-module"):
+        runtime_for([], enabled=("missing-module",))
+
+
+def test_loader_failure_contains_import_phase_and_module_id() -> None:
+    manifest = parse_manifest(manifest_data("broken-module"))
+
+    def broken_loader():
+        raise ImportError("broken import")
+
+    broken = ModuleDefinition(manifest, broken_loader, "test:broken", "broken-module")
+    with pytest.raises(ModuleLoadError) as error:
+        runtime_for([broken])
+
+    assert error.value.phase == "import"
+    assert error.value.module_id == "broken-module"
+    assert isinstance(error.value.__cause__, ImportError)
+
+
+def test_registry_exposes_manifest_capabilities() -> None:
+    runtime = runtime_for([definition("capable-module", capabilities=["map.layer"])])
+    assert runtime.registry.capabilities("capable-module") == ("map.layer",)
+
+
+def test_registration_failure_is_fail_fast_and_registration_is_single_use() -> None:
+    broken = runtime_for(
+        [definition("broken-module", registration_error=RuntimeError("register failed"))]
+    )
+    with pytest.raises(ModuleRegistrationError, match="module_id=broken-module"):
+        broken.register(FastAPI())
+
+    runtime = runtime_for([])
+    app = FastAPI()
+    runtime.register(app)
+    with pytest.raises(ModuleRegistrationError, match="already attached"):
+        runtime.register(app)
+
+
+@pytest.mark.asyncio
+async def test_router_registration_coexists_with_legacy_router() -> None:
+    runtime = runtime_for([EXAMPLE_DEFINITION])
+    app = FastAPI()
+    app.include_router(api_router)
+    runtime.register(app)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        module_response = await client.get("/api/v1/module-test/ping")
+        legacy_response = await client.get("/api/v1/auth/providers")
+
+    assert module_response.status_code == 200
+    assert module_response.json() == {"status": "ok"}
+    assert legacy_response.status_code == 200
+    assert "providers" in legacy_response.json()
+
+
+@pytest.mark.asyncio
+async def test_disabled_fixture_module_has_no_route() -> None:
+    runtime = runtime_for([], enabled=[])
+    app = FastAPI()
+    runtime.register(app)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/v1/module-test/ping")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_uses_load_order_and_reverse_shutdown_order() -> None:
+    events: list[str] = []
+    runtime = runtime_for(
+        [
+            definition("consumer", required={"base-module": ">=1.0.0,<2.0.0"}, events=events),
+            definition("base-module", events=events),
+        ]
+    )
+    runtime.register(FastAPI())
+    await runtime.startup()
+    await runtime.shutdown()
+
+    assert events == [
+        "start:base-module",
+        "start:consumer",
+        "stop:consumer",
+        "stop:base-module",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_cleans_up_already_started_modules() -> None:
+    events: list[str] = []
+    runtime = runtime_for(
+        [
+            definition("module-a", events=events),
+            definition("module-b", events=events, startup_error=RuntimeError("startup failed")),
+        ]
+    )
+    runtime.register(FastAPI())
+
+    with pytest.raises(ModuleStartupError) as error:
+        await runtime.startup()
+
+    assert error.value.module_id == "module-b"
+    assert events == ["start:module-a", "start:module-b", "stop:module-a"]
+    await runtime.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_failure_does_not_skip_earlier_modules() -> None:
+    events: list[str] = []
+    module_a = definition("module-a", events=events)
+    manifest_b = parse_manifest(manifest_data("module-b"))
+
+    class FailingShutdownModule(RecordingModule):
+        def register(self, context: ModuleRegistrationContext) -> None:
+            async def startup() -> None:
+                events.append("start:module-b")
+
+            async def shutdown() -> None:
+                events.append("stop:module-b")
+                raise RuntimeError("shutdown failed")
+
+            context.add_lifecycle(startup=startup, shutdown=shutdown)
+
+    module_b = ModuleDefinition(
+        manifest=manifest_b,
+        loader=lambda: FailingShutdownModule(manifest_b),
+        origin="test:module-b",
+        declared_id="module-b",
+    )
+    runtime = runtime_for([module_a, module_b])
+    runtime.register(FastAPI())
+    await runtime.startup()
+
+    with pytest.raises(ModuleShutdownError) as error:
+        await runtime.shutdown()
+
+    assert error.value.module_id == "module-b"
+    assert events == ["start:module-a", "start:module-b", "stop:module-b", "stop:module-a"]
+
+
+class FakeEntryPoints(list):
+    def select(self, *, group: str):
+        assert group == ENTRY_POINT_GROUP
+        return self
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, value: str, result: object) -> None:
+        self.name = name
+        self.value = value
+        self.result = result
+        self.load_count = 0
+
+    def load(self) -> object:
+        self.load_count += 1
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def test_entry_point_discovery_loads_only_enabled_group_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enabled = FakeEntryPoint("test-example-module", "package:definition", EXAMPLE_DEFINITION)
+    disabled = FakeEntryPoint("disabled-module", "other:definition", RuntimeError("must not load"))
+    monkeypatch.setattr(
+        discovery_module.metadata, "entry_points", lambda: FakeEntryPoints([disabled, enabled])
+    )
+
+    runtime = create_module_runtime(
+        enabled_module_ids=("test-example-module",),
+        discovery_providers=(EntryPointModuleDiscovery(),),
+        host_version="0.2.0",
+    )
+
+    assert runtime.module_ids == ("test-example-module",)
+    assert enabled.load_count == 1
+    assert disabled.load_count == 0
+
+
+def test_broken_enabled_entry_point_has_discovery_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broken = FakeEntryPoint("broken-module", "broken:definition", ImportError("broken"))
+    monkeypatch.setattr(
+        discovery_module.metadata, "entry_points", lambda: FakeEntryPoints([broken])
+    )
+
+    with pytest.raises(ModuleDiscoveryError) as error:
+        create_module_runtime(
+            enabled_module_ids=("broken-module",),
+            discovery_providers=(EntryPointModuleDiscovery(),),
+            host_version="0.2.0",
+        )
+
+    assert error.value.module_id == "broken-module"
+    assert error.value.phase == "discovery"
+    assert isinstance(error.value.__cause__, ImportError)

--- a/deploy/ansible/vault.example.yml
+++ b/deploy/ansible/vault.example.yml
@@ -28,6 +28,7 @@ stadtplaner_backend_env_content: |
   APP_ENVIRONMENT=production
   APP_BASE_URL=https://stadtplaner.oklabflensburg.de
   API_BASE_URL=https://api.stadtplaner.oklabflensburg.de
+  ENABLED_MODULES=
   MAP_PREVIEW_RENDERER_URL=http://127.0.0.1:3020
   MAP_PREVIEW_RENDERER_TIMEOUT_SECONDS=20
   MAP_PREVIEW_CACHE_DIR=/data/stadtplaner/previews

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 
 - [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
 - [Module Manifest Schema V1](modules/module-manifest-v1.md)
+- [Backend-Module-Runtime](modules/backend-module-runtime.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)
 - [Intelligente Suche](intelligent-search.md)

--- a/docs/modules/backend-module-runtime.md
+++ b/docs/modules/backend-module-runtime.md
@@ -1,0 +1,86 @@
+# Backend-Module-Runtime
+
+Die erste Module Runtime ergänzt den bestehenden FastAPI-Host während der
+inkrementellen Migration aus
+[ADR #92](../architecture/adr-modular-host-and-module-boundaries.md). Sie verwendet
+den bestehenden [Manifest-V1-Contract](module-manifest-v1.md) für Parsing,
+Compatibility, Dependencies und deterministische Load Order. Der zentrale Legacy-
+Router bleibt parallel eingebunden; keine bestehende Fachdomäne wurde migriert.
+
+## Bootstrap und Enablement
+
+`backend/app/main.py` erzeugt eine fachneutrale Runtime aus zwei Discovery-Providern
+und bindet deren Router zusätzlich zum Legacy-Router ein. `ENABLED_MODULES` enthält
+eine komma-separierte Liste aktivierter Modul-IDs. Der leere Default aktiviert kein
+neues Modul und bewahrt damit das bisherige Produktionsverhalten.
+
+Die API-Version aus `Settings.api_version` ist gleichzeitig die zentral gepflegte
+Host-Kompatibilitätsversion. Die öffentliche Backend-SDK-Version steht unabhängig
+davon als `MODULE_SDK_VERSION` in der Runtime. Release-SHA, Host-Version und
+SDK-Version sind unterschiedliche Werte.
+
+Aktivierung ist in dieser Ausbaustufe ausschließlich deploy-time Konfiguration. Ein
+aktiviertes, aber nicht auffindbares Modul stoppt den Bootstrap. Deaktivierte Module
+werden weder importiert noch instanziiert und stehen der Dependency-Auflösung nicht
+zur Verfügung. Dadurch schlägt eine Required Dependency auf ein deaktiviertes Modul
+mit der bestehenden Manifest-Fehlersemantik fehl. Eine optionale Dependency darf
+weiterhin fehlen.
+
+## Discovery-Quellen
+
+`FirstPartyModuleDiscovery` verwendet einen fachneutralen Katalog aus passiven
+`ModuleDefinition`-Objekten oder verzögerten Definition-Loadern. Ein neues
+First-Party-Modul benötigt dadurch keine Änderung an `main.py` oder
+`app/api/router.py`.
+
+`EntryPointModuleDiscovery` berücksichtigt ausschließlich die Python-Entry-Point-
+Gruppe `open_city_planner.modules`. Der Entry-Point-Name ist die aktivierbare
+Modul-ID. Nur Entry Points mit explizit aktivierter ID werden geladen; andere Gruppen
+und deaktivierte Einträge werden nicht ausgeführt. Ein Entry Point exportiert eine
+passive `ModuleDefinition`, deren Manifest vor dem eigentlichen Modul-Loader geprüft
+wird. Distribution und Installation werden von dieser Runtime nicht verändert.
+
+## Registrierungs- und Lifecycle-Reihenfolge
+
+Der Ablauf ist strikt getrennt:
+
+1. Definitionen aktivierter Module entdecken;
+2. Manifeste über `parse_manifest()` und `validate_manifests()` prüfen;
+3. Reihenfolge über `resolve_module_order()` bestimmen;
+4. validierte Module instanziieren;
+5. deklarative Router- und Lifecycle-Beiträge registrieren;
+6. Startup-Hooks in Load Order ausführen;
+7. Shutdown-Hooks in umgekehrter Reihenfolge ausführen.
+
+`ModuleRegistrationContext` enthält bewusst nur Router- und asynchrone Lifecycle-
+Registrierung. Datenbank, Redis, Storage, Events, Services, Jobs und Secrets sind
+nicht Teil dieses kleinen Vertrags. Capabilities stammen unverändert aus dem
+Manifest und sind über `ModuleRegistry.capabilities(module_id)` verfügbar.
+
+`ModuleRuntime.register(app)` darf genau einmal aufgerufen werden. Damit entstehen
+keine stillen Router-Duplikate. `register()` ist für deklarative Beiträge bestimmt;
+Verbindungen, Worker und andere externe Side Effects gehören in asynchrone Startup-
+Hooks.
+
+## Fehler und Cleanup
+
+Manifest-, Compatibility- und Dependency-Fehler bleiben als verkettete Ursachen der
+strukturierten Runtime-Fehler erhalten. Runtime-Fehler nennen die Phase
+`discovery`, `validation`, `import`, `registration`, `startup` oder `shutdown` sowie
+Modul-ID und Origin, soweit diese bekannt sind. Registrierungs- und Startup-Fehler
+stoppen den Host fail-fast.
+
+Schlägt ein Startup-Hook fehl, führt die Runtime die Shutdown-Hooks aller bereits
+erfolgreich gestarteten Beiträge in umgekehrter Reihenfolge aus. Cleanup-Fehler
+werden protokolliert, ohne den ursprünglichen Startup-Fehler zu verdecken. Beim
+regulären Shutdown werden trotz eines einzelnen Hook-Fehlers die übrigen Beiträge
+weiter beendet. Runtime-Logs tragen die strukturierten Felder `module_id`,
+`module_version` und `module_phase`.
+
+## Vertrauen und Sicherheit
+
+First-Party- und Entry-Point-Module sind installierter, vertrauenswürdiger
+In-Process-Code und nicht sandboxed. Die Runtime installiert keine Pakete, lädt keine
+URLs und akzeptiert keine Python-Modulnamen aus HTTP- oder sonstigen Nutzereingaben.
+Aktivierte IDs und installierte Entry Points werden ausschließlich durch Deployment
+und Packaging kontrolliert.

--- a/docs/modules/module-manifest-v1.md
+++ b/docs/modules/module-manifest-v1.md
@@ -2,8 +2,9 @@
 
 Diese Dokumentation präzisiert den maschinenlesbaren Modulvertrag aus
 [ADR: Modularer Host und Grenzen von Fachmodulen](../architecture/adr-modular-host-and-module-boundaries.md).
-Sie führt keine Module Runtime ein. Discovery, Aktivierung und das Laden von Paketen
-folgen in #94, #112 und #113.
+Die darauf aufbauende Discovery und Registrierung beschreibt die
+[Backend-Module-Runtime](backend-module-runtime.md). Der vollständige
+Aktivierungs-Lifecycle und die Distribution bleiben Gegenstand von #112 und #113.
 
 ## Contract und Formate
 


### PR DESCRIPTION
## Hintergrund

PR #116 / Issue #94 wurde versehentlich direkt nach `main` gemerged und anschließend über PR #119 wieder aus `main` entfernt.

Die Umsetzung aus #94 gehört gemäß Epic #91 und ADR #92 ausschließlich auf die temporäre Integrationslinie:

`staging/epic-91-modular-host`

Dieser Pull Request integriert deshalb die ursprüngliche #94-Implementierung korrekt in die Epic-Staging-Branch.

## Inhalt

Enthalten ist der Delta von #93 zu #94, insbesondere:

- fachneutrale `ModuleRegistry` und `ModuleRuntime`;
- First-Party- und Python-Entry-Point-Discovery über `open_city_planner.modules`;
- explizites Enablement über `ENABLED_MODULES`;
- Wiederverwendung des Manifest-/Dependency-Contracts aus #93;
- deterministische Registrierung in Dependency-Reihenfolge;
- Router-Registrierung ohne fachliche Erweiterung des Legacy-Routers;
- asynchrone Startup-/Shutdown-Hooks;
- Runtime-spezifische Fehler und strukturierte Logs;
- Test-Fixture-Modul und Runtime-Tests;
- technische Runtime-Dokumentation.

## Abgrenzung

- keine erneute Integration nach `main`;
- keine bestehende Fachdomäne wird migriert;
- keine DB-Migration;
- keine Frontend-Module-Runtime;
- keine Vorwegnahme von #95 ff.;
- bestehender Legacy-Router bleibt parallel aktiv.

## Git-Historie

Der versehentliche Merge von #116 nach `main` wurde separat über #119 revertiert. Dieser PR ist ausschließlich die korrekte Integration derselben #94-Arbeit in die Epic-Staging-Linie.

Part of #91
Refs #92
Refs #93
Refs #94
Refs #116
Refs #119