### PR TITLE
feat(modules): define backend module context sdk

### DIFF
--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -1,7 +1,6 @@
 """Öffentliche Contracts der Backend-Module-Plattform."""
 
 from app.platform.modules.contracts import (
-    BackendModule,
     ModuleDefinition,
     ModuleDiscoveryProvider,
     ModuleLifecycleHook,
@@ -53,6 +52,7 @@ from app.platform.modules.runtime import (
     ModuleRuntime,
     create_module_runtime,
 )
+from app.platform.modules.sdk import BackendModule, ModuleContext
 
 __all__ = [
     "ENTRY_POINT_GROUP",
@@ -67,6 +67,7 @@ __all__ = [
     "ModuleBackendPackage",
     "ModuleCompatibilityError",
     "ModuleConfig",
+    "ModuleContext",
     "ModuleDefinition",
     "ModuleDependencyCycleError",
     "ModuleDependencyError",

--- a/backend/app/platform/modules/context.py
+++ b/backend/app/platform/modules/context.py
@@ -1,0 +1,125 @@
+"""Hostseitige Erzeugung modulgebundener öffentlicher SDK-Contexts."""
+
+import logging
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from app.platform.modules.contracts import ModuleRegistrationContext
+from app.platform.modules.manifest import ModuleManifestV1
+from app.platform.modules.sdk import (
+    CachePort,
+    DatabaseSessionProvider,
+    EventBusPort,
+    HttpClientFactoryPort,
+    MetricsPort,
+    ModuleContext,
+    ModuleSettingsPort,
+    ObservabilityPort,
+    PermissionPort,
+    SchedulerPort,
+    ServiceRegistryPort,
+    SpanPort,
+    StoragePort,
+    TracerPort,
+)
+
+
+class _NoOpMetrics:
+    def increment(
+        self,
+        name: str,
+        *,
+        value: float = 1,
+        attributes: Mapping[str, str] | None = None,
+    ) -> None:
+        del name, value, attributes
+
+    def observe(
+        self,
+        name: str,
+        value: float,
+        *,
+        attributes: Mapping[str, str] | None = None,
+    ) -> None:
+        del name, value, attributes
+
+
+class _NoOpSpan:
+    def set_attribute(self, name: str, value: str | float | bool) -> None:
+        del name, value
+
+    def record_exception(self, error: Exception) -> None:
+        del error
+
+
+class _NoOpTracer:
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        attributes: Mapping[str, str] | None = None,
+    ) -> Iterator[SpanPort]:
+        del name, attributes
+        yield _NoOpSpan()
+
+
+@dataclass(frozen=True, slots=True)
+class _ModuleObservability:
+    logger: logging.LoggerAdapter
+    metrics: MetricsPort
+    tracer: TracerPort
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleHostServices:
+    """Hostseitiges Adapter-Bundle; optionale Ports folgen in ihren Folge-Issues."""
+
+    database: DatabaseSessionProvider | None = None
+    events: EventBusPort | None = None
+    services: ServiceRegistryPort | None = None
+    permissions: PermissionPort | None = None
+    cache: CachePort | None = None
+    storage: StoragePort | None = None
+    http: HttpClientFactoryPort | None = None
+    scheduler: SchedulerPort | None = None
+    settings: ModuleSettingsPort | None = None
+
+
+class ModuleContextFactory:
+    """Erzeugt pro Manifest genau einen unveränderlichen ModuleContext."""
+
+    def __init__(self, services: ModuleHostServices | None = None) -> None:
+        self._services = services or ModuleHostServices()
+
+    def create(
+        self,
+        manifest: ModuleManifestV1,
+        registration: ModuleRegistrationContext,
+    ) -> ModuleContext:
+        logger = logging.LoggerAdapter(
+            logging.getLogger(f"app.modules.{manifest.id}"),
+            {"module_id": manifest.id, "module_version": manifest.version},
+        )
+        observability: ObservabilityPort = _ModuleObservability(
+            logger=logger,
+            metrics=_NoOpMetrics(),
+            tracer=_NoOpTracer(),
+        )
+        return ModuleContext(
+            module_id=manifest.id,
+            module_version=manifest.version,
+            api=registration,
+            lifecycle=registration,
+            observability=observability,
+            database=self._services.database,
+            events=self._services.events,
+            services=self._services.services,
+            permissions=self._services.permissions,
+            cache=self._services.cache,
+            storage=self._services.storage,
+            http=self._services.http,
+            scheduler=self._services.scheduler,
+            settings=self._services.settings,
+        )

--- a/backend/app/platform/modules/contracts.py
+++ b/backend/app/platform/modules/contracts.py
@@ -1,25 +1,16 @@
-"""Kleine öffentliche Registrierungsverträge der Backend-Module-Runtime."""
+"""Hostseitige Beitragsobjekte und #94-Kompatibilität der Module-Runtime."""
 
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
 from fastapi import APIRouter
 
-from app.platform.modules.manifest import ManifestInput, ModuleManifestV1
-
-type ModuleLifecycleHook = Callable[[], Awaitable[None]]
-type ModuleLoader = Callable[[], "BackendModule"]
-
-
-@dataclass(frozen=True, slots=True)
-class ModuleDefinition:
-    """Passive Discovery-Metadaten und verzögerte Modulinstanziierung."""
-
-    manifest: ManifestInput | ModuleManifestV1
-    loader: ModuleLoader
-    origin: str
-    declared_id: str
+from app.platform.modules.sdk import (
+    BackendModule,
+    ModuleDefinition,
+    ModuleLifecycleHook,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,15 +75,18 @@ class ModuleRegistrationContext:
             raise RuntimeError("The module registration context is closed.")
 
 
-class BackendModule(Protocol):
-    """Öffentlicher, bewusst kleiner Backend-Modulvertrag."""
-
-    manifest: ModuleManifestV1
-
-    def register(self, context: ModuleRegistrationContext) -> None: ...
-
-
 class ModuleDiscoveryProvider(Protocol):
     """Liefert nur Definitionen explizit aktivierter deploy-time Module."""
 
     def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]: ...
+
+
+__all__ = [
+    "BackendModule",
+    "LifecycleContribution",
+    "ModuleDefinition",
+    "ModuleDiscoveryProvider",
+    "ModuleLifecycleHook",
+    "ModuleRegistrationContext",
+    "RouterContribution",
+]

--- a/backend/app/platform/modules/discovery.py
+++ b/backend/app/platform/modules/discovery.py
@@ -4,8 +4,8 @@ from collections.abc import Callable, Mapping, Sequence
 from importlib import metadata
 from types import MappingProxyType
 
-from app.platform.modules.contracts import ModuleDefinition
 from app.platform.modules.errors import ModuleDiscoveryError
+from app.platform.modules.sdk import ModuleDefinition
 
 ENTRY_POINT_GROUP = "open_city_planner.modules"
 type DefinitionSource = ModuleDefinition | Callable[[], ModuleDefinition]

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -6,10 +6,9 @@ from dataclasses import dataclass
 
 from fastapi import FastAPI
 
+from app.platform.modules.context import ModuleContextFactory
 from app.platform.modules.contracts import (
-    BackendModule,
     LifecycleContribution,
-    ModuleDefinition,
     ModuleDiscoveryProvider,
     ModuleRegistrationContext,
 )
@@ -24,6 +23,7 @@ from app.platform.modules.errors import (
     ModuleValidationError,
 )
 from app.platform.modules.manifest import ModuleManifestV1, parse_manifest, validate_manifests
+from app.platform.modules.sdk import BackendModule, ModuleContext, ModuleDefinition
 
 logger = logging.getLogger(__name__)
 MODULE_SDK_VERSION = "1.0.0"
@@ -37,7 +37,8 @@ class ModuleRecord:
     module: BackendModule
     origin: str
     load_index: int
-    context: ModuleRegistrationContext
+    context: ModuleContext
+    registration: ModuleRegistrationContext
     registered: bool = False
 
     @property
@@ -89,9 +90,9 @@ class ModuleRuntime:
             logger.info("Module registration started", extra=fields)
             try:
                 record.module.register(record.context)
-                record.context.close()
+                record.registration.close()
             except Exception as exc:
-                record.context.close()
+                record.registration.close()
                 raise ModuleRegistrationError(
                     "The module register() hook failed.",
                     module_id=record.manifest.id,
@@ -101,7 +102,7 @@ class ModuleRuntime:
             logger.info("Module registration completed", extra=fields)
 
         for record in self.registry.records:
-            for contribution in record.context.routers:
+            for contribution in record.registration.routers:
                 try:
                     app.include_router(
                         contribution.router,
@@ -125,7 +126,7 @@ class ModuleRuntime:
             raise ModuleStartupError("The module runtime has already been started.")
 
         for record in self.registry.records:
-            for contribution in record.context.lifecycle:
+            for contribution in record.registration.lifecycle:
                 try:
                     if contribution.startup is not None:
                         await contribution.startup()
@@ -178,6 +179,7 @@ def create_module_runtime(
     discovery_providers: Sequence[ModuleDiscoveryProvider],
     host_version: str,
     sdk_version: str = MODULE_SDK_VERSION,
+    context_factory: ModuleContextFactory | None = None,
 ) -> ModuleRuntime:
     """Discover, validiere, sortiere und instanziiere aktivierte Module fail-fast."""
 
@@ -249,12 +251,11 @@ def create_module_runtime(
                 ),
                 None,
             )
-        raise ModuleValidationError(
-            str(exc), module_id=exc.module_id, origin=origin
-        ) from exc
+        raise ModuleValidationError(str(exc), module_id=exc.module_id, origin=origin) from exc
 
     definitions_by_id = {manifest.id: definition for definition, manifest in parsed}
     records: list[ModuleRecord] = []
+    active_context_factory = context_factory or ModuleContextFactory()
     for load_index, manifest in enumerate(ordered):
         definition = definitions_by_id[manifest.id]
         try:
@@ -270,13 +271,15 @@ def create_module_runtime(
                 module_id=manifest.id,
                 origin=definition.origin,
             ) from exc
+        registration = ModuleRegistrationContext()
         records.append(
             ModuleRecord(
                 manifest=manifest,
                 module=module,
                 origin=definition.origin,
                 load_index=load_index,
-                context=ModuleRegistrationContext(),
+                context=active_context_factory.create(manifest, registration),
+                registration=registration,
             )
         )
     return ModuleRuntime(ModuleRegistry(records))

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -1,0 +1,299 @@
+"""Öffentliches Backend-SDK für Open-City-Planner-Module.
+
+Dieses Modul ist der stabile Importpfad für Modulcode. Es definiert ausschließlich
+Plattform-Ports und importiert keine Host-Infrastruktur oder Fachdomänen.
+"""
+
+import logging
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import AbstractAsyncContextManager, AbstractContextManager
+from dataclasses import dataclass
+from typing import Protocol, TypeVar
+
+from fastapi import APIRouter
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform.modules.manifest import (
+    ManifestInput,
+    ModuleManifestV1,
+    parse_manifest,
+)
+
+type ModuleLifecycleHook = Callable[[], Awaitable[None]]
+type ModuleLoader = Callable[[], "BackendModule"]
+type JobHandler = Callable[[], Awaitable[None]]
+T = TypeVar("T")
+
+
+class ApiRegistrar(Protocol):
+    """Registriert vom Host kontrolliert einzubindende FastAPI-Router."""
+
+    def include_router(
+        self,
+        router: APIRouter,
+        *,
+        prefix: str = "",
+        tags: Sequence[str] = (),
+    ) -> None: ...
+
+
+class LifecycleRegistrar(Protocol):
+    """Registriert asynchrone Hooks ohne externe Side Effects während register()."""
+
+    def add_lifecycle(
+        self,
+        *,
+        startup: ModuleLifecycleHook | None = None,
+        shutdown: ModuleLifecycleHook | None = None,
+    ) -> None: ...
+
+
+class DatabaseSessionProvider(Protocol):
+    """Öffnet eine vom Host verwaltete SQLAlchemy-Session."""
+
+    def session(self) -> AbstractAsyncContextManager[AsyncSession]: ...
+
+
+class DomainEvent(Protocol):
+    """Minimale Identität eines vom Fachmodul definierten Domain Events."""
+
+    event_type: str
+    event_version: int
+
+
+class EventBusPort(Protocol):
+    """Publiziert Domain Events; Zustellung und Outbox folgen in #96."""
+
+    async def publish(self, event: DomainEvent) -> None: ...
+
+
+class ServiceRegistryPort(Protocol):
+    """Löst ausschließlich explizite öffentliche Cross-Module-Contracts auf."""
+
+    def resolve(self, contract: type[T]) -> T: ...
+
+
+class PermissionPort(Protocol):
+    """Prüft eine stabile Permission-ID; die Policy Engine folgt in #104."""
+
+    async def is_allowed(
+        self,
+        permission_id: str,
+        *,
+        principal_id: str | None,
+        resource_id: str | None = None,
+    ) -> bool: ...
+
+
+class CachePort(Protocol):
+    """Modulgebundener Byte-Cache mit TTL in positiven ganzen Sekunden."""
+
+    async def get(self, key: str) -> bytes | None: ...
+
+    async def set(self, key: str, value: bytes, *, ttl_seconds: int) -> bool: ...
+
+    async def delete(self, *keys: str) -> int: ...
+
+    async def clear(self) -> int: ...
+
+
+class MetricsPort(Protocol):
+    """Vendor-neutraler Zugriff auf begrenzte Modulmetriken."""
+
+    def increment(
+        self,
+        name: str,
+        *,
+        value: float = 1,
+        attributes: Mapping[str, str] | None = None,
+    ) -> None: ...
+
+    def observe(
+        self,
+        name: str,
+        value: float,
+        *,
+        attributes: Mapping[str, str] | None = None,
+    ) -> None: ...
+
+
+class SpanPort(Protocol):
+    """Kleiner, vendor-neutraler Trace-Span."""
+
+    def set_attribute(self, name: str, value: str | float | bool) -> None: ...
+
+    def record_exception(self, error: Exception) -> None: ...
+
+
+class TracerPort(Protocol):
+    """Erzeugt automatisch modulgebundene Trace-Spans."""
+
+    def span(
+        self,
+        name: str,
+        *,
+        attributes: Mapping[str, str] | None = None,
+    ) -> AbstractContextManager[SpanPort]: ...
+
+
+class ObservabilityPort(Protocol):
+    """Gebündelte, bereits an Modul-ID und Modulversion gebundene Telemetrie."""
+
+    @property
+    def logger(self) -> logging.LoggerAdapter: ...
+
+    @property
+    def metrics(self) -> MetricsPort: ...
+
+    @property
+    def tracer(self) -> TracerPort: ...
+
+
+class StoragePort(Protocol):
+    """Modulgebundener Blob-Storage ohne Dateisystem- oder Cloud-Annahmen."""
+
+    async def read(self, key: str) -> bytes | None: ...
+
+    async def write(self, key: str, value: bytes, *, content_type: str | None = None) -> None: ...
+
+    async def delete(self, key: str) -> bool: ...
+
+    async def exists(self, key: str) -> bool: ...
+
+
+class HttpResponsePort(Protocol):
+    """Begrenzte HTTP-Antwort ohne Zugriff auf den konkreten Client."""
+
+    status_code: int
+    headers: Mapping[str, str]
+    content: bytes
+
+    def json(self) -> object: ...
+
+
+class HttpClientPort(Protocol):
+    """Asynchroner HTTP-Port mit Host-kontrollierten Transport-Policies."""
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        content: bytes | None = None,
+    ) -> HttpResponsePort: ...
+
+
+class HttpClientFactoryPort(Protocol):
+    """Erzeugt einen sicheren Client; Timeouts und User-Agent besitzt der Host."""
+
+    def create(
+        self,
+        *,
+        service_name: str,
+        base_url: str | None = None,
+    ) -> AbstractAsyncContextManager[HttpClientPort]: ...
+
+
+class SchedulerPort(Protocol):
+    """Registriert modulgebundene Jobs; Ausführung und Scheduling folgen in #100."""
+
+    def register(self, job_id: str, handler: JobHandler) -> None: ...
+
+
+class ModuleSettingsPort(Protocol):
+    """Liest ausschließlich Werte aus dem Namespace des aktuellen Moduls."""
+
+    def get(self, key: str, default: T | None = None) -> object | T | None: ...
+
+    def require(self, key: str) -> object: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleContext:
+    """Unveränderlicher, an genau ein Modul gebundener Host-Service-Context."""
+
+    module_id: str
+    module_version: str
+    api: ApiRegistrar
+    lifecycle: LifecycleRegistrar
+    observability: ObservabilityPort
+    database: DatabaseSessionProvider | None = None
+    events: EventBusPort | None = None
+    services: ServiceRegistryPort | None = None
+    permissions: PermissionPort | None = None
+    cache: CachePort | None = None
+    storage: StoragePort | None = None
+    http: HttpClientFactoryPort | None = None
+    scheduler: SchedulerPort | None = None
+    settings: ModuleSettingsPort | None = None
+
+    @property
+    def logger(self) -> logging.LoggerAdapter:
+        return self.observability.logger
+
+    # Kompatibilitäts-Proxys für den kleinen Registration Context aus #94.
+    def include_router(
+        self,
+        router: APIRouter,
+        *,
+        prefix: str = "",
+        tags: Sequence[str] = (),
+    ) -> None:
+        self.api.include_router(router, prefix=prefix, tags=tags)
+
+    def add_lifecycle(
+        self,
+        *,
+        startup: ModuleLifecycleHook | None = None,
+        shutdown: ModuleLifecycleHook | None = None,
+    ) -> None:
+        self.lifecycle.add_lifecycle(startup=startup, shutdown=shutdown)
+
+
+class BackendModule(Protocol):
+    """Öffentlicher Backend-Modulvertrag."""
+
+    manifest: ModuleManifestV1
+
+    def register(self, context: ModuleContext) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleDefinition:
+    """Passive Discovery-Metadaten und verzögerte Modulinstanziierung."""
+
+    manifest: ManifestInput | ModuleManifestV1
+    loader: ModuleLoader
+    origin: str
+    declared_id: str
+
+
+__all__ = [
+    "ApiRegistrar",
+    "BackendModule",
+    "CachePort",
+    "DatabaseSessionProvider",
+    "DomainEvent",
+    "EventBusPort",
+    "HttpClientFactoryPort",
+    "HttpClientPort",
+    "HttpResponsePort",
+    "JobHandler",
+    "LifecycleRegistrar",
+    "MetricsPort",
+    "ModuleContext",
+    "ModuleDefinition",
+    "ModuleLifecycleHook",
+    "ModuleManifestV1",
+    "ModuleSettingsPort",
+    "ObservabilityPort",
+    "PermissionPort",
+    "SchedulerPort",
+    "ServiceRegistryPort",
+    "SpanPort",
+    "StoragePort",
+    "TracerPort",
+    "parse_manifest",
+]

--- a/backend/app/platform/modules/testing.py
+++ b/backend/app/platform/modules/testing.py
@@ -1,0 +1,298 @@
+"""Infrastrukturfreie Test-Fakes für Module, die das öffentliche SDK konsumieren."""
+
+import json
+import logging
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import TypeVar, cast
+
+from app.platform.modules.contracts import ModuleRegistrationContext
+from app.platform.modules.sdk import (
+    DomainEvent,
+    HttpClientPort,
+    HttpResponsePort,
+    JobHandler,
+    ModuleContext,
+    ObservabilityPort,
+    SpanPort,
+)
+
+T = TypeVar("T")
+
+
+class FakeCache:
+    def __init__(self, module_id: str) -> None:
+        self.module_id = module_id
+        self.values: dict[str, bytes] = {}
+        self.ttls: dict[str, int] = {}
+
+    async def get(self, key: str) -> bytes | None:
+        return self.values.get(key)
+
+    async def set(self, key: str, value: bytes, *, ttl_seconds: int) -> bool:
+        if ttl_seconds <= 0:
+            raise ValueError("Cache TTL must be a positive number of seconds.")
+        self.values[key] = value
+        self.ttls[key] = ttl_seconds
+        return True
+
+    async def delete(self, *keys: str) -> int:
+        deleted = 0
+        for key in keys:
+            if key in self.values:
+                deleted += 1
+                self.values.pop(key)
+                self.ttls.pop(key, None)
+        return deleted
+
+    async def clear(self) -> int:
+        deleted = len(self.values)
+        self.values.clear()
+        self.ttls.clear()
+        return deleted
+
+
+class FakeEventBus:
+    def __init__(self) -> None:
+        self.published: list[DomainEvent] = []
+
+    async def publish(self, event: DomainEvent) -> None:
+        self.published.append(event)
+
+
+class FakeServiceRegistry:
+    def __init__(self, services: Mapping[type[object], object] | None = None) -> None:
+        self.services = dict(services or {})
+
+    def resolve(self, contract: type[T]) -> T:
+        if contract not in self.services:
+            raise LookupError(f"No test service is registered for {contract.__name__}.")
+        return cast(T, self.services[contract])
+
+
+class FakePermissions:
+    def __init__(self, allowed: set[str] | None = None) -> None:
+        self.allowed = set(allowed or ())
+        self.checks: list[tuple[str, str | None, str | None]] = []
+
+    async def is_allowed(
+        self,
+        permission_id: str,
+        *,
+        principal_id: str | None,
+        resource_id: str | None = None,
+    ) -> bool:
+        self.checks.append((permission_id, principal_id, resource_id))
+        return permission_id in self.allowed
+
+
+class FakeMetrics:
+    def __init__(self) -> None:
+        self.increments: list[tuple[str, float, Mapping[str, str]]] = []
+        self.observations: list[tuple[str, float, Mapping[str, str]]] = []
+
+    def increment(
+        self,
+        name: str,
+        *,
+        value: float = 1,
+        attributes: Mapping[str, str] | None = None,
+    ) -> None:
+        self.increments.append((name, value, dict(attributes or {})))
+
+    def observe(
+        self,
+        name: str,
+        value: float,
+        *,
+        attributes: Mapping[str, str] | None = None,
+    ) -> None:
+        self.observations.append((name, value, dict(attributes or {})))
+
+
+@dataclass(slots=True)
+class FakeSpan:
+    name: str
+    attributes: dict[str, str | float | bool] = field(default_factory=dict)
+    exceptions: list[Exception] = field(default_factory=list)
+
+    def set_attribute(self, name: str, value: str | float | bool) -> None:
+        self.attributes[name] = value
+
+    def record_exception(self, error: Exception) -> None:
+        self.exceptions.append(error)
+
+
+class FakeTracer:
+    def __init__(self) -> None:
+        self.spans: list[FakeSpan] = []
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        attributes: Mapping[str, str] | None = None,
+    ):
+        span = FakeSpan(name, dict(attributes or {}))
+        self.spans.append(span)
+        yield cast(SpanPort, span)
+
+
+@dataclass(frozen=True, slots=True)
+class FakeObservability:
+    logger: logging.LoggerAdapter
+    metrics: FakeMetrics
+    tracer: FakeTracer
+
+
+class FakeStorage:
+    def __init__(self, module_id: str) -> None:
+        self.module_id = module_id
+        self.values: dict[str, bytes] = {}
+        self.content_types: dict[str, str | None] = {}
+
+    async def read(self, key: str) -> bytes | None:
+        return self.values.get(key)
+
+    async def write(self, key: str, value: bytes, *, content_type: str | None = None) -> None:
+        self.values[key] = value
+        self.content_types[key] = content_type
+
+    async def delete(self, key: str) -> bool:
+        existed = key in self.values
+        self.values.pop(key, None)
+        self.content_types.pop(key, None)
+        return existed
+
+    async def exists(self, key: str) -> bool:
+        return key in self.values
+
+
+@dataclass(frozen=True, slots=True)
+class FakeHttpResponse:
+    status_code: int = 200
+    headers: Mapping[str, str] = field(default_factory=dict)
+    content: bytes = b""
+    json_body: object | None = None
+
+    def json(self) -> object:
+        if self.json_body is not None:
+            return self.json_body
+        return json.loads(self.content)
+
+
+class FakeHttpClient:
+    def __init__(self) -> None:
+        self.responses: dict[tuple[str, str], HttpResponsePort] = {}
+        self.requests: list[tuple[str, str]] = []
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+        content: bytes | None = None,
+    ) -> HttpResponsePort:
+        del headers, params, content
+        key = (method.upper(), url)
+        self.requests.append(key)
+        if key not in self.responses:
+            raise LookupError(f"No fake HTTP response is configured for {key[0]} {key[1]}.")
+        return self.responses[key]
+
+
+class FakeHttpClientFactory:
+    def __init__(self, client: FakeHttpClient | None = None) -> None:
+        self.client = client or FakeHttpClient()
+        self.created: list[tuple[str, str | None]] = []
+
+    @asynccontextmanager
+    async def create(
+        self,
+        *,
+        service_name: str,
+        base_url: str | None = None,
+    ) -> AsyncIterator[HttpClientPort]:
+        self.created.append((service_name, base_url))
+        yield self.client
+
+
+class FakeScheduler:
+    def __init__(self) -> None:
+        self.jobs: dict[str, JobHandler] = {}
+
+    def register(self, job_id: str, handler: JobHandler) -> None:
+        if job_id in self.jobs:
+            raise ValueError(f'Test job "{job_id}" is already registered.')
+        self.jobs[job_id] = handler
+
+
+class FakeModuleSettings:
+    def __init__(self, values: Mapping[str, object] | None = None) -> None:
+        self.values = MappingProxyType(dict(values or {}))
+
+    def get(self, key: str, default: T | None = None) -> object | T | None:
+        return self.values.get(key, default)
+
+    def require(self, key: str) -> object:
+        if key not in self.values:
+            raise KeyError(key)
+        return self.values[key]
+
+
+def create_test_module_context(
+    *,
+    module_id: str = "test-module",
+    module_version: str = "1.0.0",
+    settings: Mapping[str, object] | None = None,
+) -> ModuleContext:
+    """Erzeuge einen vollständigen Context ohne DB, Redis, Netzwerk oder Dateisystem."""
+
+    registration = ModuleRegistrationContext()
+    observability: ObservabilityPort = FakeObservability(
+        logger=logging.LoggerAdapter(
+            logging.getLogger(f"tests.modules.{module_id}"),
+            {"module_id": module_id, "module_version": module_version},
+        ),
+        metrics=FakeMetrics(),
+        tracer=FakeTracer(),
+    )
+    return ModuleContext(
+        module_id=module_id,
+        module_version=module_version,
+        api=registration,
+        lifecycle=registration,
+        observability=observability,
+        events=FakeEventBus(),
+        services=FakeServiceRegistry(),
+        permissions=FakePermissions(),
+        cache=FakeCache(module_id),
+        storage=FakeStorage(module_id),
+        http=FakeHttpClientFactory(),
+        scheduler=FakeScheduler(),
+        settings=FakeModuleSettings(settings),
+    )
+
+
+__all__ = [
+    "FakeCache",
+    "FakeEventBus",
+    "FakeHttpClient",
+    "FakeHttpClientFactory",
+    "FakeHttpResponse",
+    "FakeMetrics",
+    "FakeModuleSettings",
+    "FakeObservability",
+    "FakePermissions",
+    "FakeScheduler",
+    "FakeServiceRegistry",
+    "FakeSpan",
+    "FakeStorage",
+    "FakeTracer",
+    "create_test_module_context",
+]

