### PR TITLE
feat(database): define module persistence ownership

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -100,3 +100,6 @@ jobs:
       - name: Upgrade fresh database
         working-directory: backend
         run: uv run alembic upgrade head
+      - name: Verify module persistence and migration contracts
+        working-directory: backend
+        run: uv run pytest tests/test_module_persistence.py

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -6,50 +6,52 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 from app.core.config import get_settings
-from app.db.base import Base
-from app.models import (  # noqa: F401
-    AdminAuditLog,
-    AnalysisArea,
-    AuthMfaChallenge,
-    CacheVersion,
-    CityMetrics,
-    DomainEventOutbox,
-    EmailCampaign,
-    EmailCampaignDelivery,
-    EmailOutbox,
-    EmailTemplate,
-    EmailUnsubscribeToken,
-    EmailVerificationToken,
-    EventDelivery,
-    MastodonOAuthInstance,
-    OAuthFlowGrant,
-    OsmFeature,
-    PasswordResetToken,
-    PolygonAnalysisArea,
-    SocialPublication,
-    SocialPublicationOutbox,
-    SocialPublishingSettings,
-    User,
-    UserMfaMethod,
-    UserMfaRecoveryCode,
-    UserOAuthAccount,
-    UserPolygon,
-    UserSession,
+from app.platform.modules import EntryPointModuleDiscovery, FirstPartyModuleDiscovery
+from app.platform.modules.persistence import (
+    build_persistence_registry,
+    include_autogenerate_object,
 )
+from app.platform.modules.runtime import resolve_module_definitions
+
+settings = get_settings()
+resolved_modules = resolve_module_definitions(
+    enabled_module_ids=settings.enabled_module_list,
+    discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
+    host_version=settings.api_version,
+)
+registry = build_persistence_registry(resolved_modules)
 
 config = context.config
-config.set_main_option("sqlalchemy.url", get_settings().database_url)
+database_url = config.attributes.get("database_url", settings.database_url)
+config.set_main_option("sqlalchemy.url", database_url)
 
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+if config.config_file_name is not None and config.attributes.get("configure_logger", True):
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
-target_metadata = Base.metadata
+target_metadata = registry.target_metadata
+
+
+def include_name(name: str | None, type_: str, parent_names: dict[str, str | None]) -> bool:
+    """Reflektiere nur das Legacy-/Public-Schema und explizit registrierte Module."""
+
+    if type_ == "schema":
+        return name in {None, "public", *registry.owned_schemas}
+    return parent_names.get("schema_name") in {None, "public", *registry.owned_schemas}
+
+
+def configure_context(**kwargs) -> None:
+    context.configure(
+        target_metadata=target_metadata,
+        include_schemas=True,
+        include_name=include_name,
+        include_object=include_autogenerate_object,
+        **kwargs,
+    )
 
 
 def run_migrations_offline() -> None:
-    context.configure(
-        url=get_settings().database_url,
-        target_metadata=target_metadata,
+    configure_context(
+        url=database_url,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
     )
@@ -58,7 +60,7 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection: Connection) -> None:
-    context.configure(connection=connection, target_metadata=target_metadata)
+    configure_context(connection=connection)
     with context.begin_transaction():
         context.run_migrations()
 

--- a/backend/app/cli/process_domain_event_outbox.py
+++ b/backend/app/cli/process_domain_event_outbox.py
@@ -14,7 +14,8 @@ from app.platform.modules import (
     FirstPartyModuleDiscovery,
     create_module_runtime,
 )
-from app.platform.modules.context import ModuleContextFactory
+from app.platform.modules.context import ModuleContextFactory, ModuleHostServices
+from app.platform.modules.persistence import HostDatabaseSessionProvider
 from app.services.polygon_event_handlers import register_polygon_event_handlers
 
 
@@ -27,7 +28,9 @@ async def run(limit: int) -> dict[str, int]:
         enabled_module_ids=settings.enabled_module_list,
         discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
         host_version=settings.api_version,
-        context_factory=ModuleContextFactory(event_bus=bus),
+        context_factory=ModuleContextFactory(
+            ModuleHostServices(database=HostDatabaseSessionProvider()), event_bus=bus
+        ),
     )
     runtime.register(FastAPI())
     bus.seal()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,7 +26,8 @@ from app.platform.modules import (
     FirstPartyModuleDiscovery,
     create_module_runtime,
 )
-from app.platform.modules.context import ModuleContextFactory
+from app.platform.modules.context import ModuleContextFactory, ModuleHostServices
+from app.platform.modules.persistence import HostDatabaseSessionProvider
 from app.security.request_limits import RequestBodyLimitMiddleware
 from app.services.assistant_provider import close_assistant_provider
 from app.services.map_previews import MapPreviewError, map_preview_service
