### PR TITLE
feat(modules): add cross-module service registry

### DIFF
--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -16,8 +16,11 @@ from app.platform.modules.errors import (
     DuplicateConfigNamespaceError,
     DuplicateModuleIdError,
     DuplicatePersistenceSchemaError,
+    DuplicateServiceRegistrationError,
+    IncompatibleServiceVersionError,
     InvalidRuntimeVersionError,
     MissingModuleDependencyError,
+    MissingRequiredServiceError,
     ModuleCompatibilityError,
     ModuleDependencyCycleError,
     ModuleDependencyError,
@@ -32,6 +35,10 @@ from app.platform.modules.errors import (
     ModuleShutdownError,
     ModuleStartupError,
     ModuleValidationError,
+    ServiceContractMismatchError,
+    ServiceRegistryError,
+    ServiceRegistrySealedError,
+    UndeclaredServiceDependencyError,
     UnsupportedManifestVersionError,
 )
 from app.platform.modules.manifest import (
@@ -61,6 +68,7 @@ from app.platform.modules.sdk import (
     ModuleMigrationSource,
     ModulePersistenceContribution,
 )
+from app.platform.modules.services import ServiceRegistry
 
 __all__ = [
     "ENTRY_POINT_GROUP",
@@ -69,10 +77,13 @@ __all__ = [
     "DuplicateConfigNamespaceError",
     "DuplicateModuleIdError",
     "DuplicatePersistenceSchemaError",
+    "DuplicateServiceRegistrationError",
     "EntryPointModuleDiscovery",
     "FirstPartyModuleDiscovery",
+    "IncompatibleServiceVersionError",
     "InvalidRuntimeVersionError",
     "MissingModuleDependencyError",
+    "MissingRequiredServiceError",
     "ModuleBackendPackage",
     "ModuleCompatibilityError",
     "ModuleConfig",
@@ -104,6 +115,11 @@ __all__ = [
     "ModuleShutdownError",
     "ModuleStartupError",
     "ModuleValidationError",
+    "ServiceContractMismatchError",
+    "ServiceRegistry",
+    "ServiceRegistryError",
+    "ServiceRegistrySealedError",
+    "UndeclaredServiceDependencyError",
     "UnsupportedManifestVersionError",
     "create_module_runtime",
     "module_manifest_json_schema",

--- a/backend/app/platform/modules/context.py
+++ b/backend/app/platform/modules/context.py
@@ -24,6 +24,7 @@ from app.platform.modules.sdk import (
     StoragePort,
     TracerPort,
 )
+from app.platform.modules.services import ServiceRegistry
 
 if TYPE_CHECKING:
     from app.platform.events.bus import InProcessEventBus
@@ -102,6 +103,13 @@ class ModuleContextFactory:
     ) -> None:
         self._services = services or ModuleHostServices()
         self._event_bus = event_bus
+        self._service_registry: ServiceRegistry | None = None
+        if self._services.services is None:
+            self._service_registry = ServiceRegistry()
+
+    @property
+    def service_registry(self) -> "ServiceRegistry | None":
+        return self._service_registry
 
     def create(
         self,
@@ -122,6 +130,9 @@ class ModuleContextFactory:
         event_adapter = self._services.events
         if event_adapter is None and self._event_bus is not None:
             event_adapter = HostEventBusAdapter(self._event_bus, module_id=manifest.id)
+        service_adapter = self._services.services
+        if service_adapter is None and self._service_registry is not None:
+            service_adapter = self._service_registry.bind(manifest)
         return ModuleContext(
             module_id=manifest.id,
             module_version=manifest.version,
@@ -130,7 +141,7 @@ class ModuleContextFactory:
             observability=observability,
             database=self._services.database,
             events=event_adapter,
-            services=self._services.services,
+            services=service_adapter,
             permissions=self._services.permissions,
             cache=self._services.cache,
             storage=self._services.storage,

--- a/backend/app/platform/modules/errors.py
+++ b/backend/app/platform/modules/errors.py
@@ -257,3 +257,66 @@ class ModulePersistenceError(RuntimeError):
         self.module_id = module_id
         self.schema = schema
         self.phase = phase
+
+
+class ServiceRegistryError(RuntimeError):
+    """Basisklasse für verletzte Cross-Module-Service-Verträge."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        service_id: str | None = None,
+        requested_version: int | None = None,
+        provider_module: str | None = None,
+        consumer_module: str | None = None,
+        available_versions: Sequence[int] = (),
+        available_services: Sequence[str] = (),
+    ) -> None:
+        context: list[str] = []
+        if service_id is not None:
+            context.append(f"service_id={service_id}")
+        if requested_version is not None:
+            context.append(f"requested_version={requested_version}")
+        if provider_module is not None:
+            context.append(f"provider_module={provider_module}")
+        if consumer_module is not None:
+            context.append(f"consumer_module={consumer_module}")
+        if available_versions:
+            context.append(
+                "available_versions=" + ",".join(str(version) for version in available_versions)
+            )
+        if available_services:
+            context.append("available_services=" + ",".join(available_services))
+        suffix = f" ({', '.join(context)})" if context else ""
+        super().__init__(f"Service registry error{suffix}: {message}")
+        self.service_id = service_id
+        self.requested_version = requested_version
+        self.provider_module = provider_module
+        self.consumer_module = consumer_module
+        self.available_versions = tuple(available_versions)
+        self.available_services = tuple(available_services)
+
+
+class DuplicateServiceRegistrationError(ServiceRegistryError):
+    """Dieselbe Service-ID und Version wurde mehr als einmal registriert."""
+
+
+class MissingRequiredServiceError(ServiceRegistryError):
+    """Ein erforderlicher öffentlicher Service ist nicht registriert."""
+
+
+class IncompatibleServiceVersionError(ServiceRegistryError):
+    """Eine Service-ID existiert, aber nicht in der angeforderten Version."""
+
+
+class ServiceContractMismatchError(ServiceRegistryError):
+    """Die Service-ID und Version sind an einen anderen Protocol-Typ gebunden."""
+
+
+class UndeclaredServiceDependencyError(ServiceRegistryError):
+    """Der Consumer hat den Service-Owner nicht passend im Manifest deklariert."""
+
+
+class ServiceRegistrySealedError(ServiceRegistryError):
+    """Nach Abschluss der Modulregistrierung sind Mutationen verboten."""

--- a/backend/app/platform/modules/import_boundaries.py
+++ b/backend/app/platform/modules/import_boundaries.py
@@ -1,0 +1,145 @@
+"""AST-basierte Strukturregeln für modulübergreifende Python-Imports."""
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+_ORM_IMPORT_PREFIXES = ("sqlalchemy", "sqlmodel")
+_ORM_NAMES = frozenset(
+    {"AsyncSession", "DeclarativeBase", "Mapped", "Session", "mapped_column", "relationship"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleImportViolation:
+    consumer_module: str
+    source: Path
+    imported_module: str
+    allowed_alternative: str
+    line: int
+
+    def __str__(self) -> str:
+        return (
+            f'Module "{self.consumer_module}" imports forbidden foreign module '
+            f'"{self.imported_module}" in {self.source}:{self.line}; import only the public '
+            f'contract namespace "{self.allowed_alternative}".'
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ContractPersistenceLeak:
+    source: Path
+    name: str
+    line: int
+
+    def __str__(self) -> str:
+        return f'Public contract {self.source}:{self.line} leaks persistence type "{self.name}".'
+
+
+def find_cross_module_import_violations(
+    modules_root: Path,
+    *,
+    package_prefix: str,
+) -> tuple[ModuleImportViolation, ...]:
+    """Erlaube von einem fremden Modul ausschließlich dessen contracts-Namespace."""
+
+    prefix = tuple(package_prefix.split("."))
+    violations: list[ModuleImportViolation] = []
+    for source in sorted(modules_root.rglob("*.py")):
+        relative = source.relative_to(modules_root)
+        if len(relative.parts) < 2:
+            continue
+        consumer = relative.parts[0]
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        current_package = _current_package(prefix, relative)
+        for node in ast.walk(tree):
+            imported_names = _imported_names(node, current_package)
+            forbidden_by_provider: dict[str, tuple[str, tuple[str, ...]]] = {}
+            for imported in imported_names:
+                parts = tuple(imported.split("."))
+                if parts[: len(prefix)] != prefix or len(parts) <= len(prefix):
+                    continue
+                provider = parts[len(prefix)]
+                if provider == consumer:
+                    continue
+                public_contract = (
+                    len(parts) > len(prefix) + 1 and parts[len(prefix) + 1] == "contracts"
+                )
+                if public_contract:
+                    continue
+                current = forbidden_by_provider.get(provider)
+                if current is None or len(parts) < len(current[1]):
+                    forbidden_by_provider[provider] = (imported, parts)
+            for provider, (imported, _) in forbidden_by_provider.items():
+                violations.append(
+                    ModuleImportViolation(
+                        consumer_module=consumer,
+                        source=source,
+                        imported_module=imported,
+                        allowed_alternative=".".join((*prefix, provider, "contracts")),
+                        line=node.lineno,
+                    )
+                )
+    return tuple(violations)
+
+
+def find_contract_persistence_leaks(modules_root: Path) -> tuple[ContractPersistenceLeak, ...]:
+    """Ermittelt ORM-/Session-Typen in allen öffentlichen contracts-Paketen."""
+
+    leaks: list[ContractPersistenceLeak] = []
+    for source in sorted(modules_root.rglob("*.py")):
+        relative = source.relative_to(modules_root)
+        if "contracts" not in relative.parts and source.stem != "contracts":
+            continue
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith(_ORM_IMPORT_PREFIXES):
+                        leaks.append(ContractPersistenceLeak(source, alias.name, node.lineno))
+            elif isinstance(node, ast.ImportFrom):
+                if node.module and node.module.startswith(_ORM_IMPORT_PREFIXES):
+                    leaks.append(ContractPersistenceLeak(source, node.module, node.lineno))
+                    leaks.extend(
+                        ContractPersistenceLeak(source, alias.name, node.lineno)
+                        for alias in node.names
+                        if alias.name in _ORM_NAMES
+                    )
+            elif isinstance(node, ast.Name) and node.id in _ORM_NAMES:
+                leaks.append(ContractPersistenceLeak(source, node.id, node.lineno))
+            elif isinstance(node, ast.Attribute) and node.attr in _ORM_NAMES:
+                leaks.append(ContractPersistenceLeak(source, node.attr, node.lineno))
+    return tuple(leaks)
+
+
+def _current_package(prefix: tuple[str, ...], relative: Path) -> tuple[str, ...]:
+    return (*prefix, *relative.parent.parts)
+
+
+def _imported_names(node: ast.AST, current_package: tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(node, ast.Import):
+        return tuple(alias.name for alias in node.names)
+    if not isinstance(node, ast.ImportFrom):
+        return ()
+    if node.level == 0:
+        base = tuple(node.module.split(".")) if node.module else ()
+    else:
+        keep = len(current_package) - (node.level - 1)
+        relative_base = current_package[: max(keep, 0)]
+        suffix = tuple(node.module.split(".")) if node.module else ()
+        base = (*relative_base, *suffix)
+    if not base:
+        return ()
+    base_name = ".".join(base)
+    imported_aliases = tuple(
+        f"{base_name}.{alias.name}" for alias in node.names if alias.name != "*"
+    )
+    return (base_name, *imported_aliases)
+
+
+__all__ = [
+    "ContractPersistenceLeak",
+    "ModuleImportViolation",
+    "find_contract_persistence_leaks",
+    "find_cross_module_import_violations",
+]

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -24,9 +24,10 @@ from app.platform.modules.errors import (
 )
 from app.platform.modules.manifest import ModuleManifestV1, parse_manifest, validate_manifests
 from app.platform.modules.sdk import BackendModule, ModuleContext, ModuleDefinition
+from app.platform.modules.services import ServiceRegistry
 
 logger = logging.getLogger(__name__)
-MODULE_SDK_VERSION = "1.2.0"
+MODULE_SDK_VERSION = "1.3.0"
 
 
 @dataclass(slots=True)
@@ -69,8 +70,14 @@ class ModuleRegistry:
 class ModuleRuntime:
     """Registriert Router und orchestriert asynchrone Module-Lifecycles."""
 
-    def __init__(self, registry: ModuleRegistry) -> None:
+    def __init__(
+        self,
+        registry: ModuleRegistry,
+        *,
+        service_registry: ServiceRegistry | None = None,
+    ) -> None:
         self.registry = registry
+        self._service_registry = service_registry
         self._attached_app: FastAPI | None = None
         self._started: list[tuple[ModuleRecord, LifecycleContribution]] = []
         self._running = False
@@ -100,6 +107,9 @@ class ModuleRuntime:
                 ) from exc
             record.registered = True
             logger.info("Module registration completed", extra=fields)
+
+        if self._service_registry is not None:
+            self._service_registry.seal()
 
         for record in self.registry.records:
             for contribution in record.registration.routers:
@@ -220,7 +230,10 @@ def create_module_runtime(
                 registration=registration,
             )
         )
-    return ModuleRuntime(ModuleRegistry(records))
+    return ModuleRuntime(
+        ModuleRegistry(records),
+        service_registry=active_context_factory.service_registry,
+    )
 
 
 def resolve_module_definitions(

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -229,7 +229,22 @@ class EventBusPort(Protocol):
 
 
 class ServiceRegistryPort(Protocol):
-    """Löst ausschließlich explizite öffentliche Cross-Module-Contracts auf."""
+    """Registriert und löst explizite öffentliche Cross-Module-Contracts auf."""
+
+    def register(
+        self,
+        contract: type[T],
+        implementation: T,
+        *,
+        service_id: str,
+        version: int,
+        deprecated_since: str | None = None,
+        replacement: str | None = None,
+    ) -> None: ...
+
+    def require(self, contract: type[T], *, service_id: str, version: int) -> T: ...
+
+    def optional(self, contract: type[T], *, service_id: str, version: int) -> T | None: ...
 
     def resolve(self, contract: type[T]) -> T: ...
 

--- a/backend/app/platform/modules/services.py
+++ b/backend/app/platform/modules/services.py
@@ -1,0 +1,309 @@
+"""Runtime-skopierte Registry für öffentliche Cross-Module-Service-Contracts."""
+
+import re
+from dataclasses import dataclass
+from typing import TypeVar, cast
+
+from app.platform.modules.errors import (
+    DuplicateServiceRegistrationError,
+    IncompatibleServiceVersionError,
+    MissingRequiredServiceError,
+    ServiceContractMismatchError,
+    ServiceRegistryError,
+    ServiceRegistrySealedError,
+    UndeclaredServiceDependencyError,
+)
+from app.platform.modules.manifest import ModuleManifestV1
+
+T = TypeVar("T")
+_SERVICE_ID = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$")
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredService:
+    service_id: str
+    version: int
+    provider_module: str
+    contract: type[object]
+    implementation: object
+    deprecated_since: str | None = None
+    replacement: str | None = None
+
+
+class ServiceRegistry:
+    """Host-owned Registry mit exakten, parallel registrierbaren Integer-Versionen."""
+
+    def __init__(self) -> None:
+        self._services: dict[tuple[str, int], RegisteredService] = {}
+        self._sealed = False
+
+    @property
+    def services(self) -> tuple[RegisteredService, ...]:
+        return tuple(self._services[key] for key in sorted(self._services))
+
+    @property
+    def sealed(self) -> bool:
+        return self._sealed
+
+    def bind(self, manifest: ModuleManifestV1) -> "ModuleServiceRegistryAdapter":
+        return ModuleServiceRegistryAdapter(self, manifest)
+
+    def register(
+        self,
+        *,
+        provider_module: str,
+        contract: type[T],
+        implementation: T,
+        service_id: str,
+        version: int,
+        deprecated_since: str | None = None,
+        replacement: str | None = None,
+    ) -> None:
+        owner = _validate_service_reference(service_id, version, contract)
+        _validate_deprecation_metadata(
+            service_id=service_id,
+            version=version,
+            deprecated_since=deprecated_since,
+            replacement=replacement,
+        )
+        if implementation is None:
+            raise ServiceRegistryError(
+                "Service implementations must not be None.",
+                service_id=service_id,
+                requested_version=version,
+                provider_module=provider_module,
+            )
+        if self._sealed:
+            raise ServiceRegistrySealedError(
+                "Service registration is closed.",
+                service_id=service_id,
+                requested_version=version,
+                provider_module=provider_module,
+            )
+        if owner != provider_module:
+            raise ServiceRegistryError(
+                "Providers may register services only in their own module namespace.",
+                service_id=service_id,
+                requested_version=version,
+                provider_module=provider_module,
+            )
+        key = (service_id, version)
+        if key in self._services:
+            registered = self._services[key]
+            raise DuplicateServiceRegistrationError(
+                "The service ID and version are already registered.",
+                service_id=service_id,
+                requested_version=version,
+                provider_module=registered.provider_module,
+            )
+        self._services[key] = RegisteredService(
+            service_id=service_id,
+            version=version,
+            provider_module=provider_module,
+            contract=cast(type[object], contract),
+            implementation=implementation,
+            deprecated_since=deprecated_since,
+            replacement=replacement,
+        )
+
+    def lookup(
+        self,
+        contract: type[T],
+        *,
+        service_id: str,
+        version: int,
+        consumer_module: str,
+        required: bool,
+    ) -> T | None:
+        provider_module = _validate_service_reference(service_id, version, contract)
+        registered = self._services.get((service_id, version))
+        if registered is None:
+            available_versions = self._available_versions(service_id)
+            if available_versions:
+                raise IncompatibleServiceVersionError(
+                    "The requested exact service version is not registered.",
+                    service_id=service_id,
+                    requested_version=version,
+                    provider_module=provider_module,
+                    consumer_module=consumer_module,
+                    available_versions=available_versions,
+                    available_services=self._available_service_references(),
+                )
+            if required:
+                raise MissingRequiredServiceError(
+                    "The required service is not registered.",
+                    service_id=service_id,
+                    requested_version=version,
+                    provider_module=provider_module,
+                    consumer_module=consumer_module,
+                    available_services=self._available_service_references(),
+                )
+            return None
+        if registered.contract is not contract:
+            raise ServiceContractMismatchError(
+                "The registered service uses a different public contract type.",
+                service_id=service_id,
+                requested_version=version,
+                provider_module=registered.provider_module,
+                consumer_module=consumer_module,
+            )
+        return cast(T, registered.implementation)
+
+    def resolve_unique(self, contract: type[T], *, consumer_module: str) -> RegisteredService:
+        matches = [service for service in self._services.values() if service.contract is contract]
+        if len(matches) != 1:
+            raise MissingRequiredServiceError(
+                "Compatibility resolve() requires exactly one registered contract; "
+                "use require() with an explicit service ID and version.",
+                consumer_module=consumer_module,
+                available_services=self._available_service_references(),
+            )
+        return matches[0]
+
+    def seal(self) -> None:
+        self._sealed = True
+
+    def _available_versions(self, service_id: str) -> tuple[int, ...]:
+        return tuple(
+            sorted(version for candidate, version in self._services if candidate == service_id)
+        )
+
+    def _available_service_references(self) -> tuple[str, ...]:
+        return tuple(f"{service_id}@{version}" for service_id, version in sorted(self._services))
+
+
+class ModuleServiceRegistryAdapter:
+    """An genau ein Provider-/Consumer-Modul gebundener öffentlicher SDK-Adapter."""
+
+    def __init__(self, registry: ServiceRegistry, manifest: ModuleManifestV1) -> None:
+        self._registry = registry
+        self._manifest = manifest
+
+    def register(
+        self,
+        contract: type[T],
+        implementation: T,
+        *,
+        service_id: str,
+        version: int,
+        deprecated_since: str | None = None,
+        replacement: str | None = None,
+    ) -> None:
+        self._registry.register(
+            provider_module=self._manifest.id,
+            contract=contract,
+            implementation=implementation,
+            service_id=service_id,
+            version=version,
+            deprecated_since=deprecated_since,
+            replacement=replacement,
+        )
+
+    def require(self, contract: type[T], *, service_id: str, version: int) -> T:
+        self._validate_dependency(service_id, required=True)
+        service = self._registry.lookup(
+            contract,
+            service_id=service_id,
+            version=version,
+            consumer_module=self._manifest.id,
+            required=True,
+        )
+        assert service is not None
+        return service
+
+    def optional(self, contract: type[T], *, service_id: str, version: int) -> T | None:
+        self._validate_dependency(service_id, required=False)
+        return self._registry.lookup(
+            contract,
+            service_id=service_id,
+            version=version,
+            consumer_module=self._manifest.id,
+            required=False,
+        )
+
+    def resolve(self, contract: type[T]) -> T:
+        registered = self._registry.resolve_unique(contract, consumer_module=self._manifest.id)
+        self._validate_dependency(registered.service_id, required=True)
+        return cast(T, registered.implementation)
+
+    def _validate_dependency(self, service_id: str, *, required: bool) -> None:
+        provider_module = service_id.partition(".")[0]
+        if provider_module == self._manifest.id:
+            return
+        declared_required = provider_module in self._manifest.requires.modules
+        declared_optional = provider_module in self._manifest.optional.modules
+        if declared_required or (not required and declared_optional):
+            return
+        kind = "required" if required else "required or optional"
+        raise UndeclaredServiceDependencyError(
+            f"The provider must be declared as a {kind} module dependency.",
+            service_id=service_id,
+            provider_module=provider_module,
+            consumer_module=self._manifest.id,
+        )
+
+
+def _validate_service_reference(service_id: str, version: int, contract: type[object]) -> str:
+    if not isinstance(service_id, str) or not _SERVICE_ID.fullmatch(service_id):
+        raise ServiceRegistryError(
+            "Service IDs must use the form <owner-module>.<service-name>.",
+            service_id=service_id if isinstance(service_id, str) else None,
+        )
+    if len(service_id) > 160:
+        raise ServiceRegistryError(
+            "Service IDs must not exceed 160 characters.", service_id=service_id
+        )
+    if type(version) is not int or version < 1:
+        raise ServiceRegistryError(
+            "Service versions must be positive integers.",
+            service_id=service_id,
+        )
+    if not isinstance(contract, type):
+        raise ServiceRegistryError(
+            "Service contracts must be public Protocol or class types.",
+            service_id=service_id,
+            requested_version=version,
+        )
+    return service_id.partition(".")[0]
+
+
+def _validate_deprecation_metadata(
+    *,
+    service_id: str,
+    version: int,
+    deprecated_since: str | None,
+    replacement: str | None,
+) -> None:
+    if deprecated_since is not None and (
+        not isinstance(deprecated_since, str)
+        or not deprecated_since.strip()
+        or len(deprecated_since) > 128
+    ):
+        raise ServiceRegistryError(
+            "deprecated_since must be a non-empty value of at most 128 characters.",
+            service_id=service_id,
+            requested_version=version,
+        )
+    if replacement is None:
+        return
+    if deprecated_since is None:
+        raise ServiceRegistryError(
+            "A replacement requires deprecated_since metadata.",
+            service_id=service_id,
+            requested_version=version,
+        )
+    if not isinstance(replacement, str) or not _SERVICE_ID.fullmatch(replacement):
+        raise ServiceRegistryError(
+            "Replacement service IDs must use the form <owner-module>.<service-name>.",
+            service_id=service_id,
+            requested_version=version,
+        )
+    if len(replacement) > 160 or replacement.partition(".")[0] != service_id.partition(".")[0]:
+        raise ServiceRegistryError(
+            "Replacement services must remain in the same owner namespace and ID length limit.",
+            service_id=service_id,
+            requested_version=version,
+        )
+
+
+__all__ = ["ModuleServiceRegistryAdapter", "RegisteredService", "ServiceRegistry"]

--- a/backend/app/platform/modules/testing.py
+++ b/backend/app/platform/modules/testing.py
@@ -94,11 +94,50 @@ class FakeEventBus:
 class FakeServiceRegistry:
     def __init__(self, services: Mapping[type[object], object] | None = None) -> None:
         self.services = dict(services or {})
+        self.versioned_services: dict[tuple[str, int], tuple[type[object], object]] = {}
+        self.sealed = False
+
+    def register(
+        self,
+        contract: type[T],
+        implementation: T,
+        *,
+        service_id: str,
+        version: int,
+        deprecated_since: str | None = None,
+        replacement: str | None = None,
+    ) -> None:
+        del deprecated_since, replacement
+        if self.sealed:
+            raise RuntimeError("The fake service registry is sealed.")
+        key = (service_id, version)
+        if key in self.versioned_services:
+            raise ValueError(f'Test service "{service_id}" version {version} is duplicated.')
+        self.versioned_services[key] = (cast(type[object], contract), implementation)
+        self.services[contract] = implementation
+
+    def require(self, contract: type[T], *, service_id: str, version: int) -> T:
+        key = (service_id, version)
+        if key not in self.versioned_services:
+            raise LookupError(f'No test service "{service_id}" version {version} is registered.')
+        registered_contract, implementation = self.versioned_services[key]
+        if registered_contract is not contract:
+            raise TypeError(f'Test service "{service_id}" uses a different contract.')
+        return cast(T, implementation)
+
+    def optional(self, contract: type[T], *, service_id: str, version: int) -> T | None:
+        key = (service_id, version)
+        if key not in self.versioned_services:
+            return None
+        return self.require(contract, service_id=service_id, version=version)
 
     def resolve(self, contract: type[T]) -> T:
         if contract not in self.services:
             raise LookupError(f"No test service is registered for {contract.__name__}.")
         return cast(T, self.services[contract])
+
+    def seal(self) -> None:
+        self.sealed = True
 
 
 class FakePermissions:

--- a/backend/tests/fixtures/service_modules/__init__.py
+++ b/backend/tests/fixtures/service_modules/__init__.py
@@ -1,0 +1,1 @@
+"""Zwei kleine Testmodule für öffentliche Service-Contracts."""

--- a/backend/tests/fixtures/service_modules/analysis_areas/__init__.py
+++ b/backend/tests/fixtures/service_modules/analysis_areas/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-Fixture für Analysis-Area-Query-Contracts."""

--- a/backend/tests/fixtures/service_modules/analysis_areas/application.py
+++ b/backend/tests/fixtures/service_modules/analysis_areas/application.py
@@ -1,0 +1,14 @@
+from collections.abc import Sequence
+
+from tests.fixtures.service_modules.analysis_areas.contracts import AnalysisAreaSummary
+
+
+class InMemoryAnalysisAreaQueryService:
+    async def list_areas(self) -> Sequence[AnalysisAreaSummary]:
+        return (
+            AnalysisAreaSummary(
+                area_id="flensburg",
+                name="Flensburg",
+                geometry={"type": "Point", "coordinates": [9.43, 54.79]},
+            ),
+        )

--- a/backend/tests/fixtures/service_modules/analysis_areas/contracts.py
+++ b/backend/tests/fixtures/service_modules/analysis_areas/contracts.py
@@ -1,0 +1,21 @@
+"""Einziger modulübergreifend importierbarer Namespace des Provider-Fixtures."""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.platform.modules.sdk import JsonValue
+
+SERVICE_ID = "analysis-areas-fixture.query"
+SERVICE_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisAreaSummary:
+    area_id: str
+    name: str
+    geometry: Mapping[str, JsonValue]
+
+
+class AnalysisAreaQueryService(Protocol):
+    async def list_areas(self) -> Sequence[AnalysisAreaSummary]: ...

--- a/backend/tests/fixtures/service_modules/analysis_areas/module.py
+++ b/backend/tests/fixtures/service_modules/analysis_areas/module.py
@@ -1,0 +1,40 @@
+from app.platform.modules.sdk import ModuleContext, ModuleDefinition, parse_manifest
+from tests.fixtures.service_modules.analysis_areas.application import (
+    InMemoryAnalysisAreaQueryService,
+)
+from tests.fixtures.service_modules.analysis_areas.contracts import (
+    SERVICE_ID,
+    SERVICE_VERSION,
+    AnalysisAreaQueryService,
+)
+
+MANIFEST = parse_manifest(
+    {
+        "manifest_version": 1,
+        "id": "analysis-areas-fixture",
+        "name": "Analysis Areas Service Fixture",
+        "version": "1.0.0",
+        "requires": {"host": ">=0.2.0,<1.0.0", "sdk": ">=1.3.0,<2.0.0"},
+    }
+)
+
+
+class AnalysisAreasFixtureModule:
+    manifest = MANIFEST
+
+    def register(self, context: ModuleContext) -> None:
+        assert context.services is not None
+        context.services.register(
+            AnalysisAreaQueryService,
+            InMemoryAnalysisAreaQueryService(),
+            service_id=SERVICE_ID,
+            version=SERVICE_VERSION,
+        )
+
+
+DEFINITION = ModuleDefinition(
+    manifest=MANIFEST,
+    loader=AnalysisAreasFixtureModule,
+    origin=__name__,
+    declared_id=MANIFEST.id,
+)

--- a/backend/tests/fixtures/service_modules/statistics/__init__.py
+++ b/backend/tests/fixtures/service_modules/statistics/__init__.py
@@ -1,0 +1,1 @@
+"""Consumer-Fixture für einen fremden öffentlichen Query-Contract."""

--- a/backend/tests/fixtures/service_modules/statistics/module.py
+++ b/backend/tests/fixtures/service_modules/statistics/module.py
@@ -1,0 +1,50 @@
+from collections.abc import Sequence
+
+from app.platform.modules.sdk import ModuleContext, ModuleDefinition, parse_manifest
+from tests.fixtures.service_modules.analysis_areas.contracts import (
+    SERVICE_ID,
+    SERVICE_VERSION,
+    AnalysisAreaQueryService,
+    AnalysisAreaSummary,
+)
+
+MANIFEST = parse_manifest(
+    {
+        "manifest_version": 1,
+        "id": "statistics-fixture",
+        "name": "Statistics Service Consumer Fixture",
+        "version": "1.0.0",
+        "requires": {
+            "host": ">=0.2.0,<1.0.0",
+            "sdk": ">=1.3.0,<2.0.0",
+            "modules": {"analysis-areas-fixture": ">=1.0.0,<2.0.0"},
+        },
+    }
+)
+
+
+class StatisticsFixtureModule:
+    manifest = MANIFEST
+
+    def __init__(self) -> None:
+        self._areas: AnalysisAreaQueryService | None = None
+
+    def register(self, context: ModuleContext) -> None:
+        assert context.services is not None
+        self._areas = context.services.require(
+            AnalysisAreaQueryService,
+            service_id=SERVICE_ID,
+            version=SERVICE_VERSION,
+        )
+
+    async def areas(self) -> Sequence[AnalysisAreaSummary]:
+        assert self._areas is not None
+        return await self._areas.list_areas()
+
+
+DEFINITION = ModuleDefinition(
+    manifest=MANIFEST,
+    loader=StatisticsFixtureModule,
+    origin=__name__,
+    declared_id=MANIFEST.id,
+)

--- a/backend/tests/test_module_import_boundaries.py
+++ b/backend/tests/test_module_import_boundaries.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import pytest
+
+from app.platform.modules.import_boundaries import (
+    find_contract_persistence_leaks,
+    find_cross_module_import_violations,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures/service_modules"
+PACKAGE = "tests.fixtures.service_modules"
+
+
+def test_fixture_modules_import_foreign_code_only_through_contracts() -> None:
+    assert find_cross_module_import_violations(FIXTURES, package_prefix=PACKAGE) == ()
+
+
+def test_public_contract_dtos_do_not_leak_orm_or_session_types() -> None:
+    assert find_contract_persistence_leaks(FIXTURES) == ()
+
+
+@pytest.mark.parametrize(
+    "foreign_package",
+    ("application", "internal", "persistence", "repositories"),
+)
+def test_foreign_internal_imports_are_rejected_with_actionable_context(
+    tmp_path: Path,
+    foreign_package: str,
+) -> None:
+    modules = tmp_path / "modules"
+    source = modules / "consumer" / "module.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        f"from example.modules.provider.{foreign_package} import Repository\n",
+        encoding="utf-8",
+    )
+
+    violations = find_cross_module_import_violations(
+        modules,
+        package_prefix="example.modules",
+    )
+
+    assert len(violations) == 1
+    violation = violations[0]
+    assert violation.consumer_module == "consumer"
+    assert violation.source == source
+    assert violation.imported_module == f"example.modules.provider.{foreign_package}"
+    assert violation.allowed_alternative == "example.modules.provider.contracts"
+    assert "consumer" in str(violation)
+    assert str(source) in str(violation)
+
+
+def test_foreign_contract_import_is_allowed(tmp_path: Path) -> None:
+    modules = tmp_path / "modules"
+    source = modules / "consumer" / "module.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "from example.modules.provider.contracts import QueryService\n",
+        encoding="utf-8",
+    )
+    assert find_cross_module_import_violations(modules, package_prefix="example.modules") == ()
+
+
+def test_foreign_module_import_from_package_root_is_rejected(tmp_path: Path) -> None:
+    modules = tmp_path / "modules"
+    source = modules / "consumer" / "module.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("from example.modules import provider\n", encoding="utf-8")
+
+    violations = find_cross_module_import_violations(
+        modules,
+        package_prefix="example.modules",
+    )
+
+    assert [violation.imported_module for violation in violations] == ["example.modules.provider"]
+
+
+def test_contract_orm_import_is_rejected(tmp_path: Path) -> None:
+    contracts = tmp_path / "modules/provider/contracts.py"
+    contracts.parent.mkdir(parents=True)
+    contracts.write_text("from sqlalchemy.orm import Mapped, relationship\n", encoding="utf-8")
+
+    leaks = find_contract_persistence_leaks(tmp_path / "modules")
+
+    assert {leak.name for leak in leaks} >= {"sqlalchemy.orm", "Mapped", "relationship"}

--- a/backend/tests/test_module_sdk.py
+++ b/backend/tests/test_module_sdk.py
@@ -66,7 +66,7 @@ def test_module_context_has_typed_public_ports() -> None:
     }
 
 
-def test_runtime_context_is_bound_to_manifest_and_optional_ports_are_absent() -> None:
+def test_runtime_context_is_bound_to_manifest_and_unimplemented_ports_are_absent() -> None:
     runtime = runtime_for([EXAMPLE_DEFINITION])
     context = runtime.registry.get("test-example-module").context
 
@@ -74,7 +74,7 @@ def test_runtime_context_is_bound_to_manifest_and_optional_ports_are_absent() ->
     assert context.module_version == "1.0.0"
     assert context.database is None
     assert context.events is None
-    assert context.services is None
+    assert context.services is not None
     assert context.permissions is None
     assert context.cache is None
     assert context.storage is None

--- a/backend/tests/test_module_service_registry.py
+++ b/backend/tests/test_module_service_registry.py
@@ -1,0 +1,396 @@
+from dataclasses import is_dataclass
+from typing import Protocol
+
+import pytest
+from fastapi import FastAPI
+
+from app.platform.modules.context import ModuleContextFactory
+from app.platform.modules.errors import (
+    DuplicateServiceRegistrationError,
+    IncompatibleServiceVersionError,
+    MissingRequiredServiceError,
+    ModuleRegistrationError,
+    ServiceContractMismatchError,
+    ServiceRegistryError,
+    ServiceRegistrySealedError,
+    UndeclaredServiceDependencyError,
+)
+from app.platform.modules.manifest import parse_manifest
+from app.platform.modules.runtime import create_module_runtime
+from app.platform.modules.sdk import ModuleContext, ModuleDefinition
+from app.platform.modules.services import ServiceRegistry
+from app.platform.modules.testing import FakeServiceRegistry
+from tests.fixtures.service_modules.analysis_areas.contracts import (
+    SERVICE_ID,
+    AnalysisAreaQueryService,
+    AnalysisAreaSummary,
+)
+from tests.fixtures.service_modules.analysis_areas.module import DEFINITION as PROVIDER
+from tests.fixtures.service_modules.statistics.module import DEFINITION as CONSUMER
+from tests.fixtures.service_modules.statistics.module import StatisticsFixtureModule
+from tests.test_module_runtime import FakeDiscovery
+
+
+class ExampleContract(Protocol):
+    def value(self) -> str: ...
+
+
+class OtherContract(Protocol):
+    def other(self) -> str: ...
+
+
+class ExampleImplementation:
+    def __init__(self, value: str = "ok") -> None:
+        self._value = value
+
+    def value(self) -> str:
+        return self._value
+
+
+def manifest(
+    module_id: str,
+    *,
+    required: dict[str, str] | None = None,
+    optional: dict[str, str] | None = None,
+):
+    return parse_manifest(
+        {
+            "manifest_version": 1,
+            "id": module_id,
+            "name": module_id,
+            "version": "1.0.0",
+            "requires": {
+                "host": ">=0.2.0,<1.0.0",
+                "sdk": ">=1.3.0,<2.0.0",
+                "modules": required or {},
+            },
+            "optional": {"modules": optional or {}},
+        }
+    )
+
+
+def bound_registries():
+    registry = ServiceRegistry()
+    provider = registry.bind(manifest("provider-module"))
+    consumer = registry.bind(
+        manifest("consumer-module", required={"provider-module": ">=1.0.0,<2.0.0"})
+    )
+    return registry, provider, consumer
+
+
+def test_register_and_typed_required_lookup() -> None:
+    _, provider, consumer = bound_registries()
+    implementation = ExampleImplementation()
+
+    provider.register(
+        ExampleContract,
+        implementation,
+        service_id="provider-module.example",
+        version=1,
+    )
+
+    resolved = consumer.require(
+        ExampleContract,
+        service_id="provider-module.example",
+        version=1,
+    )
+    assert resolved is implementation
+    assert resolved.value() == "ok"
+
+
+def test_duplicate_registration_is_fail_fast_and_contextual() -> None:
+    _, provider, _ = bound_registries()
+    provider.register(
+        ExampleContract,
+        ExampleImplementation(),
+        service_id="provider-module.example",
+        version=1,
+    )
+
+    with pytest.raises(DuplicateServiceRegistrationError) as error:
+        provider.register(
+            ExampleContract,
+            ExampleImplementation(),
+            service_id="provider-module.example",
+            version=1,
+        )
+
+    assert error.value.service_id == "provider-module.example"
+    assert error.value.requested_version == 1
+    assert error.value.provider_module == "provider-module"
+
+
+def test_exact_versions_can_be_registered_in_parallel() -> None:
+    registry, provider, consumer = bound_registries()
+    first = ExampleImplementation("v1")
+    second = ExampleImplementation("v2")
+    provider.register(ExampleContract, first, service_id="provider-module.example", version=1)
+    provider.register(ExampleContract, second, service_id="provider-module.example", version=2)
+
+    assert (
+        consumer.require(ExampleContract, service_id="provider-module.example", version=1).value()
+        == "v1"
+    )
+    assert (
+        consumer.require(ExampleContract, service_id="provider-module.example", version=2).value()
+        == "v2"
+    )
+    assert [(item.service_id, item.version) for item in registry.services] == [
+        ("provider-module.example", 1),
+        ("provider-module.example", 2),
+    ]
+
+
+def test_missing_required_and_incompatible_version_have_structured_errors() -> None:
+    _, provider, consumer = bound_registries()
+    with pytest.raises(MissingRequiredServiceError) as missing:
+        consumer.require(ExampleContract, service_id="provider-module.example", version=1)
+    assert missing.value.consumer_module == "consumer-module"
+    assert missing.value.available_services == ()
+
+    provider.register(
+        ExampleContract,
+        ExampleImplementation(),
+        service_id="provider-module.example",
+        version=1,
+    )
+    with pytest.raises(IncompatibleServiceVersionError) as incompatible:
+        consumer.require(ExampleContract, service_id="provider-module.example", version=2)
+    assert incompatible.value.available_versions == (1,)
+    assert incompatible.value.available_services == ("provider-module.example@1",)
+
+
+def test_optional_lookup_distinguishes_absent_and_incompatible_service() -> None:
+    registry = ServiceRegistry()
+    provider = registry.bind(manifest("provider-module"))
+    consumer = registry.bind(
+        manifest("consumer-module", optional={"provider-module": ">=1.0.0,<2.0.0"})
+    )
+    assert (
+        consumer.optional(ExampleContract, service_id="provider-module.example", version=1) is None
+    )
+
+    provider.register(
+        ExampleContract,
+        ExampleImplementation(),
+        service_id="provider-module.example",
+        version=1,
+    )
+    assert (
+        consumer.optional(ExampleContract, service_id="provider-module.example", version=1)
+        is not None
+    )
+    with pytest.raises(IncompatibleServiceVersionError):
+        consumer.optional(ExampleContract, service_id="provider-module.example", version=2)
+
+
+def test_provider_ownership_and_consumer_dependencies_are_enforced() -> None:
+    registry = ServiceRegistry()
+    provider = registry.bind(manifest("provider-module"))
+    undeclared_consumer = registry.bind(manifest("consumer-module"))
+
+    with pytest.raises(ServiceRegistryError, match="own module namespace"):
+        provider.register(
+            ExampleContract,
+            ExampleImplementation(),
+            service_id="foreign-module.example",
+            version=1,
+        )
+    with pytest.raises(UndeclaredServiceDependencyError):
+        undeclared_consumer.require(
+            ExampleContract,
+            service_id="provider-module.example",
+            version=1,
+        )
+
+    provider.register(
+        ExampleContract,
+        ExampleImplementation(),
+        service_id="provider-module.example",
+        version=1,
+    )
+    with pytest.raises(UndeclaredServiceDependencyError):
+        undeclared_consumer.resolve(ExampleContract)
+
+
+def test_contract_identity_is_checked_without_protocol_introspection() -> None:
+    _, provider, consumer = bound_registries()
+    provider.register(
+        ExampleContract,
+        ExampleImplementation(),
+        service_id="provider-module.example",
+        version=1,
+    )
+    with pytest.raises(ServiceContractMismatchError):
+        consumer.require(OtherContract, service_id="provider-module.example", version=1)
+
+
+def test_deprecation_metadata_is_validated_and_exposed() -> None:
+    registry, provider, _ = bound_registries()
+    provider.register(
+        ExampleContract,
+        ExampleImplementation(),
+        service_id="provider-module.example",
+        version=1,
+        deprecated_since="2026-08-26",
+        replacement="provider-module.example-v2",
+    )
+    assert registry.services[0].deprecated_since == "2026-08-26"
+    assert registry.services[0].replacement == "provider-module.example-v2"
+
+    with pytest.raises(ServiceRegistryError, match="requires deprecated_since"):
+        provider.register(
+            ExampleContract,
+            ExampleImplementation(),
+            service_id="provider-module.other",
+            version=1,
+            replacement="provider-module.example",
+        )
+
+
+def test_sealed_registry_rejects_mutation_but_keeps_lookup_available() -> None:
+    registry, provider, consumer = bound_registries()
+    implementation = ExampleImplementation()
+    provider.register(
+        ExampleContract,
+        implementation,
+        service_id="provider-module.example",
+        version=1,
+    )
+    registry.seal()
+
+    assert (
+        consumer.require(ExampleContract, service_id="provider-module.example", version=1)
+        is implementation
+    )
+    with pytest.raises(ServiceRegistrySealedError):
+        provider.register(
+            ExampleContract,
+            ExampleImplementation(),
+            service_id="provider-module.other",
+            version=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_two_fixture_modules_communicate_through_public_contract_only() -> None:
+    runtime = create_module_runtime(
+        enabled_module_ids=(PROVIDER.declared_id, CONSUMER.declared_id),
+        discovery_providers=(FakeDiscovery((CONSUMER, PROVIDER)),),
+        host_version="0.2.0",
+    )
+    runtime.register(FastAPI())
+    consumer = runtime.registry.get(CONSUMER.declared_id).module
+
+    assert isinstance(consumer, StatisticsFixtureModule)
+    areas = await consumer.areas()
+    assert areas == (
+        AnalysisAreaSummary(
+            area_id="flensburg",
+            name="Flensburg",
+            geometry={"type": "Point", "coordinates": [9.43, 54.79]},
+        ),
+    )
+    assert is_dataclass(areas[0])
+
+
+def test_runtime_wires_real_registry_and_seals_it_after_registration() -> None:
+    factory = ModuleContextFactory()
+    runtime = create_module_runtime(
+        enabled_module_ids=(PROVIDER.declared_id,),
+        discovery_providers=(FakeDiscovery((PROVIDER,)),),
+        host_version="0.2.0",
+        context_factory=factory,
+    )
+    context = runtime.registry.get(PROVIDER.declared_id).context
+    assert context.services is not None
+    assert factory.service_registry is not None
+    assert not factory.service_registry.sealed
+
+    runtime.register(FastAPI())
+    assert factory.service_registry.sealed
+    with pytest.raises(ServiceRegistrySealedError):
+        context.services.register(
+            AnalysisAreaQueryService,
+            object(),  # type: ignore[arg-type]
+            service_id=SERVICE_ID,
+            version=2,
+        )
+
+
+def test_missing_required_service_prevents_runtime_registration() -> None:
+    provider_manifest = manifest("provider-module")
+    consumer_manifest = manifest("consumer-module", required={"provider-module": ">=1.0.0,<2.0.0"})
+
+    class EmptyProvider:
+        manifest = provider_manifest
+
+        def register(self, context: ModuleContext) -> None:
+            del context
+
+    class RequiredConsumer:
+        manifest = consumer_manifest
+
+        def register(self, context: ModuleContext) -> None:
+            assert context.services is not None
+            context.services.require(
+                ExampleContract, service_id="provider-module.example", version=1
+            )
+
+    definitions = (
+        ModuleDefinition(provider_manifest, EmptyProvider, "test:provider", "provider-module"),
+        ModuleDefinition(consumer_manifest, RequiredConsumer, "test:consumer", "consumer-module"),
+    )
+    runtime = create_module_runtime(
+        enabled_module_ids=("provider-module", "consumer-module"),
+        discovery_providers=(FakeDiscovery(definitions),),
+        host_version="0.2.0",
+    )
+    with pytest.raises(ModuleRegistrationError) as error:
+        runtime.register(FastAPI())
+    assert isinstance(error.value.__cause__, MissingRequiredServiceError)
+
+
+def test_missing_optional_service_does_not_prevent_runtime_registration() -> None:
+    consumer_manifest = manifest("consumer-module", optional={"provider-module": ">=1.0.0,<2.0.0"})
+
+    class OptionalConsumer:
+        manifest = consumer_manifest
+
+        def __init__(self) -> None:
+            self.service: ExampleContract | None = None
+
+        def register(self, context: ModuleContext) -> None:
+            assert context.services is not None
+            self.service = context.services.optional(
+                ExampleContract, service_id="provider-module.example", version=1
+            )
+
+    definition = ModuleDefinition(
+        consumer_manifest, OptionalConsumer, "test:consumer", "consumer-module"
+    )
+    runtime = create_module_runtime(
+        enabled_module_ids=("consumer-module",),
+        discovery_providers=(FakeDiscovery((definition,)),),
+        host_version="0.2.0",
+    )
+    runtime.register(FastAPI())
+    consumer = runtime.registry.get("consumer-module").module
+    assert isinstance(consumer, OptionalConsumer)
+    assert consumer.service is None
+
+
+def test_fake_service_registry_supports_versioned_required_and_optional_lookups() -> None:
+    fake = FakeServiceRegistry()
+    implementation = ExampleImplementation()
+    assert fake.optional(ExampleContract, service_id="provider-module.example", version=1) is None
+    fake.register(
+        ExampleContract,
+        implementation,
+        service_id="provider-module.example",
+        version=1,
+    )
+    assert (
+        fake.require(ExampleContract, service_id="provider-module.example", version=1)
+        is implementation
+    )

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -61,7 +61,7 @@ Sub-Interfaces `context.api` und `context.lifecycle`.
 | `lifecycle` | `LifecycleRegistrar` | durch die Runtime implementiert |
 | `database` | `DatabaseSessionProvider` | transaktionaler Hostadapter aus #97 |
 | `events` | `EventBusPort` | In-Process Dispatch und transaktionale Outbox aus #96 |
-| `services` | `ServiceRegistryPort` | optionaler Port; Registry folgt in #98 |
+| `services` | `ServiceRegistryPort` | runtime-skopierte Cross-Module-Registry aus #98 |
 | `permissions` | `PermissionPort` | optionaler Port; Policy Engine folgt in #104 |
 | `cache` | `CachePort` | optionaler, modulgebundener Byte-Cache |
 | `observability` | `ObservabilityPort` | immer vorhanden; Logger ist an Modul-ID/-Version gebunden |
@@ -98,9 +98,10 @@ Die Ports machen keine Redis-, Dateisystem- oder Cloud-SDK-Typen öffentlich.
 ### Events, Services, Permissions und Jobs
 
 Der Event-Port ist durch die [Domain-Event- und Outbox-Infrastruktur](domain-events.md)
-implementiert. Service Registry, Permission Policy und Job-Ausführung bleiben ihren
-Folge-Issues vorbehalten. Die Service-Auflösung ist ausschließlich für explizite
-öffentliche Cross-Module-Contracts vorgesehen und kein allgemeiner Service Locator.
+implementiert. Die [Cross-Module-Service-Registry](service-contracts.md) stellt
+versionierte öffentliche Query-/Service-Contracts bereit. Permission Policy und
+Job-Ausführung bleiben ihren Folge-Issues vorbehalten. Die Service-Auflösung ist
+kein allgemeiner Service Locator.
 
 ### HTTP
 
@@ -136,9 +137,10 @@ unter `app.*` ausschließlich den öffentlichen SDK-Pfad verwendet.
 `MODULE_SDK_VERSION` ist eine SemVer-Version und unabhängig von Release-SHA und
 Host-API-Version. Der Context wurde unter SDK `1.0.0` eingeführt. Die additive
 Event-/Outbox-API aus #96 erhöhte die SDK-Version auf `1.1.0`. Die additiven
-Persistence-Contracts und der produktive Datenbank-Session-Adapter aus #97 erhöhen
-sie auf `1.2.0`; der minimale `DomainEvent`-Contract aus 1.0 und die #94-Proxys
-bleiben kompatibel.
+Persistence-Contracts und der produktive Datenbank-Session-Adapter aus #97 erhöhten
+sie auf `1.2.0`. Die additive, versionierte Service-Registry aus #98 erhöht sie auf
+`1.3.0`; der minimale `DomainEvent`-Contract aus 1.0 und die #94-Proxys bleiben
+kompatibel.
 
 - **MAJOR:** Entfernen oder Umbenennen öffentlicher Methoden, inkompatible Änderungen
   an vorhandener Semantik oder eine inkompatible Context-Struktur.

--- a/docs/modules/service-contracts.md
+++ b/docs/modules/service-contracts.md
@@ -1,0 +1,137 @@
+# Cross-Module-Service-Contracts
+
+Die Host-Registry stellt gezielte, typisierte Abfragen zwischen Backend-Modulen
+bereit. Sie setzt die Ownership- und Importgrenzen aus
+[ADR #92](../architecture/adr-modular-host-and-module-boundaries.md) um. Sie ist kein
+allgemeiner Dependency-Injection-Container und kein versteckter Zugriff auf fremde
+Interna.
+
+## Service oder Domain Event?
+
+Ein Service-Contract passt zu einer unmittelbaren Query oder Operation, deren
+Ergebnis der Consumer für seinen aktuellen Ablauf benötigt. Ein Domain Event
+beschreibt dagegen eine bereits eingetretene fachliche Tatsache und koppelt den
+Producer nicht an einzelne Consumer. Queries wie „liefere Gebietszusammenfassungen“
+verwenden einen Service; „Gebiet wurde veröffentlicht“ ist ein Event.
+
+Service-Contracts sind standardmäßig asynchron. Damit können Implementierungen
+später Datenbank- oder Netzwerkzugriffe ausführen, ohne den öffentlichen Contract zu
+brechen. Ein Lookup selbst ist synchron und liefert die bereits registrierte,
+runtime-skopierte Implementierung.
+
+## Ownership und öffentlicher Contract
+
+Der Provider besitzt Service-ID, Contract, DTOs und Implementierung. Nur sein
+`contracts`-Namespace ist für fremde Module importierbar. DTOs sind unveränderliche
+Werte ohne SQLAlchemy-Modelle, `Mapped`, `relationship`, `Session` oder Lazy-Loading.
+Geometrien werden als GeoJSON-kompatible Mappings in EPSG:4326 mit der Reihenfolge
+Längengrad/Breitengrad transportiert.
+
+```python
+# modules/analysis_areas/contracts.py
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.platform.modules.sdk import JsonValue
+
+SERVICE_ID = "analysis-areas.query"
+SERVICE_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisAreaSummary:
+    area_id: str
+    name: str
+    geometry: Mapping[str, JsonValue]
+
+
+class AnalysisAreaQueryService(Protocol):
+    async def list_areas(self) -> Sequence[AnalysisAreaSummary]: ...
+```
+
+Service-IDs haben die Form `<owner-module>.<service-name>`. Der Host erzwingt, dass
+ein Provider nur in seinem eigenen Namespace registriert. Service-Versionen sind
+positive Integer und unabhängig von Manifest-, Host- und SDK-Version. Ein Contract
+der Version 2 wird bei Bedarf parallel zu Version 1 unter derselben Service-ID
+registriert; ein Lookup handelt Versionen nicht implizit aus.
+
+## Registrierung und Lookup
+
+Provider registrieren Implementierungen ausschließlich während
+`module.register(context)`. Nach Abschluss aller `register()`-Hooks versiegelt die
+Runtime die Registry. Spätere Registrierung oder ein Überschreiben derselben
+Kombination aus ID und Version schlägt fehl.
+
+```python
+def register(self, context: ModuleContext) -> None:
+    assert context.services is not None
+    context.services.register(
+        AnalysisAreaQueryService,
+        SqlAnalysisAreaQueryService(context.database),
+        service_id=SERVICE_ID,
+        version=SERVICE_VERSION,
+    )
+```
+
+Ein erforderlicher Lookup verwendet `require()`. Der Owner muss zugleich in
+`manifest.requires.modules` des Consumers stehen. Die bestehende Dependency-Order
+registriert den Provider zuerst. Ein fehlender Service, eine falsche exakte Version
+oder ein anderer Contract-Typ stoppt die Runtime-Registrierung mit einem
+strukturierten Fehler.
+
+```python
+from modules.analysis_areas.contracts import (
+    SERVICE_ID,
+    SERVICE_VERSION,
+    AnalysisAreaQueryService,
+)
+
+
+def register(self, context: ModuleContext) -> None:
+    assert context.services is not None
+    self.areas = context.services.require(
+        AnalysisAreaQueryService,
+        service_id=SERVICE_ID,
+        version=SERVICE_VERSION,
+    )
+```
+
+`optional()` liefert bei einer vollständig fehlenden Service-ID `None`. Der Owner
+muss als required oder optional Module Dependency deklariert sein. Existiert die ID
+in einer anderen Version, wird dies als Inkompatibilität gemeldet und nicht wie ein
+fehlendes optionales Feature behandelt.
+
+## Versionierung und Deprecation
+
+Eine Änderung an Methoden oder DTO-Semantik, die bestehende Consumer brechen kann,
+erhält eine neue Service-Version und einen neuen öffentlichen Protocol-/DTO-Vertrag.
+Versionen können während eines angekündigten Migrationszeitraums parallel laufen.
+Die optionalen Registrierungsmetadaten `deprecated_since` und `replacement`
+dokumentieren diesen Übergang; sie verändern Lookup oder Routing nicht. Erst nach
+Migration aller Consumer darf die alte Version entfallen.
+
+## Transaktionen und Lebensdauer
+
+Registry und Implementierungen leben genau so lange wie die jeweilige
+`ModuleRuntime`; es gibt keinen globalen Singleton. Die Registry eröffnet keine
+Transaktion und reicht keine Session zwischen Modulen weiter. Ein Query-Service
+öffnet über den eigenen Datenbank-Port seine eigene, hostverwaltete Transaktion und
+liefert materialisierte DTOs zurück. Wenn mehrere fachliche Schreiboperationen eine
+gemeinsame atomare Grenze benötigen, reicht ein einfacher Cross-Module-Service nicht
+als implizite Transaktionskoordination; dieser Fall braucht einen ausdrücklich
+entworfenen Application Contract. Query-first bleibt die bevorzugte Nutzung.
+
+## Importgrenzen
+
+Fremde Module dürfen ausschließlich `modules.<owner>.contracts` importieren. Imports
+aus `.application`, `.domain`, `.integrations`, `.internal`, `.persistence` oder
+`.repositories` sowie fremde ORM-Modelle sind verboten. Ein AST-basierter
+Architekturtest prüft die Strukturregel ohne dateispezifische Allowlist und nennt im
+Fehler Consumer, Quelldatei, problematischen Import sowie den erlaubten
+`contracts`-Pfad.
+
+Die Registry prüft stabile ID, Version, Ownership, Manifest-Abhängigkeit und exakte
+Contract-Identität. Sie versucht bewusst keine vollständige Runtime-Introspection
+von Python-Protocols; statische Typprüfung und Contract-Tests sichern deren fachliche
+Methodensignaturen.


### PR DESCRIPTION
## Zusammenfassung

Part of #91  
Closes #98

Dieser PR baut auf dem `ModuleContext` und dem `ServiceRegistryPort` aus #95 auf. Er ergänzt die Event-Kommunikation aus #96 um gezielte Request-/Response-Aufrufe zwischen Modulen.

## Umsetzung

- Host-eigene, runtime-skopierte `ServiceRegistry`
- Modulgebundener Adapter über `ModuleContext.services`
- Stabile Service-IDs im Format `<owner-module>.<service-name>`
- Exakte, parallel registrierbare Contract-Versionen
- Typisierte öffentliche `Protocol`-Contracts
- Persistenzfreie DTOs ohne ORM-Modelle oder Sessions
- Required- und Optional-Service-Lookups
- Validierung von Provider-Ownership und Manifest-Abhängigkeiten
- Strukturierte Fehler für:
  - doppelte Registrierungen
  - fehlende erforderliche Services
  - inkompatible Versionen
  - abweichende Contract-Typen
  - Registrierungen nach dem Versiegeln
- Versiegelung der Registry nach Abschluss der Modulregistrierung
- Erweiterter `FakeServiceRegistry` für infrastrukturfremde Modultests
- Zwei kleine Analysis-Areas-/Statistics-Fixtures als Contract-Proof
- AST-basierte Architekturtests für modulübergreifende Imports
- Dokumentation zu Event vs. Service, Ownership, DTO-Regeln, Required/Optional Services, Async-Konvention, Versionierung, Deprecation, Transaktionen und Importgrenzen

## Architekturgrenzen

Fremde Module dürfen ausschließlich den öffentlichen `contracts`-Namespace eines Moduls importieren.

Erlaubt:

```python
from modules.analysis_areas.contracts import AnalysisAreaQueryService
```

Verboten sind insbesondere fremde Imports aus:

- `application`
- `internal`
- `persistence`
- `repositories`

Die Prüfung erfolgt strukturell über den Python-AST und benötigt keine dateispezifische Allowlist.

## Tests

- `cd backend && .venv/bin/pytest` — **766 Tests bestanden**
- `cd backend && .venv/bin/ruff check app tests` — **bestanden**
- `cd backend && .venv/bin/uv lock --check` — **bestanden**
- `cd backend && .venv/bin/python -c "from app.main import app; assert app.title"` — **bestanden**
- `cd frontend && pnpm audit:language` — **bestanden, 0 unerlaubte Treffer**

## Migration und Rollout

- Keine Datenbank- oder Alembic-Migration
- Keine Frontendänderung
- Keine Big-Bang-Migration bestehender Fachdomänen
- Additive Erhöhung der Module-SDK-Version von `1.2.0` auf `1.3.0`