--- a/backend/tests/fixtures/example_backend_module.py
+++ b/backend/tests/fixtures/example_backend_module.py
@@ -2,8 +2,12 @@
 
 from fastapi import APIRouter
 
-from app.platform.modules import ModuleDefinition, ModuleManifestV1, ModuleRegistrationContext
-from app.platform.modules.manifest import parse_manifest
+from app.platform.modules.sdk import (
+    ModuleContext,
+    ModuleDefinition,
+    ModuleManifestV1,
+    parse_manifest,
+)
 
 MANIFEST = parse_manifest(
     {
@@ -21,14 +25,18 @@ MANIFEST = parse_manifest(
 class ExampleBackendModule:
     manifest: ModuleManifestV1 = MANIFEST
 
-    def register(self, context: ModuleRegistrationContext) -> None:
+    def register(self, context: ModuleContext) -> None:
         router = APIRouter()
 
         @router.get("/ping")
         async def ping() -> dict[str, str]:
             return {"status": "ok"}
 
-        context.include_router(router, prefix="/api/v1/module-test", tags=("Module test",))
+        context.api.include_router(
+            router,
+            prefix="/api/v1/module-test",
+            tags=("Module test",),
+        )
 
 
 DEFINITION = ModuleDefinition(

--- a/backend/tests/test_module_sdk.py
+++ b/backend/tests/test_module_sdk.py
@@ -1,0 +1,282 @@
+import ast
+import subprocess
+import sys
+from dataclasses import FrozenInstanceError, dataclass
+from pathlib import Path
+from typing import Protocol, get_type_hints
+
+import pytest
+from fastapi import APIRouter, FastAPI
+
+from app.platform.modules.context import ModuleContextFactory, ModuleHostServices
+from app.platform.modules.contracts import ModuleRegistrationContext
+from app.platform.modules.runtime import create_module_runtime
+from app.platform.modules.sdk import (
+    ApiRegistrar,
+    CachePort,
+    DatabaseSessionProvider,
+    EventBusPort,
+    HttpClientFactoryPort,
+    LifecycleRegistrar,
+    ModuleContext,
+    ModuleSettingsPort,
+    ObservabilityPort,
+    PermissionPort,
+    SchedulerPort,
+    ServiceRegistryPort,
+    StoragePort,
+)
+from app.platform.modules.testing import (
+    FakeCache,
+    FakeEventBus,
+    FakeHttpClientFactory,
+    FakeHttpResponse,
+    FakeMetrics,
+    FakeModuleSettings,
+    FakeObservability,
+    FakePermissions,
+    FakeScheduler,
+    FakeServiceRegistry,
+    FakeStorage,
+    FakeTracer,
+    create_test_module_context,
+)
+from tests.fixtures.example_backend_module import DEFINITION as EXAMPLE_DEFINITION
+from tests.test_module_runtime import FakeDiscovery, runtime_for
+
+
+def test_module_context_has_typed_public_ports() -> None:
+    hints = get_type_hints(ModuleContext)
+
+    assert hints == {
+        "module_id": str,
+        "module_version": str,
+        "api": ApiRegistrar,
+        "lifecycle": LifecycleRegistrar,
+        "observability": ObservabilityPort,
+        "database": DatabaseSessionProvider | None,
+        "events": EventBusPort | None,
+        "services": ServiceRegistryPort | None,
+        "permissions": PermissionPort | None,
+        "cache": CachePort | None,
+        "storage": StoragePort | None,
+        "http": HttpClientFactoryPort | None,
+        "scheduler": SchedulerPort | None,
+        "settings": ModuleSettingsPort | None,
+    }
+
+
+def test_runtime_context_is_bound_to_manifest_and_optional_ports_are_absent() -> None:
+    runtime = runtime_for([EXAMPLE_DEFINITION])
+    context = runtime.registry.get("test-example-module").context
+
+    assert context.module_id == "test-example-module"
+    assert context.module_version == "1.0.0"
+    assert context.database is None
+    assert context.events is None
+    assert context.services is None
+    assert context.permissions is None
+    assert context.cache is None
+    assert context.storage is None
+    assert context.http is None
+    assert context.scheduler is None
+    assert context.settings is None
+    assert context.logger.extra == {
+        "module_id": "test-example-module",
+        "module_version": "1.0.0",
+    }
+
+
+def test_context_identity_is_immutable_and_registration_closes_with_runtime() -> None:
+    runtime = runtime_for([EXAMPLE_DEFINITION])
+    record = runtime.registry.get("test-example-module")
+
+    with pytest.raises(FrozenInstanceError):
+        record.context.module_id = "other-module"  # type: ignore[misc]
+
+    runtime.register(FastAPI())
+    with pytest.raises(RuntimeError, match="closed"):
+        record.context.api.include_router(APIRouter())
+    with pytest.raises(RuntimeError, match="closed"):
+        record.context.lifecycle.add_lifecycle(startup=_noop_hook)
+
+
+def test_public_context_registers_router_and_lifecycle_contributions() -> None:
+    context = create_test_module_context()
+    router = APIRouter()
+
+    context.api.include_router(router, prefix="/example", tags=("Example",))
+    context.lifecycle.add_lifecycle(startup=_noop_hook)
+
+    registration = context.api
+    assert isinstance(registration, ModuleRegistrationContext)
+    assert registration.routers[0].prefix == "/example"
+    assert registration.routers[0].tags == ("Example",)
+    assert registration.lifecycle[0].startup is _noop_hook
+
+
+async def _noop_hook() -> None:
+    return None
+
+
+def test_context_factory_supplies_explicit_host_adapter() -> None:
+    cache = FakeCache("test-example-module")
+    factory = ModuleContextFactory(ModuleHostServices(cache=cache))
+    runtime = runtime_for_with_factory(factory)
+
+    assert runtime.registry.get("test-example-module").context.cache is cache
+
+
+def runtime_for_with_factory(factory: ModuleContextFactory):
+    return create_module_runtime(
+        enabled_module_ids=("test-example-module",),
+        discovery_providers=(FakeDiscovery((EXAMPLE_DEFINITION,)),),
+        host_version="0.2.0",
+        context_factory=factory,
+    )
+
+
+@dataclass(frozen=True)
+class ExampleEvent:
+    event_type: str = "example.created"
+    event_version: int = 1
+
+
+class ExampleService(Protocol):
+    def value(self) -> str: ...
+
+
+class ExampleServiceImplementation:
+    def value(self) -> str:
+        return "ok"
+
+
+@pytest.mark.asyncio
+async def test_public_test_context_fakes_need_no_infrastructure() -> None:
+    context = create_test_module_context(
+        module_id="example-module",
+        settings={"endpoint": "https://example.invalid"},
+    )
+
+    assert isinstance(context.cache, FakeCache)
+    assert isinstance(context.events, FakeEventBus)
+    assert isinstance(context.services, FakeServiceRegistry)
+    assert isinstance(context.permissions, FakePermissions)
+    assert isinstance(context.observability, FakeObservability)
+    assert isinstance(context.storage, FakeStorage)
+    assert isinstance(context.http, FakeHttpClientFactory)
+    assert isinstance(context.scheduler, FakeScheduler)
+    assert isinstance(context.settings, FakeModuleSettings)
+    assert context.database is None
+
+    assert await context.cache.set("key", b"value", ttl_seconds=30)
+    assert await context.cache.get("key") == b"value"
+    assert context.cache.ttls == {"key": 30}
+
+    event = ExampleEvent()
+    await context.events.publish(event)
+    assert context.events.published == [event]
+
+    service = ExampleServiceImplementation()
+    context.services.services[ExampleService] = service
+    assert context.services.resolve(ExampleService).value() == "ok"
+
+    context.permissions.allowed.add("example-module.read")
+    assert await context.permissions.is_allowed(
+        "example-module.read", principal_id="user-1", resource_id="resource-1"
+    )
+
+    context.observability.metrics.increment("requests", attributes={"result": "ok"})
+    with context.observability.tracer.span("load") as span:
+        span.set_attribute("cached", True)
+    assert context.observability.metrics.increments == [("requests", 1, {"result": "ok"})]
+    assert context.observability.tracer.spans[0].attributes == {"cached": True}
+
+    await context.storage.write("item", b"content", content_type="text/plain")
+    assert await context.storage.read("item") == b"content"
+
+    response = FakeHttpResponse(json_body={"status": "ok"})
+    context.http.client.responses[("GET", "/status")] = response
+    async with context.http.create(
+        service_name="example", base_url="https://example.invalid"
+    ) as client:
+        assert (await client.request("GET", "/status")).json() == {"status": "ok"}
+
+    context.scheduler.register("refresh", _noop_hook)
+    assert context.scheduler.jobs == {"refresh": _noop_hook}
+    assert context.settings.require("endpoint") == "https://example.invalid"
+
+
+def test_fake_metrics_and_tracer_are_concrete_test_ports() -> None:
+    context = create_test_module_context()
+    assert isinstance(context.observability.metrics, FakeMetrics)
+    assert isinstance(context.observability.tracer, FakeTracer)
+
+
+def test_public_sdk_import_does_not_start_application() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "from app.platform.modules.sdk import ModuleContext; "
+                "assert ModuleContext; "
+                "assert 'app.main' not in sys.modules"
+            ),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_public_sdk_has_no_host_internal_or_domain_imports() -> None:
+    sdk_path = Path(__file__).resolve().parents[1] / "app/platform/modules/sdk.py"
+    tree = ast.parse(sdk_path.read_text(encoding="utf-8"))
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+    forbidden_prefixes = (
+        "app.api",
+        "app.cache",
+        "app.core",
+        "app.db",
+        "app.models",
+        "app.observability",
+        "app.security",
+        "app.services",
+    )
+    assert not any(imported.startswith(forbidden_prefixes) for imported in imported_modules)
+
+    forbidden_domain_names = {
+        "AnalysisArea",
+        "Assistant",
+        "Notification",
+        "OsmFeature",
+        "Polygon",
+        "SocialPublication",
+        "Statistics",
+    }
+    assert forbidden_domain_names.isdisjoint(tree_names(tree))
+
+
+def test_fixture_module_uses_only_public_app_sdk_import() -> None:
+    fixture_path = Path(__file__).resolve().parent / "fixtures/example_backend_module.py"
+    tree = ast.parse(fixture_path.read_text(encoding="utf-8"))
+    app_imports = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module is not None
+        and node.module.startswith("app.")
+    }
+    assert app_imports == {"app.platform.modules.sdk"}
+
+
+def tree_names(tree: ast.AST) -> set[str]:
+    return {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 - [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
 - [Module Manifest Schema V1](modules/module-manifest-v1.md)
 - [Backend-Module-Runtime](modules/backend-module-runtime.md)
+- [Öffentliches Backend-Module-SDK](modules/backend-module-sdk.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)
 - [Intelligente Suche](intelligent-search.md)

--- a/docs/modules/backend-module-runtime.md
+++ b/docs/modules/backend-module-runtime.md
@@ -52,10 +52,12 @@ Der Ablauf ist strikt getrennt:
 6. Startup-Hooks in Load Order ausführen;
 7. Shutdown-Hooks in umgekehrter Reihenfolge ausführen.
 
-`ModuleRegistrationContext` enthält bewusst nur Router- und asynchrone Lifecycle-
-Registrierung. Datenbank, Redis, Storage, Events, Services, Jobs und Secrets sind
-nicht Teil dieses kleinen Vertrags. Capabilities stammen unverändert aus dem
-Manifest und sind über `ModuleRegistry.capabilities(module_id)` verfügbar.
+Die Runtime erzeugt pro validiertem Manifest einen unveränderlichen, modulgebundenen
+[`ModuleContext`](backend-module-sdk.md). Seine API- und Lifecycle-Registrare nutzen
+intern weiterhin den kleinen `ModuleRegistrationContext` aus #94. Datenbank, Cache,
+Storage, Events, Services und Jobs werden ausschließlich über die öffentlichen Ports
+des SDK angeboten. Capabilities stammen unverändert aus dem Manifest und sind über
+`ModuleRegistry.capabilities(module_id)` verfügbar.
 
 `ModuleRuntime.register(app)` darf genau einmal aufgerufen werden. Damit entstehen
 keine stillen Router-Duplikate. `register()` ist für deklarative Beiträge bestimmt;

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -1,0 +1,143 @@
+# Öffentliches Backend-Module-SDK
+
+Das öffentliche Backend-SDK setzt die Host-/Modulgrenze aus
+[ADR #92](../architecture/adr-modular-host-and-module-boundaries.md) um. Es baut auf
+dem [Manifest-V1-Contract](module-manifest-v1.md) und der
+[Backend-Module-Runtime](backend-module-runtime.md) auf. Modulcode importiert
+Plattformverträge ausschließlich aus:
+
+```python
+app.platform.modules.sdk
+```
+
+`app.platform.modules.runtime`, `discovery`, `context`, `contracts` und weitere
+Hostdateien sind Implementierungsdetails der Composition Root. Bestehende Re-Exports
+unter `app.platform.modules` bleiben für die junge #94-Integration kompatibel, sind
+aber kein neuer Modul-SDK-Importpfad.
+
+## ModuleContext
+
+Der Host erzeugt für jedes validierte Modul einen eigenen, unveränderlichen
+`ModuleContext`. `module_id` und `module_version` stammen aus dem bereits geprüften
+Manifest. Ein Modul kann weder den Context eines anderen Moduls anfordern noch seine
+gebundene Identität regulär verändern.
+
+```python
+from fastapi import APIRouter
+
+from app.platform.modules.sdk import ModuleContext, ModuleManifestV1
+
+
+class ExampleModule:
+    manifest: ModuleManifestV1
+
+    def register(self, context: ModuleContext) -> None:
+        router = APIRouter()
+
+        @router.get("/ping")
+        async def ping() -> dict[str, str]:
+            context.logger.info("Ping request handled")
+            return {"status": "ok"}
+
+        context.api.include_router(router, prefix="/api/v1/example")
+```
+
+`register()` deklariert Beiträge und führt keine Netzwerk-, Worker- oder anderen
+externen Startup-Side-Effects aus. `context.api` registriert Router;
+`context.lifecycle` registriert asynchrone Startup-/Shutdown-Hooks. Beide Registrare
+werden nach `register()` geschlossen. Der Context selbst kann von Hooks oder
+Request-Handlern weiter referenziert werden; seine Host-Service-Ports bleiben
+unverändert gebunden.
+
+Die direkten Methoden `context.include_router()` und `context.add_lifecycle()` sind
+Kompatibilitäts-Proxys für #94. Neuer Modulcode verwendet die expliziten
+Sub-Interfaces `context.api` und `context.lifecycle`.
+
+## Öffentliche Ports
+
+| Context-Feld | Contract | Status nach #95 |
+|---|---|---|
+| `api` | `ApiRegistrar` | durch die Runtime implementiert |
+| `lifecycle` | `LifecycleRegistrar` | durch die Runtime implementiert |
+| `database` | `DatabaseSessionProvider` | optionaler Port; Adapter folgt mit DB-/Migrationsarbeit |
+| `events` | `EventBusPort` | optionaler Port; echte Zustellung/Outbox folgt in #96 |
+| `services` | `ServiceRegistryPort` | optionaler Port; Registry folgt in #98 |
+| `permissions` | `PermissionPort` | optionaler Port; Policy Engine folgt in #104 |
+| `cache` | `CachePort` | optionaler, modulgebundener Byte-Cache |
+| `observability` | `ObservabilityPort` | immer vorhanden; Logger ist an Modul-ID/-Version gebunden |
+| `storage` | `StoragePort` | optionaler modulgebundener Blob-Storage |
+| `http` | `HttpClientFactoryPort` | optionaler sicherer Client-Port |
+| `scheduler` | `SchedulerPort` | optionaler Port; Job Runtime folgt in #100 |
+| `settings` | `ModuleSettingsPort` | optionaler, namespaced Port; Runtime folgt in #99 |
+
+Ein optionaler Port mit dem Wert `None` ist nicht durch den Host bereitgestellt. Das
+ist ein definierter Zustand und kein stiller Fallback auf Host-Interna. Ein Modul
+darf deshalb nicht ersatzweise `app.db`, `app.cache`, `app.services`, `app.core` oder
+andere interne Hostpakete importieren. Benötigte Ports müssen vor ihrer Verwendung
+explizit geprüft beziehungsweise künftig als Modulanforderung deklariert werden.
+
+### Datenbank
+
+`DatabaseSessionProvider.session()` liefert einen asynchronen Context Manager mit
+einer SQLAlchemy-`AsyncSession`. SQLAlchemy ist bewusst Teil dieses stabilen Ports,
+weil es eine Kerntechnologie des Hosts ist und eine künstliche parallele ORM-
+Abstraktion keinen Mehrwert bietet. Fachliche ORM-Modelle, globale Session Factories,
+Engines und `app.db.session` sind dagegen nicht Teil des SDK. Ownership und modulare
+Migrationen bleiben #97 vorbehalten.
+
+### Cache und Storage
+
+Cache-Schlüssel und Storage-Keys gelten relativ zum aktuellen Modul; konkrete
+Adapter müssen sie entsprechend isolieren. Cache-TTLs sind positive ganze Sekunden.
+Die Ports machen keine Redis-, Dateisystem- oder Cloud-SDK-Typen öffentlich.
+
+### Events, Services, Permissions und Jobs
+
+Diese Ports definieren nur die Richtung künftiger Hostadapter. #95 implementiert
+weder Event-Zustellung noch Outbox, Service Registry, Permission Policy oder Job-
+Ausführung. Die Service-Auflösung ist ausschließlich für explizite öffentliche
+Cross-Module-Contracts vorgesehen und kein allgemeiner Service Locator.
+
+### HTTP
+
+Module definieren fachliche Zielpfade. Der Hostadapter besitzt Timeouts, User-Agent,
+Connection Pooling, Observability und Sicherheitsregeln wie SSRF-Schutz. Der Port
+gibt keinen konkreten `httpx.AsyncClient` an Module weiter.
+
+### Observability
+
+`context.logger` ist ein Python-`LoggerAdapter`, der `module_id` und
+`module_version` automatisch als strukturierte Felder trägt. Metrics und Tracing
+verwenden kleine vendor-neutrale Ports. Metrikattribute müssen stabil und
+niedrig-kardinal bleiben; Nutzungs-, Request- oder Suchwerte sind keine Labels.
+
+## Infrastrukturfreie Tests
+
+`app.platform.modules.testing` stellt `create_test_module_context()` sowie kleine
+Fakes für Cache, Events, Services, Permissions, Metrics, Tracing, Storage, HTTP,
+Scheduler und Settings bereit. Sie verwenden weder Datenbank noch Redis, Netzwerk
+oder Dateisystem. Der Datenbankport bleibt im Standard-Testcontext bewusst `None`;
+datenbankbezogener Modulcode injiziert einen gezielten Session-Fake oder testet gegen
+eine ausdrücklich bereitgestellte isolierte Datenbank.
+
+## Vertrauen und Importregeln
+
+Das SDK ist eine Architekturgrenze, keine Sandbox. Installierte Module bleiben
+vertrauenswürdiger In-Process-Code. Ein fokussierter Architekturtest stellt sicher,
+dass das SDK keine Fachtypen oder Host-Interna importiert und das Runtime-Fixture
+unter `app.*` ausschließlich den öffentlichen SDK-Pfad verwendet.
+
+## SDK-Versionierung
+
+`MODULE_SDK_VERSION` ist eine SemVer-Version und unabhängig von Release-SHA und
+Host-API-Version. Der Context wurde unter SDK `1.0.0` additiv eingeführt; die
+kompatiblen #94-Proxys bleiben erhalten.
+
+- **MAJOR:** Entfernen oder Umbenennen öffentlicher Methoden, inkompatible Änderungen
+  an vorhandener Semantik oder eine inkompatible Context-Struktur.
+- **MINOR:** additive optionale Ports, zusätzliche Capability-APIs oder neue
+  kompatible Helper.
+- **PATCH:** Fehlerkorrekturen und Typing-Präzisierungen ohne Runtime-Bruch.
+
+Deprecations werden dokumentiert und mindestens über einen angekündigten
+Migrationszeitraum parallel unterstützt. Ein Git-SHA ist keine SDK-Version.


### PR DESCRIPTION
## Ausgangslage

Part of #91  
Closes #95

Aufbauend auf ADR #92 / PR #114, dem Manifest Contract #93 / PR #115 und der Backend Module Runtime #94 / PR #116 fehlte bislang eine stabile öffentliche Host-/Modul-Schnittstelle.

## Umsetzung

- Öffentlichen, modulgebundenen `ModuleContext` eingeführt
- Typisierte Protocol-Ports für API, Lifecycle, DB-Session, Events, Services, Permissions, Cache, Observability, Storage, HTTP, Scheduler und Module Settings definiert
- Interne `ModuleContextFactory` in die bestehende Runtime integriert
- Infrastrukturfreie Test-Fakes bereitgestellt
- Beispielmodul aus #94 vollständig auf den öffentlichen SDK-Importpfad migriert
- Public/Internal-Grenze, optionale Ports und SemVer-/Breaking-Change-Policy dokumentiert
- Architekturtests gegen direkte Host-Internal- und Fachtyp-Imports ergänzt
- Bestehende #94-Importpfade kompatibel gehalten

Die Folge-Systeme aus #96 ff. werden nicht vorweggenommen.

## Nicht enthalten

- Keine vollständige Implementierung der Subsysteme aus #96 ff.
- Keine Migration bestehender Fachmodule
- Keine Datenbankmigration
- Keine Änderung an der Frontend-Runtime
- Keine Dependency- oder Lockfile-Änderungen

## Tests

- `cd backend && .venv/bin/ruff check app tests`
- `cd backend && .venv/bin/pytest tests/test_module_manifest.py tests/test_module_runtime.py tests/test_module_sdk.py` — 90 Tests erfolgreich
- `cd backend && .venv/bin/pytest` — 697 Tests erfolgreich
- `cd backend && .venv/bin/python -c "from app.main import app; assert app.title"` — erfolgreich
- `cd frontend && pnpm audit:language` — 462 Ressourcen geprüft, 0 unerlaubte Treffer

`uv lock --check` konnte lokal nicht ausgeführt werden, weil `uv` in der Umgebung nicht installiert ist. Dependency- und Lockfiles wurden nicht geändert.