@@ -37,7 +38,9 @@ module_runtime = create_module_runtime(
     enabled_module_ids=settings.enabled_module_list,
     discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
     host_version=settings.api_version,
-    context_factory=ModuleContextFactory(event_bus=event_bus),
+    context_factory=ModuleContextFactory(
+        ModuleHostServices(database=HostDatabaseSessionProvider()), event_bus=event_bus
+    ),
 )
 configure_logging(
     level=settings.log_level,

--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -15,6 +15,7 @@ from app.platform.modules.discovery import (
 from app.platform.modules.errors import (
     DuplicateConfigNamespaceError,
     DuplicateModuleIdError,
+    DuplicatePersistenceSchemaError,
     InvalidRuntimeVersionError,
     MissingModuleDependencyError,
     ModuleCompatibilityError,
@@ -24,6 +25,7 @@ from app.platform.modules.errors import (
     ModuleDiscoveryError,
     ModuleLoadError,
     ModuleManifestError,
+    ModulePersistenceError,
     ModuleRegistrationError,
     ModuleRuntimeError,
     ModuleSelfDependencyError,
@@ -51,8 +53,14 @@ from app.platform.modules.runtime import (
     ModuleRegistry,
     ModuleRuntime,
     create_module_runtime,
+    resolve_module_definitions,
 )
-from app.platform.modules.sdk import BackendModule, ModuleContext
+from app.platform.modules.sdk import (
+    BackendModule,
+    ModuleContext,
+    ModuleMigrationSource,
+    ModulePersistenceContribution,
+)
 
 __all__ = [
     "ENTRY_POINT_GROUP",
@@ -60,6 +68,7 @@ __all__ = [
     "BackendModule",
     "DuplicateConfigNamespaceError",
     "DuplicateModuleIdError",
+    "DuplicatePersistenceSchemaError",
     "EntryPointModuleDiscovery",
     "FirstPartyModuleDiscovery",
     "InvalidRuntimeVersionError",
@@ -79,8 +88,11 @@ __all__ = [
     "ModuleLoadError",
     "ModuleManifestError",
     "ModuleManifestV1",
+    "ModuleMigrationSource",
     "ModuleOptionalRequirements",
     "ModulePersistence",
+    "ModulePersistenceContribution",
+    "ModulePersistenceError",
     "ModuleRecord",
     "ModuleRegistrationContext",
     "ModuleRegistrationError",
@@ -96,6 +108,7 @@ __all__ = [
     "create_module_runtime",
     "module_manifest_json_schema",
     "parse_manifest",
+    "resolve_module_definitions",
     "resolve_module_order",
     "validate_manifest",
     "validate_manifests",

--- a/backend/app/platform/modules/discovery.py
+++ b/backend/app/platform/modules/discovery.py
@@ -45,6 +45,7 @@ class FirstPartyModuleDiscovery:
                     loader=definition.loader,
                     origin=definition.origin,
                     declared_id=module_id,
+                    persistence=definition.persistence,
                 )
             )
         return tuple(definitions)
@@ -80,6 +81,7 @@ class EntryPointModuleDiscovery:
                     loader=definition.loader,
                     origin=origin,
                     declared_id=entry_point.name,
+                    persistence=definition.persistence,
                 )
             )
         return tuple(definitions)

--- a/backend/app/platform/modules/errors.py
+++ b/backend/app/platform/modules/errors.py
@@ -71,6 +71,18 @@ class DuplicateConfigNamespaceError(ModuleManifestError):
         self.module_ids = tuple(module_ids)
 
 
+class DuplicatePersistenceSchemaError(ModuleManifestError):
+    """Zwei Module beanspruchen dasselbe PostgreSQL-Schema."""
+
+    def __init__(self, schema: str, module_ids: Sequence[str]) -> None:
+        joined_ids = ", ".join(module_ids)
+        super().__init__(
+            f'Persistence schema "{schema}" is owned by multiple modules: {joined_ids}.'
+        )
+        self.schema = schema
+        self.module_ids = tuple(module_ids)
+
+
 class ModuleCompatibilityError(ModuleManifestError):
     """Ein Modul ist mit der aktuellen Host- oder SDK-Version inkompatibel."""
 
@@ -223,3 +235,25 @@ class ModuleShutdownError(ModuleRuntimeError):
 
     def __init__(self, message: str, *, module_id: str | None = None) -> None:
         super().__init__(message, phase="shutdown", module_id=module_id)
+
+
+class ModulePersistenceError(RuntimeError):
+    """Ein passiver Persistence-Beitrag verletzt den Ownership-Contract."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        module_id: str | None = None,
+        schema: str | None = None,
+        phase: str = "preflight",
+    ) -> None:
+        context = [f"phase={phase}"]
+        if module_id is not None:
+            context.append(f"module_id={module_id}")
+        if schema is not None:
+            context.append(f"schema={schema}")
+        super().__init__(f"Module persistence error ({', '.join(context)}): {message}")
+        self.module_id = module_id
+        self.schema = schema
+        self.phase = phase

--- a/backend/app/platform/modules/manifest.py
+++ b/backend/app/platform/modules/manifest.py
@@ -23,6 +23,7 @@ from semantic_version import SimpleSpec, Version
 from app.platform.modules.errors import (
     DuplicateConfigNamespaceError,
     DuplicateModuleIdError,
+    DuplicatePersistenceSchemaError,
     InvalidRuntimeVersionError,
     MissingModuleDependencyError,
     ModuleCompatibilityError,
@@ -168,7 +169,7 @@ class ModuleConfig(StrictManifestModel):
 
 
 class ModulePersistence(StrictManifestModel):
-    """Deklarative Metadaten für das spätere Migrations-Ownership aus #97."""
+    """Deklarative Schema- und Migrations-Ownership aus #97."""
 
     schema_name: str = Field(
         alias="schema",
@@ -326,15 +327,22 @@ def validate_manifests(
         first_index_by_id[manifest.id] = index
 
     config_owners: dict[str, str] = {}
+    schema_owners: dict[str, str] = {}
     for manifest in manifests:
-        if manifest.config is None:
-            continue
-        namespace = manifest.config.namespace
-        if namespace in config_owners:
-            raise DuplicateConfigNamespaceError(
-                namespace, (config_owners[namespace], manifest.id)
-            )
-        config_owners[namespace] = manifest.id
+        if manifest.config is not None:
+            namespace = manifest.config.namespace
+            if namespace in config_owners:
+                raise DuplicateConfigNamespaceError(
+                    namespace, (config_owners[namespace], manifest.id)
+                )
+            config_owners[namespace] = manifest.id
+        if manifest.persistence is not None:
+            schema = manifest.persistence.schema_name
+            if schema in schema_owners:
+                raise DuplicatePersistenceSchemaError(
+                    schema, (schema_owners[schema], manifest.id)
+                )
+            schema_owners[schema] = manifest.id
 
     for manifest in manifests:
         validate_manifest(

--- a/backend/app/platform/modules/migrations.py
+++ b/backend/app/platform/modules/migrations.py
@@ -1,0 +1,225 @@
+"""Alembic-Preflight für installierte, passiv registrierte Modulmigrationen."""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from alembic import command
+from app.platform.modules.errors import ModulePersistenceError
+from app.platform.modules.persistence import (
+    PersistenceRegistry,
+    migration_log_fields,
+    resolve_migration_source,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationStep:
+    module_id: str
+    schema: str | None
+    revision: str
+
+
+class MigrationCoordinator:
+    """Validiert einen global linearen Host-/Modul-Revisionsgraphen."""
+
+    def __init__(self, config: Config, registry: PersistenceRegistry) -> None:
+        self._config = config
+        self._registry = registry
+        self._config.attributes["configure_logger"] = False
+
+    def preflight(self) -> tuple[MigrationStep, ...]:
+        host_versions = self._host_versions_path()
+        source_paths: list[tuple[str, Path, str, str | None]] = []
+        for module_id, source in self._registry.migration_sources:
+            schema = next(
+                contribution.schema
+                for contribution in self._registry.contributions
+                if contribution.module_id == module_id
+            )
+            path = resolve_migration_source(source, module_id=module_id)
+            logger.info(
+                "Module migration preflight source resolved",
+                extra=migration_log_fields(
+                    module_id=module_id,
+                    revision=None,
+                    schema=schema,
+                    phase="preflight",
+                ),
+            )
+            source_paths.append(
+                (
+                    module_id,
+                    path,
+                    source.revision_namespace,
+                    schema,
+                )
+            )
+
+        locations = (host_versions, *(path for _, path, _, _ in source_paths))
+        self._config.set_main_option("version_locations", "\n".join(map(str, locations)))
+        self._config.set_main_option("path_separator", "newline")
+        scripts = ScriptDirectory.from_config(self._config)
+        heads = scripts.get_heads()
+        if len(heads) != 1:
+            raise ModulePersistenceError(
+                f"Exactly one global Alembic head is required, found: {', '.join(heads)}."
+            )
+
+        roots = {module_id: path for module_id, path, _, _ in source_paths}
+        namespaces = {module_id: namespace for module_id, _, namespace, _ in source_paths}
+        schemas = {module_id: schema for module_id, _, _, schema in source_paths}
+        expected_order = [module_id for module_id, _ in self._registry.migration_sources]
+        steps: list[MigrationStep] = []
+        seen_modules: set[str] = set()
+        first_module_order: list[str] = []
+
+        revisions = tuple(reversed(tuple(scripts.walk_revisions(base="base", head="heads"))))
+        for revision in revisions:
+            revision_path = Path(revision.path).resolve()
+            owner = next(
+                (
+                    module_id
+                    for module_id, root in roots.items()
+                    if revision_path.is_relative_to(root)
+                ),
+                "host",
+            )
+            if owner != "host":
+                namespace = namespaces[owner]
+                if not revision.revision.startswith(f"{namespace}_"):
+                    raise ModulePersistenceError(
+                        f'Revision "{revision.revision}" must start with "{namespace}_".',
+                        module_id=owner,
+                        schema=schemas[owner],
+                    )
+                if owner not in seen_modules:
+                    seen_modules.add(owner)
+                    first_module_order.append(owner)
+            if not steps or steps[-1].module_id != owner:
+                steps.append(MigrationStep(owner, schemas.get(owner), revision.revision))
+            else:
+                steps[-1] = MigrationStep(owner, schemas.get(owner), revision.revision)
+
+        missing = [module_id for module_id in expected_order if module_id not in seen_modules]
+        if missing:
+            raise ModulePersistenceError(
+                "Migration source contains no revisions.", module_id=missing[0]
+            )
+        if first_module_order != expected_order:
+            misplaced = next(
+                module_id
+                for index, module_id in enumerate(first_module_order)
+                if index >= len(expected_order) or module_id != expected_order[index]
+            )
+            raise ModulePersistenceError(
+                "Initial module revisions do not follow the resolved dependency order.",
+                module_id=misplaced,
+                schema=schemas.get(misplaced),
+            )
+        return tuple(steps)
+
+    def upgrade(self) -> tuple[MigrationStep, ...]:
+        """Führe ausstehende Host-/Modulgruppen vor Aktivierung geordnet aus."""
+
+        plan = self.preflight()
+        scripts = ScriptDirectory.from_config(self._config)
+        revisions = tuple(reversed(tuple(scripts.walk_revisions(base="base", head="heads"))))
+        position = {revision.revision: index for index, revision in enumerate(revisions)}
+        current_heads = asyncio.run(self._current_heads())
+        if len(current_heads) > 1:
+            raise ModulePersistenceError(
+                "The database has multiple current revisions; coordinated upgrade stopped."
+            )
+        current = current_heads[0] if current_heads else None
+        if current is not None and current not in position:
+            raise ModulePersistenceError(
+                f'The current database revision "{current}" is not in the installed graph.'
+            )
+        current_position = position[current] if current is not None else -1
+
+        for step in plan:
+            if position[step.revision] <= current_position:
+                continue
+            fields = {
+                "module_id": step.module_id,
+                "revision": step.revision,
+                "schema": step.schema,
+                "migration_phase": "upgrade_started",
+            }
+            logger.info("Module migration upgrade started", extra=fields)
+            try:
+                command.upgrade(self._config, step.revision)
+            except Exception as exc:
+                logger.exception(
+                    "Module migration upgrade failed",
+                    extra={**fields, "migration_phase": "upgrade_failed"},
+                )
+                raise ModulePersistenceError(
+                    f'Migration to revision "{step.revision}" failed.',
+                    module_id=step.module_id,
+                    schema=step.schema,
+                    phase="upgrade_failed",
+                ) from exc
+            logger.info(
+                "Module migration upgrade completed",
+                extra={**fields, "migration_phase": "upgrade_completed"},
+            )
+            current_position = position[step.revision]
+        return plan
+
+    def downgrade(self, target_revision: str) -> None:
+        """Führe ausschließlich einen explizit angegebenen Alembic-Downgrade aus."""
+
+        if not target_revision:
+            raise ValueError("An explicit downgrade target revision is required.")
+        self.preflight()
+        scripts = ScriptDirectory.from_config(self._config)
+        target = scripts.get_revision(target_revision)
+        if target is None:
+            raise ModulePersistenceError(
+                f'Unknown explicit downgrade target "{target_revision}".', phase="downgrade"
+            )
+        command.downgrade(self._config, target_revision)
+
+    async def _current_heads(self) -> tuple[str, ...]:
+        database_url = self._config.attributes.get(
+            "database_url", self._config.get_main_option("sqlalchemy.url")
+        )
+        if not database_url:
+            raise ModulePersistenceError("Alembic database URL is not configured.")
+        self._config.attributes["database_url"] = database_url
+        engine = create_async_engine(database_url)
+        try:
+            async with engine.connect() as connection:
+                return await connection.run_sync(
+                    lambda sync_connection: tuple(
+                        MigrationContext.configure(sync_connection).get_current_heads()
+                    )
+                )
+        finally:
+            await engine.dispose()
+
+    def _host_versions_path(self) -> Path:
+        script_location = self._config.get_main_option("script_location")
+        if not script_location:
+            raise ModulePersistenceError("Alembic script_location is not configured.")
+        root = Path(script_location)
+        if not root.is_absolute():
+            config_path = Path(self._config.config_file_name or ".").resolve()
+            root = config_path.parent / root
+        versions = (root / "versions").resolve()
+        if not versions.is_dir():
+            raise ModulePersistenceError("The host Alembic versions directory is missing.")
+        return versions
+
+
+__all__ = ["MigrationCoordinator", "MigrationStep"]

--- a/backend/app/platform/modules/persistence.py
+++ b/backend/app/platform/modules/persistence.py
@@ -1,0 +1,274 @@
+"""Hostseitige Ownership-Registry für Legacy- und Modul-Persistence."""
+
+import logging
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+
+from sqlalchemy import MetaData
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.base import Base
+from app.db.session import AsyncSessionLocal
+from app.platform.modules.errors import ModulePersistenceError
+from app.platform.modules.manifest import ModuleManifestV1
+from app.platform.modules.sdk import (
+    ModuleDefinition,
+    ModuleMigrationSource,
+    ModulePersistenceContribution,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class HostDatabaseSessionProvider:
+    """Öffnet eine Host-Session mit genau einer Commit-/Rollback-Grenze."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession] = AsyncSessionLocal,
+    ) -> None:
+        self._session_factory = session_factory
+
+    @asynccontextmanager
+    async def session(self) -> AsyncIterator[AsyncSession]:
+        async with self._session_factory() as session, session.begin():
+            yield session
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredPersistence:
+    module_id: str
+    metadata: MetaData
+    schema: str | None
+    migration_source: ModuleMigrationSource | None
+    legacy: bool = False
+
+
+class LegacyPersistenceProvider:
+    """Kontrollierter Strangler-Adapter für das bestehende zentrale Base.metadata."""
+
+    module_id = "host-legacy"
+
+    def contribution(self) -> RegisteredPersistence:
+        # Der Paketimport ist die einzige kontrollierte Legacy-Modellliste. Alembic
+        # selbst muss dadurch keine Fachmodelle mehr einzeln kennen.
+        import app.models  # noqa: F401
+
+        return RegisteredPersistence(
+            module_id=self.module_id,
+            metadata=Base.metadata,
+            schema=None,
+            migration_source=None,
+            legacy=True,
+        )
+
+
+class PersistenceRegistry:
+    """Aggregiert Metadata und Migration Sources in validierter Modulreihenfolge."""
+
+    def __init__(self) -> None:
+        self._legacy: RegisteredPersistence | None = None
+        self._modules: dict[str, RegisteredPersistence] = {}
+        self._schema_owners: dict[str, str] = {}
+        self._module_order: tuple[str, ...] = ()
+
+    def register_legacy(self, provider: LegacyPersistenceProvider) -> None:
+        if self._legacy is not None:
+            raise ModulePersistenceError("Legacy persistence is already registered.")
+        self._legacy = provider.contribution()
+
+    def register(
+        self,
+        manifest: ModuleManifestV1,
+        contribution: ModulePersistenceContribution,
+    ) -> None:
+        module_id = manifest.id
+        persistence = manifest.persistence
+        if module_id in self._modules:
+            raise ModulePersistenceError(
+                "Persistence is already registered for this module.", module_id=module_id
+            )
+        if persistence is None:
+            raise ModulePersistenceError(
+                "The module manifest does not declare persistence.", module_id=module_id
+            )
+        if contribution.module_id != module_id:
+            raise ModulePersistenceError(
+                "The contribution module ID does not match the manifest.", module_id=module_id
+            )
+        if contribution.schema != persistence.schema_name:
+            raise ModulePersistenceError(
+                "The contribution schema does not match the manifest.",
+                module_id=module_id,
+                schema=contribution.schema,
+            )
+        owner = self._schema_owners.get(contribution.schema)
+        if owner is not None:
+            raise ModulePersistenceError(
+                f'The schema is already owned by module "{owner}".',
+                module_id=module_id,
+                schema=contribution.schema,
+            )
+        if persistence.migrations != (contribution.migration_source is not None):
+            expectation = "requires" if persistence.migrations else "forbids"
+            raise ModulePersistenceError(
+                f"The manifest {expectation} a migration source.", module_id=module_id
+            )
+        expected_namespace = revision_namespace_for(module_id)
+        if (
+            contribution.migration_source is not None
+            and contribution.migration_source.revision_namespace != expected_namespace
+        ):
+            raise ModulePersistenceError(
+                f'Revision namespace must be "{expected_namespace}".', module_id=module_id
+            )
+        foreign_tables = sorted(
+            table.fullname
+            for table in contribution.metadata.tables.values()
+            if table.schema != contribution.schema
+        )
+        if foreign_tables:
+            raise ModulePersistenceError(
+                "Module metadata contains tables outside its owned schema: "
+                + ", ".join(foreign_tables),
+                module_id=module_id,
+                schema=contribution.schema,
+            )
+        self._schema_owners[contribution.schema] = module_id
+        self._modules[module_id] = RegisteredPersistence(
+            module_id=module_id,
+            metadata=contribution.metadata,
+            schema=contribution.schema,
+            migration_source=contribution.migration_source,
+        )
+
+    def seal(self, ordered_manifests: Sequence[ModuleManifestV1]) -> None:
+        order = tuple(manifest.id for manifest in ordered_manifests)
+        missing = sorted(set(self._modules).difference(order))
+        if missing:
+            raise ModulePersistenceError(
+                "Registered persistence is absent from the resolved module order: "
+                + ", ".join(missing)
+            )
+        self._module_order = order
+
+    @property
+    def contributions(self) -> tuple[RegisteredPersistence, ...]:
+        result: list[RegisteredPersistence] = []
+        if self._legacy is not None:
+            result.append(self._legacy)
+        result.extend(
+            self._modules[module_id]
+            for module_id in self._module_order
+            if module_id in self._modules
+        )
+        return tuple(result)
+
+    @property
+    def target_metadata(self) -> tuple[MetaData, ...]:
+        return tuple(contribution.metadata for contribution in self.contributions)
+
+    @property
+    def owned_schemas(self) -> frozenset[str]:
+        return frozenset(self._schema_owners)
+
+    @property
+    def migration_sources(self) -> tuple[tuple[str, ModuleMigrationSource], ...]:
+        return tuple(
+            (contribution.module_id, contribution.migration_source)
+            for contribution in self.contributions
+            if contribution.migration_source is not None
+        )
+
+
+def revision_namespace_for(module_id: str) -> str:
+    return f"mod_{module_id.replace('-', '_')}"
+
+
+def build_persistence_registry(
+    resolved_definitions: Sequence[tuple[ModuleDefinition, ModuleManifestV1]],
+    *,
+    include_legacy: bool = True,
+) -> PersistenceRegistry:
+    registry = PersistenceRegistry()
+    if include_legacy:
+        registry.register_legacy(LegacyPersistenceProvider())
+    ordered_manifests = tuple(manifest for _, manifest in resolved_definitions)
+    for definition, manifest in resolved_definitions:
+        if definition.persistence is None:
+            if manifest.persistence is not None:
+                raise ModulePersistenceError(
+                    "The manifest declares persistence but the passive definition does not.",
+                    module_id=manifest.id,
+                    schema=manifest.persistence.schema_name,
+                )
+            continue
+        registry.register(manifest, definition.persistence)
+    registry.seal(ordered_manifests)
+    return registry
+
+
+def resolve_migration_source(source: ModuleMigrationSource, *, module_id: str) -> Path:
+    """Löse ausschließlich Ressourcen bereits installierter Python-Pakete auf."""
+
+    try:
+        package_root_resource = resources.files(source.package)
+        resource = package_root_resource.joinpath(source.resource)
+    except (AttributeError, ModuleNotFoundError, TypeError) as exc:
+        raise ModulePersistenceError(
+            "The installed migration package could not be resolved.", module_id=module_id
+        ) from exc
+    package_root = Path(str(package_root_resource)).resolve()
+    path = Path(str(resource)).resolve()
+    if not path.is_relative_to(package_root) or not path.is_dir():
+        raise ModulePersistenceError(
+            "The installed migration resource is not a directory.", module_id=module_id
+        )
+    return path
+
+
+def migration_log_fields(
+    *, module_id: str, revision: str | None, schema: str | None, phase: str
+) -> dict[str, str | None]:
+    return {
+        "module_id": module_id,
+        "revision": revision,
+        "schema": schema,
+        "migration_phase": phase,
+    }
+
+
+def include_autogenerate_object(
+    object_: object,
+    name: str | None,
+    type_: str,
+    reflected: bool,
+    compare_to: object | None,
+) -> bool:
+    """Verhindere implizite Drops von nicht registrierten DB-Objekten."""
+
+    del object_, name
+    destructive_types = {
+        "table",
+        "index",
+        "unique_constraint",
+        "foreign_key_constraint",
+        "check_constraint",
+    }
+    return not (reflected and compare_to is None and type_ in destructive_types)
+
+
+__all__ = [
+    "HostDatabaseSessionProvider",
+    "LegacyPersistenceProvider",
+    "PersistenceRegistry",
+    "RegisteredPersistence",
+    "build_persistence_registry",
+    "include_autogenerate_object",
+    "migration_log_fields",
+    "resolve_migration_source",
+    "revision_namespace_for",
+]

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -26,7 +26,7 @@ from app.platform.modules.manifest import ModuleManifestV1, parse_manifest, vali
 from app.platform.modules.sdk import BackendModule, ModuleContext, ModuleDefinition
 
 logger = logging.getLogger(__name__)
-MODULE_SDK_VERSION = "1.1.0"
+MODULE_SDK_VERSION = "1.2.0"
 
 
 @dataclass(slots=True)
@@ -183,6 +183,55 @@ def create_module_runtime(
 ) -> ModuleRuntime:
     """Discover, validiere, sortiere und instanziiere aktivierte Module fail-fast."""
 
+    resolved = resolve_module_definitions(
+        enabled_module_ids=enabled_module_ids,
+        discovery_providers=discovery_providers,
+        host_version=host_version,
+        sdk_version=sdk_version,
+    )
+    definitions_by_id = {manifest.id: definition for definition, manifest in resolved}
+    ordered = tuple(manifest for _, manifest in resolved)
+
+    records: list[ModuleRecord] = []
+    active_context_factory = context_factory or ModuleContextFactory()
+    for load_index, manifest in enumerate(ordered):
+        definition = definitions_by_id[manifest.id]
+        try:
+            module = definition.loader()
+            if module.manifest != manifest:
+                raise ValueError("loaded module manifest does not match its validated definition")
+            register = module.register
+            if not callable(register):
+                raise TypeError("loaded module has no callable register hook")
+        except Exception as exc:
+            raise ModuleLoadError(
+                "The validated module could not be instantiated.",
+                module_id=manifest.id,
+                origin=definition.origin,
+            ) from exc
+        registration = ModuleRegistrationContext()
+        records.append(
+            ModuleRecord(
+                manifest=manifest,
+                module=module,
+                origin=definition.origin,
+                load_index=load_index,
+                context=active_context_factory.create(manifest, registration),
+                registration=registration,
+            )
+        )
+    return ModuleRuntime(ModuleRegistry(records))
+
+
+def resolve_module_definitions(
+    *,
+    enabled_module_ids: Sequence[str],
+    discovery_providers: Sequence[ModuleDiscoveryProvider],
+    host_version: str,
+    sdk_version: str = MODULE_SDK_VERSION,
+) -> tuple[tuple[ModuleDefinition, ModuleManifestV1], ...]:
+    """Entdecke und ordne passive Definitionen, ohne Modul-Runtimecode zu laden."""
+
     enabled = frozenset(enabled_module_ids)
     definitions: list[ModuleDefinition] = []
     for provider in discovery_providers:
@@ -254,35 +303,7 @@ def create_module_runtime(
         raise ModuleValidationError(str(exc), module_id=exc.module_id, origin=origin) from exc
 
     definitions_by_id = {manifest.id: definition for definition, manifest in parsed}
-    records: list[ModuleRecord] = []
-    active_context_factory = context_factory or ModuleContextFactory()
-    for load_index, manifest in enumerate(ordered):
-        definition = definitions_by_id[manifest.id]
-        try:
-            module = definition.loader()
-            if module.manifest != manifest:
-                raise ValueError("loaded module manifest does not match its validated definition")
-            register = module.register
-            if not callable(register):
-                raise TypeError("loaded module has no callable register hook")
-        except Exception as exc:
-            raise ModuleLoadError(
-                "The validated module could not be instantiated.",
-                module_id=manifest.id,
-                origin=definition.origin,
-            ) from exc
-        registration = ModuleRegistrationContext()
-        records.append(
-            ModuleRecord(
-                manifest=manifest,
-                module=module,
-                origin=definition.origin,
-                load_index=load_index,
-                context=active_context_factory.create(manifest, registration),
-                registration=registration,
-            )
-        )
-    return ModuleRuntime(ModuleRegistry(records))
+    return tuple((definitions_by_id[manifest.id], manifest) for manifest in ordered)
 
 
 def _log_fields(record: ModuleRecord, phase: str) -> dict[str, str]:

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -6,6 +6,7 @@ Plattform-Ports und importiert keine Host-Infrastruktur oder Fachdomänen.
 
 import logging
 import math
+import posixpath
 import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
@@ -16,6 +17,7 @@ from typing import Protocol, TypeVar
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter
+from sqlalchemy import MetaData
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.platform.modules.manifest import (
@@ -31,6 +33,8 @@ type JsonScalar = str | int | float | bool | None
 type JsonValue = JsonScalar | list["JsonValue"] | Mapping[str, "JsonValue"]
 T = TypeVar("T")
 _EVENT_NAME = re.compile(r"^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+$")
+_REVISION_NAMESPACE = re.compile(r"^mod_[a-z][a-z0-9_]*$")
+_PYTHON_IMPORT_PACKAGE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$")
 
 
 class ApiRegistrar(Protocol):
@@ -60,6 +64,41 @@ class DatabaseSessionProvider(Protocol):
     """Öffnet eine vom Host verwaltete SQLAlchemy-Session."""
 
     def session(self) -> AbstractAsyncContextManager[AsyncSession]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleMigrationSource:
+    """Installierte, lokale Alembic-Quelle eines Moduls."""
+
+    package: str
+    resource: str
+    revision_namespace: str
+
+    def __post_init__(self) -> None:
+        if not _PYTHON_IMPORT_PACKAGE.fullmatch(self.package):
+            raise ValueError("Migration packages must be installed Python package names.")
+        normalized = posixpath.normpath(self.resource)
+        if (
+            not self.resource
+            or self.resource.startswith(("/", "\\"))
+            or normalized in {".", ".."}
+            or normalized.startswith("../")
+            or "://" in self.resource
+            or "\\" in self.resource
+        ):
+            raise ValueError("Migration resources must be relative installed-package paths.")
+        if not _REVISION_NAMESPACE.fullmatch(self.revision_namespace):
+            raise ValueError('Revision namespaces must use the form "mod_<module_id>".')
+
+
+@dataclass(frozen=True, slots=True)
+class ModulePersistenceContribution:
+    """Passive ORM- und Migrationsmetadaten einer ModuleDefinition."""
+
+    module_id: str
+    metadata: MetaData
+    schema: str
+    migration_source: ModuleMigrationSource | None = None
 
 
 class DomainEvent(Protocol):
@@ -390,6 +429,7 @@ class ModuleDefinition:
     loader: ModuleLoader
     origin: str
     declared_id: str
+    persistence: ModulePersistenceContribution | None = None
 
 
 __all__ = [
@@ -413,6 +453,8 @@ __all__ = [
     "ModuleDefinition",
     "ModuleLifecycleHook",
     "ModuleManifestV1",
+    "ModuleMigrationSource",
+    "ModulePersistenceContribution",
     "ModuleSettingsPort",
     "ObservabilityPort",
     "PermissionPort",

--- a/backend/tests/fixtures/example_backend_module.py
+++ b/backend/tests/fixtures/example_backend_module.py
@@ -1,11 +1,13 @@
 """Bewusst kleines, ausschließlich in Tests aktiviertes Runtime-Modul."""
 
 from fastapi import APIRouter
+from sqlalchemy import Column, Integer, MetaData, String, Table
 
 from app.platform.modules.sdk import (
     ModuleContext,
     ModuleDefinition,
     ModuleManifestV1,
+    ModulePersistenceContribution,
     parse_manifest,
 )
 
@@ -17,8 +19,18 @@ MANIFEST = parse_manifest(
         "version": "1.0.0",
         "requires": {"host": ">=0.2.0,<1.0.0", "sdk": ">=1.0.0,<2.0.0"},
         "capabilities": ["test.ping"],
+        "persistence": {"schema": "test_example_module", "migrations": False},
     },
     origin="tests.fixtures.example_backend_module",
+)
+
+METADATA = MetaData()
+Table(
+    "items",
+    METADATA,
+    Column("id", Integer, primary_key=True),
+    Column("name", String(80), nullable=False),
+    schema="test_example_module",
 )
 
 
@@ -44,4 +56,9 @@ DEFINITION = ModuleDefinition(
     loader=ExampleBackendModule,
     origin="tests.fixtures.example_backend_module",
     declared_id=MANIFEST.id,
+    persistence=ModulePersistenceContribution(
+        module_id=MANIFEST.id,
+        metadata=METADATA,
+        schema="test_example_module",
+    ),
 )

--- a/backend/tests/fixtures/example_persistence_module.py
+++ b/backend/tests/fixtures/example_persistence_module.py
@@ -1,0 +1,59 @@
+"""Zweites passives Persistence-Fixture mit deklarierter Modulabhängigkeit."""
+
+from sqlalchemy import Column, Integer, MetaData, String, Table
+
+from app.platform.modules.sdk import (
+    ModuleContext,
+    ModuleDefinition,
+    ModuleManifestV1,
+    ModulePersistenceContribution,
+    parse_manifest,
+)
+
+MANIFEST = parse_manifest(
+    {
+        "manifest_version": 1,
+        "id": "test-persistence-dependent",
+        "name": "Abhängiges Persistence-Testmodul",
+        "version": "1.0.0",
+        "requires": {
+            "host": ">=0.2.0,<1.0.0",
+            "sdk": ">=1.0.0,<2.0.0",
+            "modules": {"test-example-module": ">=1.0.0,<2.0.0"},
+        },
+        "persistence": {
+            "schema": "test_persistence_dependent",
+            "migrations": False,
+        },
+    },
+    origin="tests.fixtures.example_persistence_module",
+)
+
+METADATA = MetaData()
+Table(
+    "items",
+    METADATA,
+    Column("id", Integer, primary_key=True),
+    Column("description", String(120), nullable=False),
+    schema="test_persistence_dependent",
+)
+
+
+class ExamplePersistenceModule:
+    manifest: ModuleManifestV1 = MANIFEST
+
+    def register(self, context: ModuleContext) -> None:
+        del context
+
+
+DEFINITION = ModuleDefinition(
+    manifest=MANIFEST,
+    loader=ExamplePersistenceModule,
+    origin="tests.fixtures.example_persistence_module",
+    declared_id=MANIFEST.id,
+    persistence=ModulePersistenceContribution(
+        module_id=MANIFEST.id,
+        metadata=METADATA,
+        schema="test_persistence_dependent",
+    ),
+)

--- a/backend/tests/fixtures/module_migrations/example_a/20260825_mod_example_a_0001.py
+++ b/backend/tests/fixtures/module_migrations/example_a/20260825_mod_example_a_0001.py
@@ -1,0 +1,25 @@
+"""Test fixture: create example A module table."""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "mod_example_a_20260825_0001"
+down_revision = "20260825_0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS example_a")
+    op.create_table(
+        "items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        schema="example_a",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("items", schema="example_a")
+    op.execute("DROP SCHEMA example_a")

--- a/backend/tests/fixtures/module_migrations/example_b/20260825_mod_example_b_0001.py
+++ b/backend/tests/fixtures/module_migrations/example_b/20260825_mod_example_b_0001.py
@@ -1,0 +1,25 @@
+"""Test fixture: create example B module table after dependency A."""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "mod_example_b_20260825_0001"
+down_revision = "mod_example_a_20260825_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS example_b")
+    op.create_table(
+        "items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        schema="example_b",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("items", schema="example_b")
+    op.execute("DROP SCHEMA example_b")

--- a/backend/tests/fixtures/module_migrations/example_b_broken/20260825_mod_example_b_0001.py
+++ b/backend/tests/fixtures/module_migrations/example_b_broken/20260825_mod_example_b_0001.py
@@ -1,0 +1,16 @@
+"""Test fixture: fail example B migration after dependency A."""
+
+from alembic import op
+
+revision = "mod_example_b_20260825_0001"
+down_revision = "mod_example_a_20260825_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("THIS IS NOT VALID SQL")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -1,0 +1,622 @@
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from alembic.autogenerate import compare_metadata
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from geoalchemy2 import Geometry
+from sqlalchemy import Column, Integer, MetaData, String, Table, func, insert, select, text, true
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import DBAPIError, OperationalError
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.core.config import get_settings
+from app.db.base import Base
+from app.platform.modules import (
+    DuplicatePersistenceSchemaError,
+    ModuleDefinition,
+    ModuleMigrationSource,
+    ModulePersistenceContribution,
+    ModulePersistenceError,
+    parse_manifest,
+    resolve_module_definitions,
+    validate_manifests,
+)
+from app.platform.modules.migrations import MigrationCoordinator
+from app.platform.modules.persistence import (
+    HostDatabaseSessionProvider,
+    PersistenceRegistry,
+    build_persistence_registry,
+    include_autogenerate_object,
+    resolve_migration_source,
+    revision_namespace_for,
+)
+from tests.fixtures.example_backend_module import DEFINITION as EXAMPLE_DEFINITION
+from tests.fixtures.example_persistence_module import DEFINITION as DEPENDENT_DEFINITION
+from tests.test_module_runtime import FakeDiscovery
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+def module_manifest(
+    module_id: str,
+    schema: str,
+    *,
+    dependencies: dict[str, str] | None = None,
+    migrations: bool = False,
+):
+    return parse_manifest(
+        {
+            "manifest_version": 1,
+            "id": module_id,
+            "name": module_id,
+            "version": "1.0.0",
+            "requires": {
+                "host": ">=0.2.0,<1.0.0",
+                "sdk": ">=1.0.0,<2.0.0",
+                "modules": dependencies or {},
+            },
+            "persistence": {"schema": schema, "migrations": migrations},
+        }
+    )
+
+
+def module_definition(
+    manifest,
+    metadata: MetaData,
+    *,
+    migration_resource: str | None = None,
+) -> ModuleDefinition:
+    def forbidden_loader():
+        raise AssertionError("Persistence discovery must not instantiate module runtime code")
+
+    return ModuleDefinition(
+        manifest=manifest,
+        loader=forbidden_loader,
+        origin=f"tests.{manifest.id}",
+        declared_id=manifest.id,
+        persistence=ModulePersistenceContribution(
+            module_id=manifest.id,
+            metadata=metadata,
+            schema=manifest.persistence.schema_name,
+            migration_source=(
+                ModuleMigrationSource(
+                    package="tests.fixtures",
+                    resource=migration_resource,
+                    revision_namespace=revision_namespace_for(manifest.id),
+                )
+                if migration_resource is not None
+                else None
+            ),
+        ),
+    )
+
+
+def module_metadata(schema: str, *, table_name: str = "items") -> MetaData:
+    metadata = MetaData()
+    Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(80), nullable=False),
+        schema=schema,
+    )
+    return metadata
+
+
+def test_registry_aggregates_legacy_and_two_metadata_sets_in_dependency_order() -> None:
+    manifest_a = module_manifest("example-a", "example_a")
+    manifest_b = module_manifest(
+        "example-b",
+        "example_b",
+        dependencies={"example-a": ">=1.0.0,<2.0.0"},
+    )
+    definition_a = module_definition(manifest_a, module_metadata("example_a"))
+    definition_b = module_definition(manifest_b, module_metadata("example_b"))
+
+    resolved = resolve_module_definitions(
+        enabled_module_ids=("example-b", "example-a"),
+        discovery_providers=(FakeDiscovery((definition_b, definition_a)),),
+        host_version="0.2.0",
+    )
+    registry = build_persistence_registry(resolved)
+
+    assert [item.module_id for item in registry.contributions] == [
+        "host-legacy",
+        "example-a",
+        "example-b",
+    ]
+    assert registry.target_metadata[0] is Base.metadata
+    assert registry.owned_schemas == frozenset({"example_a", "example_b"})
+
+
+def test_public_sdk_fixture_modules_register_two_persistence_sets() -> None:
+    resolved = resolve_module_definitions(
+        enabled_module_ids=("test-persistence-dependent", "test-example-module"),
+        discovery_providers=(
+            FakeDiscovery((DEPENDENT_DEFINITION, EXAMPLE_DEFINITION)),
+        ),
+        host_version="0.2.0",
+    )
+
+    registry = build_persistence_registry(resolved, include_legacy=False)
+
+    assert [item.module_id for item in registry.contributions] == [
+        "test-example-module",
+        "test-persistence-dependent",
+    ]
+    assert {
+        table.fullname
+        for metadata in registry.target_metadata
+        for table in metadata.tables.values()
+    } == {
+        "test_example_module.items",
+        "test_persistence_dependent.items",
+    }
+
+
+def test_independent_module_persistence_is_ordered_lexicographically() -> None:
+    manifest_b = module_manifest("example-b", "example_b")
+    manifest_a = module_manifest("example-a", "example_a")
+    definitions = (
+        module_definition(manifest_b, module_metadata("example_b")),
+        module_definition(manifest_a, module_metadata("example_a")),
+    )
+
+    resolved = resolve_module_definitions(
+        enabled_module_ids=("example-b", "example-a"),
+        discovery_providers=(FakeDiscovery(definitions),),
+        host_version="0.2.0",
+    )
+    registry = build_persistence_registry(resolved, include_legacy=False)
+
+    assert [item.module_id for item in registry.contributions] == ["example-a", "example-b"]
+
+
+def test_duplicate_module_registration_is_rejected() -> None:
+    manifest = module_manifest("example-a", "example_a")
+    contribution = module_definition(manifest, module_metadata("example_a")).persistence
+    assert contribution is not None
+    registry = PersistenceRegistry()
+    registry.register(manifest, contribution)
+
+    with pytest.raises(ModulePersistenceError, match="already registered"):
+        registry.register(manifest, contribution)
+
+
+def test_duplicate_schema_ownership_is_rejected_by_manifest_contract() -> None:
+    manifests = (
+        module_manifest("example-a", "shared_schema"),
+        module_manifest("example-b", "shared_schema"),
+    )
+
+    with pytest.raises(DuplicatePersistenceSchemaError) as captured:
+        validate_manifests(manifests, host_version="0.2.0", sdk_version="1.1.0")
+
+    assert captured.value.schema == "shared_schema"
+    assert captured.value.module_ids == ("example-a", "example-b")
+
+
+def test_module_metadata_cannot_own_tables_outside_declared_schema() -> None:
+    manifest = module_manifest("example-a", "example_a")
+    contribution = ModulePersistenceContribution(
+        module_id="example-a",
+        metadata=module_metadata("other_schema"),
+        schema="example_a",
+    )
+
+    with pytest.raises(ModulePersistenceError, match="outside its owned schema"):
+        PersistenceRegistry().register(manifest, contribution)
+
+
+@pytest.mark.parametrize(
+    "resource",
+    ("../migrations", "/tmp/migrations", "https://example.invalid/migrations"),
+)
+def test_migration_sources_reject_external_or_escaping_resources(resource: str) -> None:
+    with pytest.raises(ValueError, match="relative installed-package"):
+        ModuleMigrationSource(
+            package="tests.fixtures",
+            resource=resource,
+            revision_namespace="mod_example_a",
+        )
+
+
+def test_unresolvable_migration_source_reports_module_id() -> None:
+    source = ModuleMigrationSource(
+        package="tests.fixtures",
+        resource="missing_migrations",
+        revision_namespace="mod_example_a",
+    )
+
+    with pytest.raises(ModulePersistenceError) as captured:
+        resolve_migration_source(source, module_id="example-a")
+
+    assert captured.value.module_id == "example-a"
+    assert captured.value.phase == "preflight"
+
+
+def test_revision_namespace_is_stable_and_namespaced() -> None:
+    assert revision_namespace_for("analysis-areas") == "mod_analysis_areas"
+
+
+@pytest.mark.parametrize(
+    "object_type",
+    ("table", "index", "unique_constraint", "foreign_key_constraint", "check_constraint"),
+)
+def test_autogenerate_never_proposes_implicit_drop_for_unowned_object(
+    object_type: str,
+) -> None:
+    assert not include_autogenerate_object(
+        object(), "legacy_object", object_type, reflected=True, compare_to=None
+    )
+    assert include_autogenerate_object(
+        object(), "owned_object", object_type, reflected=True, compare_to=object()
+    )
+
+
+def test_migration_preflight_combines_host_and_modules_in_dependency_order() -> None:
+    manifest_a = module_manifest("example-a", "example_a", migrations=True)
+    manifest_b = module_manifest(
+        "example-b",
+        "example_b",
+        dependencies={"example-a": ">=1.0.0,<2.0.0"},
+        migrations=True,
+    )
+    definitions = (
+        module_definition(
+            manifest_b,
+            module_metadata("example_b"),
+            migration_resource="module_migrations/example_b",
+        ),
+        module_definition(
+            manifest_a,
+            module_metadata("example_a"),
+            migration_resource="module_migrations/example_a",
+        ),
+    )
+    resolved = resolve_module_definitions(
+        enabled_module_ids=("example-b", "example-a"),
+        discovery_providers=(FakeDiscovery(definitions),),
+        host_version="0.2.0",
+    )
+    registry = build_persistence_registry(resolved, include_legacy=False)
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+
+    plan = MigrationCoordinator(config, registry).preflight()
+
+    assert [(step.module_id, step.revision) for step in plan[-3:]] == [
+        ("host", "20260825_0034"),
+        ("example-a", "mod_example_a_20260825_0001"),
+        ("example-b", "mod_example_b_20260825_0001"),
+    ]
+
+
+def migration_registry(*, module_b_resource: str) -> PersistenceRegistry:
+    manifest_a = module_manifest("example-a", "example_a", migrations=True)
+    manifest_b = module_manifest(
+        "example-b",
+        "example_b",
+        dependencies={"example-a": ">=1.0.0,<2.0.0"},
+        migrations=True,
+    )
+    definitions = (
+        module_definition(
+            manifest_b,
+            module_metadata("example_b"),
+            migration_resource=module_b_resource,
+        ),
+        module_definition(
+            manifest_a,
+            module_metadata("example_a"),
+            migration_resource="module_migrations/example_a",
+        ),
+    )
+    resolved = resolve_module_definitions(
+        enabled_module_ids=("example-b", "example-a"),
+        discovery_providers=(FakeDiscovery(definitions),),
+        host_version="0.2.0",
+    )
+    return build_persistence_registry(resolved, include_legacy=False)
+
+
+@pytest_asyncio.fixture
+async def fresh_database_url() -> AsyncIterator[str]:
+    base_url = make_url(get_settings().database_url)
+    admin_url = base_url.set(database="postgres")
+    database_name = f"test_module_migrations_{uuid.uuid4().hex}"
+    admin = create_async_engine(admin_url, isolation_level="AUTOCOMMIT")
+    try:
+        async with admin.connect() as connection:
+            await connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+    except (ConnectionError, DBAPIError, OSError, OperationalError) as exc:
+        await admin.dispose()
+        pytest.skip(f"PostgreSQL database creation is unavailable: {type(exc).__name__}")
+
+    database_url = str(base_url.set(database=database_name))
+    try:
+        yield database_url
+    finally:
+        async with admin.connect() as connection:
+            await connection.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    f"WHERE datname = '{database_name}' AND pid <> pg_backend_pid()"
+                )
+            )
+            await connection.execute(text(f'DROP DATABASE "{database_name}"'))
+        await admin.dispose()
+
+
+def migration_coordinator(
+    database_url: str, *, module_b_resource: str = "module_migrations/example_b"
+) -> MigrationCoordinator:
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.attributes["database_url"] = database_url
+    return MigrationCoordinator(
+        config,
+        migration_registry(module_b_resource=module_b_resource),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fresh_upgrade_explicit_downgrade_and_reupgrade_module_migrations(
+    fresh_database_url: str,
+) -> None:
+    coordinator = migration_coordinator(fresh_database_url)
+
+    await asyncio.to_thread(coordinator.upgrade)
+    engine = create_async_engine(fresh_database_url)
+    async with engine.connect() as connection:
+        schemas = set(
+            await connection.scalars(
+                text(
+                    "SELECT schema_name FROM information_schema.schemata "
+                    "WHERE schema_name IN ('example_a', 'example_b')"
+                )
+            )
+        )
+        revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
+    assert schemas == {"example_a", "example_b"}
+    assert revision == "mod_example_b_20260825_0001"
+
+    await asyncio.to_thread(coordinator.downgrade, "mod_example_a_20260825_0001")
+    async with engine.connect() as connection:
+        schemas = set(
+            await connection.scalars(
+                text(
+                    "SELECT schema_name FROM information_schema.schemata "
+                    "WHERE schema_name IN ('example_a', 'example_b')"
+                )
+            )
+        )
+    assert schemas == {"example_a"}
+
+    await asyncio.to_thread(coordinator.upgrade)
+    async with engine.connect() as connection:
+        revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
+    assert revision == "mod_example_b_20260825_0001"
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_broken_module_migration_stops_with_module_context(
+    fresh_database_url: str,
+) -> None:
+    coordinator = migration_coordinator(
+        fresh_database_url,
+        module_b_resource="module_migrations/example_b_broken",
+    )
+
+    with pytest.raises(ModulePersistenceError) as captured:
+        await asyncio.to_thread(coordinator.upgrade)
+
+    assert captured.value.module_id == "example-b"
+    assert captured.value.schema == "example_b"
+    assert captured.value.phase == "upgrade_failed"
+    engine = create_async_engine(fresh_database_url)
+    async with engine.connect() as connection:
+        revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
+    assert revision == "mod_example_a_20260825_0001"
+    await engine.dispose()
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaFixture:
+    engine: AsyncEngine
+    sessions: async_sessionmaker[AsyncSession]
+    schema_a: str
+    schema_b: str
+    metadata_a: MetaData
+    metadata_b: MetaData
+    table_a: Table
+    table_b: Table
+
+
+@pytest_asyncio.fixture
+async def postgres_schemas() -> AsyncIterator[SchemaFixture]:
+    suffix = uuid.uuid4().hex[:12]
+    schema_a = f"test_module_a_{suffix}"
+    schema_b = f"test_module_b_{suffix}"
+    engine = create_async_engine(make_url(get_settings().database_url))
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(text(f'CREATE SCHEMA "{schema_a}"'))
+            await connection.execute(text(f'CREATE SCHEMA "{schema_b}"'))
+    except (ConnectionError, DBAPIError, OSError, OperationalError) as exc:
+        await engine.dispose()
+        pytest.skip(f"PostgreSQL test database is unavailable: {type(exc).__name__}")
+
+    metadata_a = MetaData()
+    metadata_b = MetaData()
+    table_a = Table(
+        "features",
+        metadata_a,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(80), nullable=False),
+        Column("geometry", Geometry("POLYGON", srid=4326), nullable=False),
+        schema=schema_a,
+    )
+    table_b = Table(
+        "features",
+        metadata_b,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(80), nullable=False),
+        Column("geometry", Geometry("POLYGON", srid=4326), nullable=False),
+        schema=schema_b,
+    )
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield SchemaFixture(
+            engine,
+            sessions,
+            schema_a,
+            schema_b,
+            metadata_a,
+            metadata_b,
+            table_a,
+            table_b,
+        )
+    finally:
+        async with engine.begin() as connection:
+            await connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema_a}" CASCADE'))
+            await connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema_b}" CASCADE'))
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_autogenerate_sees_two_module_tables_without_false_legacy_drops(
+    postgres_schemas: SchemaFixture,
+) -> None:
+    metadata = (postgres_schemas.metadata_a, postgres_schemas.metadata_b)
+
+    def differences(sync_connection):
+        context = MigrationContext.configure(
+            sync_connection,
+            opts={
+                "include_schemas": True,
+                "include_name": lambda name, type_, parents: (
+                    name in {postgres_schemas.schema_a, postgres_schemas.schema_b}
+                    if type_ == "schema"
+                    else parents.get("schema_name")
+                    in {postgres_schemas.schema_a, postgres_schemas.schema_b}
+                ),
+            },
+        )
+        return compare_metadata(context, metadata)
+
+    async with postgres_schemas.engine.begin() as connection:
+        before = await connection.run_sync(differences)
+        await connection.run_sync(postgres_schemas.metadata_a.create_all)
+        await connection.run_sync(postgres_schemas.metadata_b.create_all)
+        after = await connection.run_sync(differences)
+
+    added_tables = {operation[1].fullname for operation in before if operation[0] == "add_table"}
+    assert added_tables == {
+        f"{postgres_schemas.schema_a}.features",
+        f"{postgres_schemas.schema_b}.features",
+    }
+    assert not [operation for operation in after if operation[0] in {"add_table", "remove_table"}]
+
+
+@pytest.mark.asyncio
+async def test_same_table_name_and_cross_schema_postgis_query_work(
+    postgres_schemas: SchemaFixture,
+) -> None:
+    polygon = "POLYGON((9.4 54.7,9.5 54.7,9.5 54.8,9.4 54.8,9.4 54.7))"
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.run_sync(postgres_schemas.metadata_a.create_all)
+        await connection.run_sync(postgres_schemas.metadata_b.create_all)
+        await connection.execute(
+            insert(postgres_schemas.table_a).values(
+                id=1, name="A", geometry=func.ST_GeomFromText(polygon, 4326)
+            )
+        )
+        await connection.execute(
+            insert(postgres_schemas.table_b).values(
+                id=1, name="B", geometry=func.ST_GeomFromText(polygon, 4326)
+            )
+        )
+        intersects = await connection.scalar(
+            select(
+                func.ST_Intersects(
+                    postgres_schemas.table_a.c.geometry,
+                    postgres_schemas.table_b.c.geometry,
+                )
+            ).select_from(postgres_schemas.table_a.join(postgres_schemas.table_b, true()))
+        )
+
+    assert intersects is True
+
+
+@pytest.mark.asyncio
+async def test_host_session_provider_commits_and_rolls_back(
+    postgres_schemas: SchemaFixture,
+) -> None:
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.run_sync(postgres_schemas.metadata_a.create_all)
+    provider = HostDatabaseSessionProvider(postgres_schemas.sessions)
+
+    async with provider.session() as session:
+        await session.execute(
+            insert(postgres_schemas.table_a).values(
+                id=1,
+                name="kept",
+                geometry=func.ST_GeomFromText(
+                    "POLYGON((9.4 54.7,9.5 54.7,9.5 54.8,9.4 54.8,9.4 54.7))",
+                    4326,
+                ),
+            )
+        )
+
+    with pytest.raises(RuntimeError, match="rollback"):
+        async with provider.session() as session:
+            await session.execute(
+                insert(postgres_schemas.table_a).values(
+                    id=2,
+                    name="discarded",
+                    geometry=func.ST_GeomFromText(
+                        "POLYGON((9.4 54.7,9.5 54.7,9.5 54.8,9.4 54.8,9.4 54.7))",
+                        4326,
+                    ),
+                )
+            )
+            raise RuntimeError("rollback")
+
+    async with postgres_schemas.sessions() as session:
+        names = tuple(await session.scalars(select(postgres_schemas.table_a.c.name)))
+    assert names == ("kept",)
+
+
+@pytest.mark.asyncio
+async def test_disabling_module_does_not_drop_schema_or_data(
+    postgres_schemas: SchemaFixture,
+) -> None:
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.run_sync(postgres_schemas.metadata_a.create_all)
+        await connection.execute(
+            insert(postgres_schemas.table_a).values(
+                id=1,
+                name="preserved",
+                geometry=func.ST_GeomFromText(
+                    "POLYGON((9.4 54.7,9.5 54.7,9.5 54.8,9.4 54.8,9.4 54.7))",
+                    4326,
+                ),
+            )
+        )
+
+    disabled_registry = build_persistence_registry((), include_legacy=False)
+    assert disabled_registry.contributions == ()
+    async with postgres_schemas.sessions() as session:
+        assert await session.scalar(select(func.count()).select_from(postgres_schemas.table_a)) == 1

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -11,7 +11,7 @@ from alembic.config import Config
 from alembic.migration import MigrationContext
 from geoalchemy2 import Geometry
 from sqlalchemy import Column, Integer, MetaData, String, Table, func, insert, select, text, true
-from sqlalchemy.engine import make_url
+from sqlalchemy.engine import URL, make_url
 from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -343,7 +343,7 @@ async def fresh_database_url() -> AsyncIterator[str]:
         await admin.dispose()
         pytest.skip(f"PostgreSQL database creation is unavailable: {type(exc).__name__}")
 
-    database_url = str(base_url.set(database=database_name))
+    database_url = database_url_for(base_url, database_name)
     try:
         yield database_url
     finally:
@@ -356,6 +356,35 @@ async def fresh_database_url() -> AsyncIterator[str]:
             )
             await connection.execute(text(f'DROP DATABASE "{database_name}"'))
         await admin.dispose()
+
+
+def database_url_for(base_url: URL, database_name: str) -> str:
+    """Ersetze nur den DB-Namen und erhalte Credentials für echte Verbindungen."""
+
+    return base_url.set(database=database_name).render_as_string(hide_password=False)
+
+
+def test_database_url_for_preserves_credentials_and_connection_options() -> None:
+    password_marker = "credential-marker"
+    base_url = URL.create(
+        "postgresql+asyncpg",
+        username="ci-user",
+        password=password_marker,
+        host="127.0.0.1",
+        port=5432,
+        database="base_db",
+        query={"ssl": "require"},
+    )
+
+    derived_url = make_url(database_url_for(base_url, "temporary_db"))
+
+    assert derived_url.drivername == base_url.drivername
+    assert derived_url.username == base_url.username
+    assert derived_url.password == password_marker
+    assert derived_url.host == base_url.host
+    assert derived_url.port == base_url.port
+    assert derived_url.query == base_url.query
+    assert derived_url.database == "temporary_db"
 
 
 def migration_coordinator(

--- a/backend/tests/test_module_sdk.py
+++ b/backend/tests/test_module_sdk.py
@@ -265,8 +265,12 @@ def test_public_sdk_has_no_host_internal_or_domain_imports() -> None:
     assert forbidden_domain_names.isdisjoint(tree_names(tree))
 
 
-def test_fixture_module_uses_only_public_app_sdk_import() -> None:
-    fixture_path = Path(__file__).resolve().parent / "fixtures/example_backend_module.py"
+@pytest.mark.parametrize(
+    "fixture_name",
+    ("example_backend_module.py", "example_persistence_module.py"),
+)
+def test_fixture_module_uses_only_public_app_sdk_import(fixture_name: str) -> None:
+    fixture_path = Path(__file__).resolve().parent / f"fixtures/{fixture_name}"
     tree = ast.parse(fixture_path.read_text(encoding="utf-8"))
     app_imports = {
         node.module

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,10 +13,12 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 ## Architektur und Frontend
 
 - [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
+- [ADR: Datenbank- und Migrations-Ownership von Modulen](architecture/adr-module-database-and-migration-ownership.md)
 - [Module Manifest Schema V1](modules/module-manifest-v1.md)
 - [Backend-Module-Runtime](modules/backend-module-runtime.md)
 - [Öffentliches Backend-Module-SDK](modules/backend-module-sdk.md)
 - [Domain Events und transaktionale Outbox](modules/domain-events.md)
+- [Modul-Datenbanken und Migrationen](modules/database-and-migrations.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)
 - [Intelligente Suche](intelligent-search.md)

--- a/docs/architecture/adr-module-database-and-migration-ownership.md
+++ b/docs/architecture/adr-module-database-and-migration-ownership.md
@@ -1,0 +1,238 @@
+# ADR: Datenbank- und Migrations-Ownership von Modulen
+
+- Status: Angenommen
+- Datum: 2026-08-25
+- Entscheidung: [Issue #97](https://github.com/oklabflensburg/open-city-planner/issues/97)
+- Epic: [Issue #91](https://github.com/oklabflensburg/open-city-planner/issues/91)
+- Grundlage: [ADR #92](adr-modular-host-and-module-boundaries.md)
+
+## Kontext
+
+Open City Planner verwendet produktiv eine gemeinsame PostgreSQL-/PostGIS-Datenbank,
+ein zentrales SQLAlchemy-`Base.metadata` und eine veröffentlichte lineare
+Alembic-Historie. Bis Revision `20260825_0034` lädt `alembic/env.py` die ORM-Modelle
+über eine zentrale Fachmodellliste. Das funktioniert, macht künftige Modulgrenzen
+aber unsichtbar und zwingt jede neue Tabelle zu einer Änderung am Host.
+
+Die bestehende Historie und Produktionsdaten dürfen nicht neu aufgebaut werden.
+Insbesondere bleibt `20260825_0034` unverändert und als Host-Infrastrukturrevision
+für `domain_event_outbox` und `event_delivery` eingeordnet.
+
+## Entscheidung
+
+Der Host und alle Module verwenden weiterhin **eine gemeinsame PostgreSQL-Datenbank
+mit genau einer hostverwalteten PostGIS-Extension**. Neue größere Module besitzen
+ein explizites PostgreSQL-Schema, ihre eigene SQLAlchemy-`MetaData` und ihre
+Migrationen. Der Host besitzt Engine, Session Factory, Transaktionsgrenzen,
+DB-Health, PostGIS-Installation, Alembic-Konfiguration und Migrationskoordination.
+
+Die Umstellung erfolgt als Strangler:
+
+```text
+Host
+├── Engine / Session Factory / Transaktionen
+├── PostGIS Extension
+├── PersistenceRegistry
+├── LegacyPersistenceProvider -> Base.metadata / public
+└── Module
+    ├── Manifest persistence.schema
+    ├── passive ModulePersistenceContribution
+    ├── eigenes MetaData
+    └── installierte ModuleMigrationSource
+```
+
+Bestehende Tabellen bleiben vorerst im bisherigen, überwiegend öffentlichen Schema.
+Es gibt in #97 keine fachliche Tabellenverschiebung und keine Datenkopie.
+
+## Schema-Strategie
+
+- Ein neues größeres Fachmodul erhält grundsätzlich ein PostgreSQL-Schema. Der Name
+  steht einmalig in `manifest.persistence.schema` und folgt dem vorhandenen
+  PostgreSQL-Identifier-Contract.
+- Ein Schema hat genau einen Modul-Owner. Doppelte Ownership wird bereits bei der
+  Manifestvalidierung und erneut in der Persistence Registry abgelehnt.
+- ORM-Tabellen setzen `schema=` explizit. Migrationen verwenden ebenfalls immer
+  `schema=` oder schemaqualifiziertes SQL. Der zufällige `search_path` ist kein
+  Architekturvertrag.
+- Eine Modulmigration legt ihr Schema vor ihrer ersten Tabelle mit
+  `CREATE SCHEMA IF NOT EXISTS` an. Rollen- und Benutzerprovisionierung bleibt
+  Deployment-Aufgabe und ist nicht Teil dieses Issues.
+- Kleine eng zusammengehörige Teilfunktionen dürfen nach Architekturreview ein
+  gemeinsames Modulschema verwenden; sie sind dann ein gemeinsamer Persistence-
+  Owner und keine zwei unabhängig registrierten Module.
+
+Die ersten möglichen Fachschemas sind beispielsweise `polygons`,
+`analysis_areas`, `statistics` und `osm`. Diese Namen sind keine Anweisung, die
+heutigen Tabellen jetzt zu verschieben.
+
+## Metadata-Ownership und Discovery
+
+Ein Modul veröffentlicht seine Persistence passiv an seiner bestehenden
+`ModuleDefinition`:
+
+```python
+ModulePersistenceContribution(
+    module_id="example-module",
+    metadata=metadata,
+    schema="example_module",
+    migration_source=ModuleMigrationSource(...),
+)
+```
+
+Der Schemawert muss mit `manifest.persistence.schema` übereinstimmen. Alle Tabellen
+im beigetragenen Metadata-Set müssen explizit im eigenen Schema liegen. Ein Beitrag
+darf weder Legacy- noch fremde Modultabellen enthalten.
+
+Die passive Definition ist wichtig: Alembic validiert Metadata und Migrationen,
+ohne `BackendModule.register()`, Lifecycle-Hooks, Router, Subscriber oder andere
+Runtime-Side-Effects auszuführen. Discovery betrachtet ausschließlich explizit
+konfigurierte First-Party-Definitionen und installierte Python Entry Points. Es gibt
+keinen Wildcard-Scan mit `pkgutil.walk_packages`.
+
+`LegacyPersistenceProvider` importiert kontrolliert `app.models` und liefert das
+bisherige `Base.metadata`. `alembic/env.py` enthält dadurch keine einzelne
+Fachmodellliste mehr. Autogenerate erhält eine Sequenz aus Legacy-Metadata und den
+geordneten Modul-Metadata-Sets. Die Schemafilter reflektieren nur `public` und
+explizit registrierte Modulschemas; PostGIS-Systemschemas werden nicht als
+Anwendungsobjekte behandelt. Reflektierte Tabellen, Indizes oder Constraints ohne
+registriertes Gegenstück werden konservativ nicht als automatischer Drop erzeugt.
+Destruktive Änderungen benötigen dadurch immer eine explizite reviewte Migration.
+
+## Migrationsquellen und Sicherheit
+
+`ModuleMigrationSource` verweist ausschließlich auf einen relativen Ressourcenpfad
+in einem bereits installierten Python-Paket. URLs, absolute Pfade und
+Verzeichnis-Traversal sind ungültig. Es gibt keine Runtime-Downloads und keine
+Shell-Ausführung durch den Contract.
+
+Installierte Module sind weiterhin vertrauenswürdiger In-Process-Code, keine
+Sandbox. Migrationen besitzen besonders weitreichende Datenbankrechte und benötigen
+deshalb zwingend Review. Automatische Ownership-Prüfungen ergänzen dieses Review,
+ersetzen es aber nicht; dynamisches SQL kann nicht vollständig statisch bewiesen
+werden.
+
+## Alembic-Heads und Revision-Naming
+
+V1 behält **einen globalen linearen Alembic-Head** bei. Mehrere Branch-Heads pro
+Modul wurden verworfen, weil sie Deployment, Downgrade, Autogenerate und externe
+Modulupdates deutlich komplexer machen und der aktuelle Monolith keinen Nutzen aus
+parallelen Heads zieht. Alembic bleibt alleinige Source of Truth; eine zusätzliche
+`module_migration_state`-Tabelle wird nicht eingeführt.
+
+Modulrevisionen verwenden die kollisionsarme Konvention:
+
+```text
+mod_<normalisierte-modul-id>_<YYYYMMDD>_<sequence>
+```
+
+Für `analysis-areas` ist der Namespace beispielsweise `mod_analysis_areas`.
+Branch Labels werden in V1 nicht verwendet. Eine Modulmigration referenziert mit
+`down_revision` die letzte Revision der vorherigen geordneten Gruppe. Damit bleibt
+der Graph linear.
+
+## Deterministische Reihenfolge
+
+Für die erstmalige Aufnahme von Modulen lautet die Reihenfolge:
+
+1. Host-/Legacy-Revisionen;
+2. Module in der bereits durch #93 aufgelösten Dependency-Reihenfolge;
+3. innerhalb eines Moduls dessen eigene Revisionsreihenfolge.
+
+Unabhängige Module werden wie im bestehenden Resolver lexikografisch nach Modul-ID
+geordnet. Spätere Host- oder Modulrevisionen werden am globalen Head angehängt und
+dürfen deshalb über Releases hinweg zwischen Ownern wechseln; ihre `down_revision`
+bleibt die eindeutige Reihenfolge. Der `MigrationCoordinator` verwendet denselben
+aufgelösten Katalog und implementiert keine zweite Graphlogik. Sein Preflight prüft
+genau einen Head, auflösbare installierte Quellen, Revision-Namespaces und die
+Dependency-Reihenfolge der initialen Modulrevisionen.
+
+Der aktuelle Production-Pfad `alembic upgrade head` bleibt für die bestehende
+Host-/Legacy-Historie unverändert. Sobald ein deploytes Modul echte Migrationen
+liefert, muss der Deployment-Schritt dessen installierte Quellen in den Coordinator
+geben und den Preflight vor dem Upgrade ausführen. Die Migrationsinventur umfasst
+dabei auch installierte, aber deaktivierte Module, deren Revisionen bereits in der
+Datenbank stehen; Deaktivierung entfernt weder Paket noch Historie.
+
+## Cross-Module-Beziehungen
+
+Cross-Module-Foreign-Keys sind seltene, explizite Ausnahmen. Bevorzugt werden IDs und
+versionierte Query-/Service-Contracts statt Imports fremder ORM-Modelle. Ist ein FK
+fachlich unvermeidbar, müssen dokumentiert sein:
+
+- Owner der Quell- und Zieltabelle;
+- passende Manifestabhängigkeit;
+- Erstellungs- und Migrationsreihenfolge;
+- `ON DELETE`-/`ON UPDATE`-Semantik;
+- Verhalten bei Deaktivierung und inkompatiblen Modulversionen.
+
+Eine Migration darf nie eigenmächtig eine fremde Tabelle ändern. Solche Änderungen
+benötigen ein eigenes Architektur-/Migrations-Issue und Review beider Owner.
+Schemaübergreifende räumliche Abfragen bleiben erlaubt. Module exponieren sie nach
+außen über Query-/Service-Contracts statt über fremde ORM-Imports.
+
+## PostGIS
+
+Die Extension `postgis` wird genau einmal vom Host beziehungsweise der
+Betriebsumgebung bereitgestellt. Module dürfen Geometry-/Geography-Spalten,
+räumliche Indizes und Funktionen wie `ST_Intersects` oder `ST_DWithin` verwenden.
+Sie dürfen die Extension weder installieren noch entfernen. Explizit qualifizierte
+Modultabellen verhindern schemaabhängige Unterschiede zwischen Umgebungen.
+
+## Installieren, Deaktivieren und Entfernen
+
+Installation folgt fail-closed:
+
+1. Manifest und Kompatibilität validieren;
+2. Persistence-Ownership und Migrationsquellen im Preflight prüfen;
+3. Backup und Zielrevisionen prüfen;
+4. Migrationen in Host-/Dependency-Reihenfolge ausführen;
+5. erst nach erfolgreicher Migration das Modul aktivieren.
+
+Schlägt eine Migration fehl, stoppt das Deployment. Der Fehler enthält nach
+Möglichkeit Modul-ID, Revision, Schema und Phase. Erfolgreich abgeschlossene frühere
+Revisionen bleiben über Alembic diagnostizierbar; die fehlgeschlagene Revision wird
+bei transaktionaler DDL zurückgerollt.
+
+Deaktivieren entfernt Router, Jobs und Subscriber, führt aber **keinen Downgrade**
+aus. Tabellen, Alembic-Quellen und Daten bleiben erhalten. Auch das Entfernen eines
+Modulpakets darf Tabellen nicht automatisch löschen. Zuerst muss eine explizite,
+administrativ bestätigte Datenhaltungs-/Export-/Löschentscheidung erfolgen.
+
+Downgrades werden nur mit einer expliziten Zielrevision ausgeführt. Ein
+Modulversionswechsel oder eine geänderte Enablement-Liste löst niemals still einen
+Downgrade aus. Vor einem Downgrade werden aktuelle Version, Zielversion,
+Kompatibilität, Datenverlust und Backup geprüft.
+
+## Production-Migrationsstrategie
+
+- Veröffentlichte Revisionen bis einschließlich `20260825_0034` bleiben
+  unverändert und Host-/Legacy-owned.
+- Bestehende Tabellen verbleiben zunächst im aktuellen Schema und im
+  `LegacyPersistenceProvider`.
+- Eine spätere Fachmigration darf Tabellen schrittweise mit
+  `ALTER TABLE ... SET SCHEMA` oder einer geprüften Copy-/Rename-Strategie
+  übernehmen. Sie benötigt ein eigenes Issue, Backup-, Locking-, Laufzeit- und
+  Rollback-Konzept.
+- Es gibt keinen Datenbank-Rebuild und keinen Reimport von Production-Daten.
+- Ein fehlgeschlagenes Migrationspreflight beziehungsweise Upgrade verhindert die
+  Aktivierung des neuen Releases.
+
+## Observability
+
+Migrationslogs verwenden die niedrig-kardinalen Felder `module_id`, `revision`,
+`schema` und `migration_phase`. Gültige Phasen sind `preflight`,
+`upgrade_started`, `upgrade_completed` und `upgrade_failed`. Verbindungs-URLs,
+SQL-Payloads und Secrets werden nicht protokolliert.
+
+## Folgen
+
+Neue Module können Tabellen besitzen, ohne die zentrale Alembic-Modellimportliste zu
+erweitern. Schemas machen Ownership und Namenskollisionen sichtbar, während
+Cross-Schema-PostGIS-Abfragen erhalten bleiben. Die bestehende Datenbank, Historie
+und der Production-Deploy bleiben kompatibel.
+
+Der Preis ist eine koordinierte lineare Revisionserstellung: unabhängige Module
+können nicht beliebig gleichzeitig neue Heads veröffentlichen. Für den modularen
+Monolithen ist diese geringere Komplexität derzeit wichtiger. Sollte echte externe
+Distribution später parallele Release-Zyklen erfordern, muss ein neues ADR mehrere
+Heads oder eine andere Koordination bewerten; #97 führt sie nicht vorsorglich ein.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,7 +11,7 @@ bei reinen Dokumentationsänderungen nicht.
 | --- | --- | --- |
 | Backend CI | `backend-lint` | Ruff sowie Import- und Startkonfigurations-Smoke-Test |
 | Backend CI | `backend-tests` | vollständige Pytest-Suite |
-| Backend CI | `backend-migrations` | genau ein Alembic-Head und Upgrade einer frischen PostGIS-Datenbank |
+| Backend CI | `backend-migrations` | genau ein Alembic-Head, Upgrade einer frischen PostGIS-Datenbank sowie Modul-Persistence-, Schema- und Migrationscontracts |
 | Frontend CI | `frontend-tests` | vollständige Vitest-Suite |
 | Frontend CI | `frontend-typecheck` | Nuxt-/Vue-Typecheck |
 | Frontend CI | `frontend-build` | produktiver Nuxt-Build und zentraler SSR-/SEO-Audit über Sitemap-, Noindex-, Redirect- und Fehler-Routen |
@@ -97,12 +97,13 @@ pnpm test:e2e
 Produktivdatenbanken dürfen niemals als E2E-Ziel verwendet werden. Der Seed ist
 für eine frische, isolierte Datenbank vorgesehen.
 
-`alembic check` ist derzeit absichtlich kein CI-Schritt. Die Autogenerierung
-behandelt Tabellen der von PostGIS installierten Tiger-/Topology-Schemata sowie
-einzelne bestehende, nicht in der Alembic-Metadatenmenge registrierte Objekte als
-zu entfernende Anwendungstabellen. Das erzeugt auf einer korrekt migrierten,
-frischen Datenbank Fehlalarme. Bis die Alembic-Filter und die Metadatenregistrierung
-bereinigt sind, prüft CI deshalb den eindeutigen Head und das vollständige Upgrade.
+`alembic check` ist derzeit absichtlich kein CI-Schritt. Die modulare
+Metadata-Registry filtert PostGIS-Systemschemas und erzeugt für nicht registrierte
+Legacy-Objekte keine automatischen Drops mehr. Einzelne historische Unterschiede
+bei Nullability und serverseitigen Defaults erzeugen auf einer korrekt migrierten,
+frischen Datenbank aber weiterhin nicht-destruktive Fehlalarme. Bis diese Legacy-
+Baseline separat bereinigt ist, prüft CI deshalb den eindeutigen Head, das
+vollständige Upgrade und die gezielten Modul-Autogenerate-Contracts.
 
 ## Security-Workflow
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,6 +55,14 @@ uv run alembic heads
 uv run alembic upgrade head
 ```
 
+Der bestehende Befehl bleibt für die veröffentlichte Host-/Legacy-Historie
+maßgeblich. Installierte Module mit eigenen Migrationen werden vor ihrer Aktivierung
+zusätzlich über den in
+[ADR #97](architecture/adr-module-database-and-migration-ownership.md)
+beschriebenen Persistence-Preflight geprüft. Bereits angewandte Migrationsquellen
+müssen auch bei deaktiviertem Modul installiert und im Migrationsinventar auflösbar
+bleiben; Deaktivierung führt nie automatisch einen Downgrade aus.
+
 Die produktive Installation verwendet keine Development-Extras. CI und lokale
 Vorabprüfungen ergänzen dagegen `--extra dev` für Pytest und Ruff. Beide Pfade
 verwenden dasselbe `backend/uv.lock`; eine Auflösung auf dem Produktionsserver

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -59,7 +59,7 @@ Sub-Interfaces `context.api` und `context.lifecycle`.
 |---|---|---|
 | `api` | `ApiRegistrar` | durch die Runtime implementiert |
 | `lifecycle` | `LifecycleRegistrar` | durch die Runtime implementiert |
-| `database` | `DatabaseSessionProvider` | optionaler Port; Adapter folgt mit DB-/Migrationsarbeit |
+| `database` | `DatabaseSessionProvider` | transaktionaler Hostadapter aus #97 |
 | `events` | `EventBusPort` | In-Process Dispatch und transaktionale Outbox aus #96 |
 | `services` | `ServiceRegistryPort` | optionaler Port; Registry folgt in #98 |
 | `permissions` | `PermissionPort` | optionaler Port; Policy Engine folgt in #104 |
@@ -83,7 +83,11 @@ einer SQLAlchemy-`AsyncSession`. SQLAlchemy ist bewusst Teil dieses stabilen Por
 weil es eine Kerntechnologie des Hosts ist und eine künstliche parallele ORM-
 Abstraktion keinen Mehrwert bietet. Fachliche ORM-Modelle, globale Session Factories,
 Engines und `app.db.session` sind dagegen nicht Teil des SDK. Ownership und modulare
-Migrationen bleiben #97 vorbehalten.
+Migrationen sind im
+[Datenbank- und Migrationsvertrag](database-and-migrations.md) definiert.
+`ModulePersistenceContribution` hängt Metadata und eine optionale installierte
+`ModuleMigrationSource` passiv an die `ModuleDefinition`; Alembic muss dafür weder
+`register()` ausführen noch Modul-Interna durchsuchen.
 
 ### Cache und Storage
 
@@ -131,8 +135,10 @@ unter `app.*` ausschließlich den öffentlichen SDK-Pfad verwendet.
 
 `MODULE_SDK_VERSION` ist eine SemVer-Version und unabhängig von Release-SHA und
 Host-API-Version. Der Context wurde unter SDK `1.0.0` eingeführt. Die additive
-Event-/Outbox-API aus #96 erhöht die SDK-Version auf `1.1.0`; der minimale
-`DomainEvent`-Contract aus 1.0 und die #94-Proxys bleiben kompatibel.
+Event-/Outbox-API aus #96 erhöhte die SDK-Version auf `1.1.0`. Die additiven
+Persistence-Contracts und der produktive Datenbank-Session-Adapter aus #97 erhöhen
+sie auf `1.2.0`; der minimale `DomainEvent`-Contract aus 1.0 und die #94-Proxys
+bleiben kompatibel.
 
 - **MAJOR:** Entfernen oder Umbenennen öffentlicher Methoden, inkompatible Änderungen
   an vorhandener Semantik oder eine inkompatible Context-Struktur.

--- a/docs/modules/database-and-migrations.md
+++ b/docs/modules/database-and-migrations.md
@@ -1,0 +1,154 @@
+# Datenbank und Migrationen für Backend-Module
+
+Diese Anleitung beschreibt den Persistence-Contract aus
+[ADR #97](../architecture/adr-module-database-and-migration-ownership.md). Alle
+Module verwenden dieselbe PostgreSQL-/PostGIS-Datenbank. Ein Modul besitzt ein
+Schema und Metadata, keine eigene Datenbank.
+
+## Metadata deklarieren
+
+Das Manifest ist die einzige deklarative Quelle für das Schema:
+
+```json
+{
+  "persistence": {
+    "schema": "example_module",
+    "migrations": true
+  }
+}
+```
+
+Tabellen werden explizit qualifiziert:
+
+```python
+from sqlalchemy import Column, Integer, MetaData, String, Table
+
+metadata = MetaData()
+items = Table(
+    "items",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("name", String(120), nullable=False),
+    schema="example_module",
+)
+```
+
+Die passive Definition verbindet Manifest und Metadata:
+
+```python
+from app.platform.modules.sdk import (
+    ModuleDefinition,
+    ModuleMigrationSource,
+    ModulePersistenceContribution,
+)
+
+DEFINITION = ModuleDefinition(
+    manifest=MANIFEST,
+    loader=ExampleModule,
+    origin="example_module",
+    declared_id=MANIFEST.id,
+    persistence=ModulePersistenceContribution(
+        module_id=MANIFEST.id,
+        metadata=metadata,
+        schema="example_module",
+        migration_source=ModuleMigrationSource(
+            package="example_module",
+            resource="migrations",
+            revision_namespace="mod_example_module",
+        ),
+    ),
+)
+```
+
+Der Ressourcenpfad ist relativ zu einem installierten Python-Paket. URLs, absolute
+Pfade und Runtime-Downloads sind nicht erlaubt. `register()` wird für Migration
+Discovery nicht ausgeführt.
+
+## Migration anlegen
+
+Die erste Revision eines Moduls erstellt das Schema und qualifiziert jede Operation:
+
+```python
+revision = "mod_example_module_20260825_0001"
+down_revision = "<letzte-geordnete-revision>"
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS example_module")
+    op.create_table(
+        "items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        schema="example_module",
+    )
+```
+
+Revision-IDs beginnen immer mit `mod_<normalisierte-modul-id>_`. Der aktuelle
+Contract verwendet einen global linearen Head und keine Branch Labels. Vor dem
+Commit müssen Head, Upgrade, expliziter gezielter Downgrade und erneutes Upgrade auf
+einer frischen PostGIS-Datenbank geprüft werden.
+
+Eine Migration ändert ausschließlich Tabellen und Schemas ihres Moduls. Für eine
+unvermeidbare Cross-Module-Änderung ist vorab ein eigenes Architektur- und
+Migrations-Issue erforderlich. Fremde ORM-Modelle werden nicht importiert.
+
+## Reihenfolge und Preflight
+
+Bei der erstmaligen Aufnahme migriert der Host zuerst seine Infrastruktur. Danach
+folgen Module in der bereits validierten Dependency-Reihenfolge aus dem Manifest;
+unabhängige Module sind nach ID sortiert. Spätere Revisionen werden unabhängig vom
+Owner am einen globalen Head angehängt. `MigrationCoordinator.preflight()` prüft:
+
+- genau einen globalen Alembic-Head;
+- auflösbare installierte Migrationsressourcen;
+- eindeutige Schema-Ownership;
+- passende Revision-Namespaces;
+- Host- und Modulgruppen in Dependency-Reihenfolge.
+
+Migrationen sind vertrauenswürdiger Code mit weitreichenden DB-Rechten. Jede
+Revision benötigt manuelles Review; der Preflight ist keine Sandbox.
+
+## Session und Transaktionen
+
+`context.database.session()` öffnet eine Host-Session mit einer Transaktionsgrenze.
+Der Context Manager committed bei Erfolg und rollt bei Fehler zurück:
+
+```python
+if context.database is None:
+    raise RuntimeError("database capability required")
+
+async with context.database.session() as session:
+    session.add(record)
+```
+
+Module importieren weder globale Engine noch `AsyncSessionLocal`. Fachliche
+Repositories und ORM-Modelle bleiben im eigenen Modul.
+
+## Lifecycle und Datenhaltbarkeit
+
+- **Installieren:** Manifest validieren, Preflight, Backup, Migration, danach erst
+  aktivieren.
+- **Deaktivieren:** Runtime-Beiträge entfernen; kein Downgrade, keine Datenlöschung.
+- **Entfernen:** Tabellen bleiben standardmäßig erhalten. Löschen erfolgt nur nach
+  expliziter administrativer Entscheidung.
+- **Downgrade:** nur mit benannter Zielrevision und geprüftem Datenverlust-/Backup-
+  Plan; nie automatisch durch Versions- oder Enablement-Änderungen.
+
+Bereits angewandte Migrationsquellen müssen im Deployment-Inventar auflösbar
+bleiben, auch wenn ein Modul deaktiviert ist. Sonst kann Alembic den aktuellen
+Datenbankstand nicht sicher koordinieren.
+
+## Legacy und bestehende Daten
+
+`LegacyPersistenceProvider` hält das bestehende `Base.metadata` vollständig im
+Autogenerate-Ziel. Bestehende Tabellen verbleiben im bisherigen Schema. Ein späterer
+Umzug verwendet eine eigene, geprüfte Migration wie `ALTER TABLE ... SET SCHEMA`;
+er ist keine Voraussetzung für neue Module und nicht Teil von #97.
+
+Autogenerate schlägt keine Drops für reflektierte Tabellen, Indizes oder Constraints
+vor, denen kein registriertes Metadata-Objekt gegenübersteht. Ein echter Drop wird
+immer explizit geschrieben und hinsichtlich Ownership und Datenverlust geprüft.
+
+PostGIS bleibt Host-owned. Module dürfen räumliche Typen, Indizes und
+schemaübergreifende Funktionen verwenden, installieren oder entfernen die Extension
+aber nicht.

--- a/docs/modules/module-manifest-v1.md
+++ b/docs/modules/module-manifest-v1.md
@@ -101,7 +101,7 @@ definiert. Auswertung und Registrierung der Permissions folgen in #104.
 | `permissions` | stabile, vom Modul namespacete Permission-IDs |
 | `config.namespace` | eindeutige Identität für die spätere Config Runtime aus #99 |
 | `persistence.schema` | deklarativer, unquoted-sicherer PostgreSQL-Schemaname |
-| `persistence.migrations` | kündigt eigene Migrationen für #97 deklarativ an |
+| `persistence.migrations` | kündigt eigene, durch #97 koordinierte Migrationen an |
 
 Backend-only-, Frontend-only- und kombinierte Module sind darstellbar. Die
 Package-Felder lösen in #93 weder Imports noch Downloads aus. Das Manifest enthält
@@ -109,8 +109,9 @@ keine Secrets, SQL-Anweisungen, Entry-Point-Ausführung oder Settingswerte.
 
 `config.namespace` ist über die validierte Manifestmenge eindeutig und stabil.
 Environment-Namen, Secret-Zugriff und Settings-Lifecycle werden erst in #99
-definiert. Persistence-Metadaten erzeugen weder DB-Schemas noch Migrationen; der
-Alembic-Runner bleibt bis #97 unverändert.
+definiert. Persistence-Metadaten führen selbst keine DB-Operation aus; Metadata,
+Migration Sources, Schema-Ownership und Alembic-Preflight sind im
+[Datenbank- und Migrationsvertrag](database-and-migrations.md) beschrieben.
 
 ## Dependency-Semantik
 

--- a/docs/modules/schema/module-manifest-v1.schema.json
+++ b/docs/modules/schema/module-manifest-v1.schema.json
@@ -76,7 +76,7 @@
     },
     "ModulePersistence": {
       "additionalProperties": false,
-      "description": "Deklarative Metadaten für das spätere Migrations-Ownership aus #97.",
+      "description": "Deklarative Schema- und Migrations-Ownership aus #97.",
       "properties": {
         "migrations": {
           "default": false,


### PR DESCRIPTION
Part of #91  
Closes #97

## Ausgangslage

Alembic verwendete bisher eine zentrale Fachmodell-Importliste und ein gemeinsames `Base.metadata`. Für den modularen Host fehlten klare Verträge für Tabellen-, Schema-, Metadata- und Migrations-Ownership.

Die bestehende PostgreSQL-/PostGIS-Datenbank und alle Produktionsdaten müssen dabei ohne Big-Bang-Migration erhalten bleiben.

## Umsetzung

- Host-owned `PersistenceRegistry` für Legacy- und Modul-Metadata
- `LegacyPersistenceProvider` für das bestehende `Base.metadata`
- passive Public-SDK-Contracts:
  - `ModulePersistenceContribution`
  - `ModuleMigrationSource`
- explizite PostgreSQL-Schema-Ownership pro Modul
- Validierung von:
  - doppelter Schema-Ownership
  - Tabellen außerhalb des eigenen Modulschemas
  - Manifest-/Contribution-Abweichungen
  - Migration Sources und Revision-Namespaces
- deterministische Migrationsreihenfolge über den Dependency-Resolver aus #93
- global linearer Alembic-Head mit namespaceten Modulrevisionen
- `MigrationCoordinator` mit:
  - Preflight
  - Upgrade
  - explizitem Downgrade
  - Modul- und Schemakontext bei Fehlern
- transaktionaler `DatabaseSessionProvider` im `ModuleContext`
- Alembic-Autogenerate ohne zentrale Fachmodell-Importliste
- Schutz vor impliziten Drops nicht registrierter Legacy-/PostGIS-Objekte
- Migration-CI um Modul-Persistence-Contracts erweitert

## Architekturentscheidung

Die gemeinsame PostgreSQL-/PostGIS-Datenbank bleibt erhalten.

Neue größere Module können künftig besitzen:

- eigene ORM-Modelle
- eigene SQLAlchemy-Metadata
- ein explizites PostgreSQL-Schema
- eigene Alembic-Migrationen

Der Host besitzt weiterhin:

- Engine und Session Factory
- Transaktionsgrenzen
- PostGIS-Extension
- Alembic-Konfiguration
- Migration Preflight und Koordination
- Host-Infrastruktur-Tabellen

PostGIS bleibt vollständig Host-owned.

## Migration und Kompatibilität

- keine bestehenden Fachtabellen verschoben
- keine Production-Daten neu aufgebaut oder importiert
- kein Datenbank-Rebuild
- Migration `20260825_0034` aus #96 bleibt unverändert und Host-owned
- bestehender `alembic upgrade head`-Pfad bleibt für Host und Legacy kompatibel
- Moduldeaktivierung führt weder Downgrade noch Datenlöschung aus
- Modulentfernung löscht Tabellen nicht automatisch
- Downgrades erfolgen ausschließlich explizit auf eine benannte Revision

## Dokumentation

Ergänzt wurden:

- ADR zur Datenbank- und Migrations-Ownership
- Anleitung für externe Modulentwickler
- Schema- und Revision-Naming
- Cross-Module-FK-Regeln
- Installations-, Deaktivierungs- und Entfernungslifecycle
- PostGIS-Ownership
- Production-Migrations- und Rollback-Strategie

Die Umsetzung basiert auf:

- ADR #92
- Manifest-/Dependency-Contract #93
- Backend Module Runtime #94
- Module SDK / ModuleContext #95
- Domain Events / Transactional Outbox #96

## Tests

- `uv run ruff check app tests`  
  Erfolgreich

- `uv run pytest`  
  742 Tests bestanden

- gezielte Manifest-, Runtime-, SDK- und Persistence-Tests  
  114 Tests bestanden

- Fresh PostgreSQL/PostGIS:
  - vollständiges Upgrade
  - `downgrade -1`
  - erneutes Upgrade  
  Erfolgreich

- Modul-Migrations-Fixtures:
  - Host → Modul A → abhängiges Modul B
  - expliziter Modul-Downgrade
  - erneutes Upgrade  
  Erfolgreich

- fehlerhafte Modulmigration:
  - Deployment stoppt
  - Modul-ID und Schema bleiben im Fehler sichtbar
  - vorheriger Revisionsstand bleibt diagnostizierbar  
  Erfolgreich

- PostgreSQL-Schemas:
  - identischer Tabellenname in zwei Modulschemas
  - Metadata-Aggregation
  - Autogenerate-Erkennung
  - Datenerhalt bei Deaktivierung  
  Erfolgreich

- PostGIS:
  - schemaübergreifendes `ST_Intersects`  
  Erfolgreich

- `uv lock --check`  
  Erfolgreich

- `alembic heads`  
  Genau `20260825_0034 (head)`

- FastAPI-Import-Smoke  
  Erfolgreich

- `pnpm audit:language`  
  475 Ressourcen geprüft, 0 unerlaubte Treffer

## Hinweis zu `alembic check`

Historische Nullability-Abweichungen verhindern weiterhin, dass `alembic check` als vollständiges CI-Gate aktiviert wird.

Die gefährlichen falschen Drop-Vorschläge für nicht registrierte Legacy- und PostGIS-Objekte werden mit dieser Änderung jedoch verhindert. Destruktive Änderungen müssen weiterhin als explizite, reviewpflichtige Migration umgesetzt werden.