### PR TITLE
feat(modules): add module job registry

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run pytest
         working-directory: backend
         run: uv run pytest
+      - name: Verify module job contracts explicitly
+        working-directory: backend
+        run: uv run pytest tests/test_module_jobs.py
       - name: Verify observability contracts explicitly
         working-directory: backend
         run: uv run pytest tests/test_observability.py

--- a/backend/app/cli/process_domain_event_outbox.py
+++ b/backend/app/cli/process_domain_event_outbox.py
@@ -8,14 +8,17 @@ from fastapi import FastAPI
 from app.core.config import BACKEND_ENV_FILE, get_settings
 from app.db.session import AsyncSessionLocal
 from app.observability.jobs import observed_job
-from app.platform.events import InProcessEventBus, OutboxDispatcher
+from app.platform.events import InProcessEventBus
+from app.platform.events.jobs import domain_event_outbox_handler
 from app.platform.modules import (
     EntryPointModuleDiscovery,
     FirstPartyModuleDiscovery,
     create_module_runtime,
 )
 from app.platform.modules.context import ModuleContextFactory, ModuleHostServices
+from app.platform.modules.jobs import JobRunner, LegacyJobAdapter
 from app.platform.modules.persistence import HostDatabaseSessionProvider
+from app.platform.modules.sdk import JobSchedule, RetryPolicy
 from app.services.polygon_event_handlers import register_polygon_event_handlers
 
 
@@ -34,16 +37,29 @@ async def run(limit: int) -> dict[str, int]:
             module_env_file=BACKEND_ENV_FILE,
         ),
     )
+    registry = runtime.job_registry
+    assert registry is not None
+    legacy_jobs = LegacyJobAdapter(registry, module_id="host-events")
+    handler = domain_event_outbox_handler(
+        bus,
+        session_factory=AsyncSessionLocal,
+        worker_id=f"{socket.gethostname()}:{os.getpid()}",
+        limit=limit,
+    )
+    legacy_jobs.register(
+        job_id="host-events.outbox-dispatch",
+        handler=handler,
+        retry=RetryPolicy(max_attempts=1),
+        schedule=JobSchedule(interval_seconds=60),
+    )
     runtime.register(FastAPI())
     bus.seal()
     await runtime.startup()
     try:
-        dispatcher = OutboxDispatcher(
-            bus,
-            worker_id=f"{socket.gethostname()}:{os.getpid()}",
-        )
-        async with AsyncSessionLocal() as session:
-            return await dispatcher.run_once(session, limit=limit)
+        result = await JobRunner(registry).run("host-events.outbox-dispatch")
+        if not isinstance(result, dict):
+            raise TypeError("The domain event outbox job returned an invalid result.")
+        return result
     finally:
         await runtime.shutdown()
 

--- a/backend/app/observability/metrics.py
+++ b/backend/app/observability/metrics.py
@@ -109,6 +109,36 @@ JOB_DURATION = Histogram(
 JOB_LAST_SUCCESS = Gauge(
     "job_last_success_timestamp_seconds", "Last successful job completion", ("job_name",), registry=REGISTRY
 )
+MODULE_JOB_RUNS = Counter(
+    "module_job_runs_total",
+    "Completed module job runs",
+    ("module_id", "job_id", "result"),
+    registry=REGISTRY,
+)
+MODULE_JOB_FAILURES = Counter(
+    "module_job_failures_total",
+    "Failed module job attempts",
+    ("module_id", "job_id"),
+    registry=REGISTRY,
+)
+MODULE_JOB_RETRIES = Counter(
+    "module_job_retries_total",
+    "Retried module job attempts",
+    ("module_id", "job_id"),
+    registry=REGISTRY,
+)
+MODULE_JOB_DURATION = Histogram(
+    "module_job_duration_seconds",
+    "Module job run duration",
+    ("module_id", "job_id", "result"),
+    registry=REGISTRY,
+)
+MODULE_JOB_LAST_SUCCESS = Gauge(
+    "module_job_last_success_timestamp_seconds",
+    "Last successful module job completion",
+    ("module_id", "job_id"),
+    registry=REGISTRY,
+)
 OSM_REPLICATION_LAG = Gauge(
     "osm_replication_lag_seconds", "Age of the newest locally imported OSM feature", registry=REGISTRY
 )

--- a/backend/app/platform/events/jobs.py
+++ b/backend/app/platform/events/jobs.py
@@ -1,0 +1,31 @@
+"""Fachneutraler Legacy-Job-Adapter für den Domain-Event-Outbox-Dispatcher."""
+
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform.events.bus import InProcessEventBus
+from app.platform.events.outbox import OutboxDispatcher
+
+type SessionFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
+
+
+def domain_event_outbox_handler(
+    bus: InProcessEventBus,
+    *,
+    session_factory: SessionFactory,
+    worker_id: str,
+    limit: int,
+) -> Callable[[], Awaitable[dict[str, int]]]:
+    """Erzeuge den injizierten Handler, ohne Host-Settings oder globale DB-Imports."""
+
+    async def handler() -> dict[str, int]:
+        dispatcher = OutboxDispatcher(bus, worker_id=worker_id)
+        async with session_factory() as session:
+            return await dispatcher.run_once(session, limit=limit)
+
+    return handler
+
+
+__all__ = ["domain_event_outbox_handler"]

--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -14,11 +14,16 @@ from app.platform.modules.discovery import (
 )
 from app.platform.modules.errors import (
     DuplicateConfigNamespaceError,
+    DuplicateJobRegistrationError,
     DuplicateModuleIdError,
     DuplicatePersistenceSchemaError,
     DuplicateServiceRegistrationError,
     IncompatibleServiceVersionError,
     InvalidRuntimeVersionError,
+    JobExecutionError,
+    JobRegistryError,
+    JobRegistrySealedError,
+    JobTimeoutError,
     MissingModuleDependencyError,
     MissingRequiredServiceError,
     ModuleCompatibilityError,
@@ -43,6 +48,7 @@ from app.platform.modules.errors import (
     ServiceRegistryError,
     ServiceRegistrySealedError,
     UndeclaredServiceDependencyError,
+    UnknownJobError,
     UnsupportedManifestVersionError,
 )
 from app.platform.modules.manifest import (
@@ -68,10 +74,13 @@ from app.platform.modules.runtime import (
 )
 from app.platform.modules.sdk import (
     BackendModule,
+    JobDefinition,
+    JobSchedule,
     ModuleContext,
     ModuleMigrationSource,
     ModulePersistenceContribution,
     ModuleSettingsContribution,
+    RetryPolicy,
 )
 from app.platform.modules.services import ServiceRegistry
 
@@ -80,6 +89,7 @@ __all__ = [
     "MODULE_SDK_VERSION",
     "BackendModule",
     "DuplicateConfigNamespaceError",
+    "DuplicateJobRegistrationError",
     "DuplicateModuleIdError",
     "DuplicatePersistenceSchemaError",
     "DuplicateServiceRegistrationError",
@@ -87,6 +97,12 @@ __all__ = [
     "FirstPartyModuleDiscovery",
     "IncompatibleServiceVersionError",
     "InvalidRuntimeVersionError",
+    "JobDefinition",
+    "JobExecutionError",
+    "JobRegistryError",
+    "JobRegistrySealedError",
+    "JobSchedule",
+    "JobTimeoutError",
     "MissingModuleDependencyError",
     "MissingRequiredServiceError",
     "ModuleBackendPackage",
@@ -125,11 +141,13 @@ __all__ = [
     "ModuleShutdownError",
     "ModuleStartupError",
     "ModuleValidationError",
+    "RetryPolicy",
     "ServiceContractMismatchError",
     "ServiceRegistry",
     "ServiceRegistryError",
     "ServiceRegistrySealedError",
     "UndeclaredServiceDependencyError",
+    "UnknownJobError",
     "UnsupportedManifestVersionError",
     "create_module_runtime",
     "module_manifest_json_schema",

--- a/backend/app/platform/modules/context.py
+++ b/backend/app/platform/modules/context.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from app.platform.modules.contracts import ModuleRegistrationContext
+from app.platform.modules.jobs import JobRegistry
 from app.platform.modules.manifest import ModuleManifestV1
 from app.platform.modules.sdk import (
     CachePort,
@@ -103,6 +104,7 @@ class ModuleContextFactory:
         *,
         event_bus: "InProcessEventBus | None" = None,
         settings_registry: ModuleSettingsRegistry | None = None,
+        job_registry: JobRegistry | None = None,
         module_environment: Mapping[str, str] | None = None,
         module_env_file: Path | None = None,
     ) -> None:
@@ -119,6 +121,9 @@ class ModuleContextFactory:
                     environment=module_environment,
                 )
             )
+        self._job_registry: JobRegistry | None = None
+        if self._services.scheduler is None:
+            self._job_registry = job_registry or JobRegistry()
 
     @property
     def service_registry(self) -> "ServiceRegistry | None":
@@ -127,6 +132,10 @@ class ModuleContextFactory:
     @property
     def settings_registry(self) -> ModuleSettingsRegistry | None:
         return self._settings_registry
+
+    @property
+    def job_registry(self) -> JobRegistry | None:
+        return self._job_registry
 
     def create(
         self,
@@ -153,7 +162,10 @@ class ModuleContextFactory:
         settings_adapter = self._services.settings
         if settings_adapter is None and self._settings_registry is not None:
             settings_adapter = self._settings_registry.bind(manifest)
-        return ModuleContext(
+        scheduler_adapter = self._services.scheduler
+        if scheduler_adapter is None and self._job_registry is not None:
+            scheduler_adapter = self._job_registry.bind(manifest)
+        context = ModuleContext(
             module_id=manifest.id,
             module_version=manifest.version,
             api=registration,
@@ -166,6 +178,9 @@ class ModuleContextFactory:
             cache=self._services.cache,
             storage=self._services.storage,
             http=self._services.http,
-            scheduler=self._services.scheduler,
+            scheduler=scheduler_adapter,
             settings=settings_adapter,
         )
+        if scheduler_adapter is not None and self._job_registry is not None:
+            scheduler_adapter.attach_context(context)
+        return context

--- a/backend/app/platform/modules/errors.py
+++ b/backend/app/platform/modules/errors.py
@@ -365,3 +365,56 @@ class ModuleSettingsNamespaceError(ModuleSettingsError):
 
 class ModulePublicConfigError(ModuleSettingsError):
     """Ein als öffentlich markierter Wert ist nicht sicher exportierbar."""
+
+
+class JobRegistryError(RuntimeError):
+    """Basisklasse für sichere Fehler der modularen Job-Infrastruktur."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        job_id: str | None = None,
+        module_id: str | None = None,
+        provider_modules: Sequence[str] = (),
+        run_id: str | None = None,
+        attempt: int | None = None,
+    ) -> None:
+        context: list[str] = []
+        if job_id is not None:
+            context.append(f"job_id={job_id}")
+        if module_id is not None:
+            context.append(f"module_id={module_id}")
+        if provider_modules:
+            context.append(f"provider_modules={','.join(provider_modules)}")
+        if run_id is not None:
+            context.append(f"run_id={run_id}")
+        if attempt is not None:
+            context.append(f"attempt={attempt}")
+        suffix = f" ({', '.join(context)})" if context else ""
+        super().__init__(f"Module job error{suffix}: {message}")
+        self.job_id = job_id
+        self.module_id = module_id
+        self.provider_modules = tuple(provider_modules)
+        self.run_id = run_id
+        self.attempt = attempt
+
+
+class DuplicateJobRegistrationError(JobRegistryError):
+    """Eine globale Job-ID wurde durch mehrere Provider registriert."""
+
+
+class UnknownJobError(JobRegistryError):
+    """Die angeforderte stabile Job-ID ist nicht registriert."""
+
+
+class JobRegistrySealedError(JobRegistryError):
+    """Nach dem Bootstrap sind keine Job-Mutationen mehr erlaubt."""
+
+
+class JobExecutionError(JobRegistryError):
+    """Ein Job blieb nach seiner begrenzten Retry-Policy fehlerhaft."""
+
+
+class JobTimeoutError(JobExecutionError):
+    """Ein Job überschritt in seinem letzten Versuch das deklarierte Timeout."""

--- a/backend/app/platform/modules/jobs.py
+++ b/backend/app/platform/modules/jobs.py
@@ -1,0 +1,396 @@
+"""Host-owned Registry und Runner für modulgebundene Background Jobs."""
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from app.observability.metrics import (
+    MODULE_JOB_DURATION,
+    MODULE_JOB_FAILURES,
+    MODULE_JOB_LAST_SUCCESS,
+    MODULE_JOB_RETRIES,
+    MODULE_JOB_RUNS,
+)
+from app.platform.modules.errors import (
+    DuplicateJobRegistrationError,
+    JobExecutionError,
+    JobRegistryError,
+    JobRegistrySealedError,
+    JobTimeoutError,
+    UnknownJobError,
+)
+from app.platform.modules.manifest import ModuleManifestV1
+from app.platform.modules.sdk import (
+    JobDefinition,
+    JobSchedule,
+    LegacyJobHandler,
+    ModuleContext,
+    RetryPolicy,
+)
+
+if TYPE_CHECKING:
+    from prometheus_client import Counter, Gauge, Histogram
+
+logger = logging.getLogger(__name__)
+type Sleep = Callable[[float], Awaitable[None]]
+type RunIdFactory = Callable[[], UUID]
+
+
+class _JobAttemptTimedOut(TimeoutError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class JobDescriptor:
+    module_id: str
+    definition: JobDefinition
+    context: ModuleContext | None
+    legacy: bool = False
+
+    @property
+    def job_id(self) -> str:
+        return self.definition.job_id
+
+
+class JobRegistry:
+    """Runtime-skopierte Registry mit Ownership und deterministischer Reihenfolge."""
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, JobDescriptor] = {}
+        self._sealed = False
+
+    @property
+    def jobs(self) -> tuple[JobDescriptor, ...]:
+        return tuple(self._jobs[job_id] for job_id in sorted(self._jobs))
+
+    @property
+    def sealed(self) -> bool:
+        return self._sealed
+
+    def bind(self, manifest: ModuleManifestV1) -> "ModuleSchedulerAdapter":
+        return ModuleSchedulerAdapter(self, manifest)
+
+    def register(
+        self,
+        *,
+        module_id: str,
+        definition: JobDefinition,
+        context: ModuleContext,
+    ) -> None:
+        self._register(module_id, definition, context=context, legacy=False)
+
+    def register_legacy(
+        self,
+        *,
+        module_id: str,
+        definition: JobDefinition,
+    ) -> None:
+        """Expliziter Strangler-Adapter für bestehende zentrale Worker."""
+
+        self._register(module_id, definition, context=None, legacy=True)
+
+    def _register(
+        self,
+        module_id: str,
+        definition: JobDefinition,
+        *,
+        context: ModuleContext | None,
+        legacy: bool,
+    ) -> None:
+        if self._sealed:
+            raise JobRegistrySealedError(
+                "Job registration is closed.", job_id=definition.job_id, module_id=module_id
+            )
+        owner = definition.job_id.partition(".")[0]
+        if owner != module_id:
+            raise JobRegistryError(
+                "Jobs may be registered only in their provider module namespace.",
+                job_id=definition.job_id,
+                module_id=module_id,
+            )
+        existing = self._jobs.get(definition.job_id)
+        if existing is not None:
+            raise DuplicateJobRegistrationError(
+                "The job ID is already registered.",
+                job_id=definition.job_id,
+                module_id=module_id,
+                provider_modules=(existing.module_id, module_id),
+            )
+        self._jobs[definition.job_id] = JobDescriptor(
+            module_id=module_id,
+            definition=definition,
+            context=context,
+            legacy=legacy,
+        )
+        if definition.schedule is not None:
+            logger.info(
+                "Module job scheduled",
+                extra={
+                    "module_id": module_id,
+                    "job_id": definition.job_id,
+                    "job_phase": "scheduled",
+                    "schedule_interval_seconds": definition.schedule.interval_seconds,
+                },
+            )
+
+    def get(self, job_id: str) -> JobDescriptor:
+        try:
+            return self._jobs[job_id]
+        except KeyError as exc:
+            raise UnknownJobError("The requested job is not registered.", job_id=job_id) from exc
+
+    def seal(self) -> None:
+        self._sealed = True
+
+
+class ModuleSchedulerAdapter:
+    """An genau ein Modul und seinen ModuleContext gebundener Registrar."""
+
+    def __init__(self, registry: JobRegistry, manifest: ModuleManifestV1) -> None:
+        self._registry = registry
+        self._manifest = manifest
+        self._context: ModuleContext | None = None
+
+    def attach_context(self, context: ModuleContext) -> None:
+        if self._context is not None or context.module_id != self._manifest.id:
+            raise JobRegistryError(
+                "The scheduler adapter cannot be rebound.", module_id=self._manifest.id
+            )
+        self._context = context
+
+    def register(
+        self,
+        definition: JobDefinition | str,
+        handler: LegacyJobHandler | None = None,
+    ) -> None:
+        if isinstance(definition, str):
+            if handler is None:
+                raise TypeError("Compatibility job registration requires a handler.")
+
+            async def invoke(_context: ModuleContext) -> object | None:
+                return await handler()
+
+            definition = JobDefinition(job_id=definition, handler=invoke)
+        elif handler is not None:
+            raise TypeError("JobDefinition registration does not accept a second handler.")
+        if "." not in definition.job_id:
+            definition = replace(
+                definition,
+                job_id=f"{self._manifest.id}.{definition.job_id}",
+            )
+        if self._context is None:
+            raise JobRegistryError(
+                "The scheduler adapter is not bound to its module context.",
+                job_id=definition.job_id,
+                module_id=self._manifest.id,
+            )
+        self._registry.register(
+            module_id=self._manifest.id,
+            definition=definition,
+            context=self._context,
+        )
+
+
+class LegacyJobAdapter:
+    """Bindet einen vorhandenen parameterlosen Worker an die neue Registry."""
+
+    def __init__(self, registry: JobRegistry, *, module_id: str) -> None:
+        self._registry = registry
+        self._module_id = module_id
+
+    def register(
+        self,
+        *,
+        job_id: str,
+        handler: Callable[[], Awaitable[object | None]],
+        retry: RetryPolicy | None = None,
+        timeout_seconds: float | None = None,
+        schedule: JobSchedule | None = None,
+        allow_concurrent_runs: bool = False,
+    ) -> None:
+        async def invoke(_context: ModuleContext) -> object | None:
+            return await handler()
+
+        definition = JobDefinition(
+            job_id=job_id,
+            handler=invoke,
+            retry=retry or RetryPolicy(),
+            timeout_seconds=timeout_seconds,
+            schedule=schedule,
+            allow_concurrent_runs=allow_concurrent_runs,
+        )
+        self._registry.register_legacy(module_id=self._module_id, definition=definition)
+
+
+class _PrometheusJobMetrics:
+    runs: "Counter" = MODULE_JOB_RUNS
+    failures: "Counter" = MODULE_JOB_FAILURES
+    retries: "Counter" = MODULE_JOB_RETRIES
+    duration: "Histogram" = MODULE_JOB_DURATION
+    last_success: "Gauge" = MODULE_JOB_LAST_SUCCESS
+
+
+class JobRunner:
+    """Führt registrierte Jobs mit Timeout, begrenzten Retries und Telemetrie aus."""
+
+    def __init__(
+        self,
+        registry: JobRegistry,
+        *,
+        sleep: Sleep = asyncio.sleep,
+        run_id_factory: RunIdFactory = uuid4,
+        metrics: object | None = None,
+    ) -> None:
+        self._registry = registry
+        self._sleep = sleep
+        self._run_id_factory = run_id_factory
+        self._metrics = metrics or _PrometheusJobMetrics()
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    async def run(self, job_id: str) -> object | None:
+        if not self._registry.sealed:
+            raise JobRegistryError("Jobs cannot run before registration is sealed.", job_id=job_id)
+        descriptor = self._registry.get(job_id)
+        if descriptor.definition.allow_concurrent_runs:
+            return await self._execute(descriptor)
+        lock = self._locks.setdefault(job_id, asyncio.Lock())
+        async with lock:
+            return await self._execute(descriptor)
+
+    async def _execute(self, descriptor: JobDescriptor) -> object | None:
+        definition = descriptor.definition
+        run_id = str(self._run_id_factory())
+        started = time.perf_counter()
+        for attempt in range(1, definition.retry.max_attempts + 1):
+            attempt_started = time.perf_counter()
+            fields = _log_fields(descriptor, run_id=run_id, attempt=attempt)
+            logger.info("Module job started", extra={**fields, "job_phase": "started"})
+            try:
+                result = await self._invoke(descriptor)
+            except _JobAttemptTimedOut:
+                self._metrics.failures.labels(descriptor.module_id, definition.job_id).inc()
+                logger.error(
+                    "Module job timed out",
+                    extra={
+                        **fields,
+                        "job_phase": "timed_out",
+                        "job_duration_ms": _duration_ms(attempt_started),
+                        "error_type": "TimeoutError",
+                    },
+                )
+                if attempt == definition.retry.max_attempts:
+                    self._record_completion(descriptor, started, result="timed_out")
+                    raise JobTimeoutError(
+                        "The job exceeded its timeout.",
+                        job_id=definition.job_id,
+                        module_id=descriptor.module_id,
+                        run_id=run_id,
+                        attempt=attempt,
+                    ) from None
+            except Exception as exc:
+                self._metrics.failures.labels(descriptor.module_id, definition.job_id).inc()
+                logger.error(
+                    "Module job attempt failed",
+                    extra={
+                        **fields,
+                        "job_phase": "failed",
+                        "job_duration_ms": _duration_ms(attempt_started),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                if attempt == definition.retry.max_attempts:
+                    self._record_completion(descriptor, started, result="failed")
+                    raise JobExecutionError(
+                        "The job failed after its configured attempts.",
+                        job_id=definition.job_id,
+                        module_id=descriptor.module_id,
+                        run_id=run_id,
+                        attempt=attempt,
+                    ) from exc
+            else:
+                self._record_completion(descriptor, started, result="succeeded")
+                self._metrics.last_success.labels(
+                    descriptor.module_id, definition.job_id
+                ).set_to_current_time()
+                logger.info(
+                    "Module job succeeded",
+                    extra={
+                        **fields,
+                        "job_phase": "succeeded",
+                        "job_duration_ms": _duration_ms(attempt_started),
+                    },
+                )
+                return result
+
+            delay = definition.retry.delay_after(attempt)
+            self._metrics.retries.labels(descriptor.module_id, definition.job_id).inc()
+            logger.info(
+                "Module job retry scheduled",
+                extra={
+                    **fields,
+                    "job_phase": "retry_scheduled",
+                    "retry_delay_seconds": delay,
+                },
+            )
+            if delay:
+                await self._sleep(delay)
+        raise AssertionError("validated retry policy must execute at least once")
+
+    async def _invoke(self, descriptor: JobDescriptor) -> object | None:
+        context = descriptor.context
+        if context is None and not descriptor.legacy:
+            raise JobRegistryError(
+                "The registered module job has no ModuleContext.",
+                job_id=descriptor.job_id,
+                module_id=descriptor.module_id,
+            )
+        timeout = descriptor.definition.timeout_seconds
+        if timeout is None:
+            return await descriptor.definition.handler(context)  # type: ignore[arg-type]
+        timeout_scope = asyncio.timeout(timeout)
+        try:
+            async with timeout_scope:
+                return await descriptor.definition.handler(context)  # type: ignore[arg-type]
+        except TimeoutError as exc:
+            if timeout_scope.expired():
+                raise _JobAttemptTimedOut from exc
+            raise
+
+    def _record_completion(
+        self,
+        descriptor: JobDescriptor,
+        started: float,
+        *,
+        result: str,
+    ) -> None:
+        duration = time.perf_counter() - started
+        self._metrics.runs.labels(descriptor.module_id, descriptor.job_id, result).inc()
+        self._metrics.duration.labels(
+            descriptor.module_id, descriptor.job_id, result
+        ).observe(duration)
+
+
+def _log_fields(descriptor: JobDescriptor, *, run_id: str, attempt: int) -> dict[str, object]:
+    return {
+        "module_id": descriptor.module_id,
+        "job_id": descriptor.job_id,
+        "job_run_id": run_id,
+        "job_attempt": attempt,
+    }
+
+
+def _duration_ms(started: float) -> float:
+    return round((time.perf_counter() - started) * 1000, 3)
+
+
+__all__ = [
+    "JobDescriptor",
+    "JobRegistry",
+    "JobRunner",
+    "LegacyJobAdapter",
+    "ModuleSchedulerAdapter",
+]

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -22,6 +22,7 @@ from app.platform.modules.errors import (
     ModuleStartupError,
     ModuleValidationError,
 )
+from app.platform.modules.jobs import JobRegistry
 from app.platform.modules.manifest import ModuleManifestV1, parse_manifest, validate_manifests
 from app.platform.modules.sdk import BackendModule, ModuleContext, ModuleDefinition
 from app.platform.modules.services import ServiceRegistry
@@ -31,7 +32,7 @@ from app.platform.modules.settings import (
 )
 
 logger = logging.getLogger(__name__)
-MODULE_SDK_VERSION = "1.4.0"
+MODULE_SDK_VERSION = "1.5.0"
 
 
 @dataclass(slots=True)
@@ -80,10 +81,12 @@ class ModuleRuntime:
         *,
         service_registry: ServiceRegistry | None = None,
         settings_registry: ModuleSettingsRegistry | None = None,
+        job_registry: JobRegistry | None = None,
     ) -> None:
         self.registry = registry
         self._service_registry = service_registry
         self._settings_registry = settings_registry
+        self._job_registry = job_registry
         self._attached_app: FastAPI | None = None
         self._started: list[tuple[ModuleRecord, LifecycleContribution]] = []
         self._running = False
@@ -97,6 +100,10 @@ class ModuleRuntime:
         if self._settings_registry is None:
             return {}
         return self._settings_registry.public_config
+
+    @property
+    def job_registry(self) -> JobRegistry | None:
+        return self._job_registry
 
     def register(self, app: FastAPI) -> None:
         """Deklariere Beiträge einmalig und binde Router kontrolliert an den Host."""
@@ -122,6 +129,8 @@ class ModuleRuntime:
 
         if self._service_registry is not None:
             self._service_registry.seal()
+        if self._job_registry is not None:
+            self._job_registry.seal()
 
         for record in self.registry.records:
             for contribution in record.registration.routers:
@@ -251,6 +260,7 @@ def create_module_runtime(
         ModuleRegistry(records),
         service_registry=active_context_factory.service_registry,
         settings_registry=active_context_factory.settings_registry,
+        job_registry=active_context_factory.job_registry,
     )
 
 

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -29,12 +29,14 @@ from app.platform.modules.manifest import (
 
 type ModuleLifecycleHook = Callable[[], Awaitable[None]]
 type ModuleLoader = Callable[[], "BackendModule"]
-type JobHandler = Callable[[], Awaitable[None]]
+type JobHandler = Callable[["ModuleContext"], Awaitable[object | None]]
+type LegacyJobHandler = Callable[[], Awaitable[object | None]]
 type JsonScalar = str | int | float | bool | None
 type JsonValue = JsonScalar | list["JsonValue"] | Mapping[str, "JsonValue"]
 T = TypeVar("T")
 TSettings = TypeVar("TSettings", bound=BaseModel)
 _EVENT_NAME = re.compile(r"^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+$")
+_JOB_NAME = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 _REVISION_NAMESPACE = re.compile(r"^mod_[a-z][a-z0-9_]*$")
 _PYTHON_IMPORT_PACKAGE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$")
 
@@ -383,10 +385,94 @@ class HttpClientFactoryPort(Protocol):
     ) -> AbstractAsyncContextManager[HttpClientPort]: ...
 
 
-class SchedulerPort(Protocol):
-    """Registriert modulgebundene Jobs; Ausführung und Scheduling folgen in #100."""
+@dataclass(frozen=True, slots=True)
+class RetryPolicy:
+    """Kleine, deterministische Retry-Policy für einen Joblauf."""
 
-    def register(self, job_id: str, handler: JobHandler) -> None: ...
+    max_attempts: int = 1
+    initial_delay_seconds: float = 0
+    backoff_multiplier: float = 2
+    max_delay_seconds: float = 300
+
+    def __post_init__(self) -> None:
+        values = (
+            self.initial_delay_seconds,
+            self.backoff_multiplier,
+            self.max_delay_seconds,
+        )
+        if type(self.max_attempts) is not int or self.max_attempts < 1:
+            raise ValueError("Job retry max_attempts must be a positive integer.")
+        if any(type(value) not in (int, float) or not math.isfinite(value) for value in values):
+            raise ValueError("Job retry delays and multiplier must be finite numbers.")
+        if self.initial_delay_seconds < 0 or self.max_delay_seconds < 0:
+            raise ValueError("Job retry delays must not be negative.")
+        if self.backoff_multiplier < 1:
+            raise ValueError("Job retry backoff_multiplier must be at least one.")
+
+    def delay_after(self, attempt: int) -> float:
+        if type(attempt) is not int or attempt < 1:
+            raise ValueError("Job retry attempts must be positive integers.")
+        try:
+            delay = self.initial_delay_seconds * self.backoff_multiplier ** (attempt - 1)
+        except OverflowError:
+            return self.max_delay_seconds
+        return min(delay, self.max_delay_seconds)
+
+
+@dataclass(frozen=True, slots=True)
+class JobSchedule:
+    """Technologieunabhängige V1-Anforderung für ein Ausführungsintervall."""
+
+    interval_seconds: int
+
+    def __post_init__(self) -> None:
+        if type(self.interval_seconds) is not int or self.interval_seconds < 1:
+            raise ValueError("Job schedule intervals must be positive integer seconds.")
+
+
+@dataclass(frozen=True, slots=True)
+class JobDefinition:
+    """Öffentlicher, stabiler Job-Contract eines Moduls."""
+
+    job_id: str
+    handler: JobHandler
+    retry: RetryPolicy = RetryPolicy()
+    timeout_seconds: float | None = None
+    schedule: JobSchedule | None = None
+    allow_concurrent_runs: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.retry, RetryPolicy):
+            raise TypeError("Job retry must be a RetryPolicy.")
+        if self.schedule is not None and not isinstance(self.schedule, JobSchedule):
+            raise TypeError("Job schedule must be a JobSchedule.")
+        if (
+            not (_JOB_NAME.fullmatch(self.job_id) or _EVENT_NAME.fullmatch(self.job_id))
+            or len(self.job_id) > 160
+        ):
+            raise ValueError(
+                "Jobs must use a local job name or the form <module-id>.<job-name>."
+            )
+        if not callable(self.handler):
+            raise TypeError("Job handlers must be callable.")
+        if self.timeout_seconds is not None and (
+            type(self.timeout_seconds) not in (int, float)
+            or not math.isfinite(self.timeout_seconds)
+            or self.timeout_seconds <= 0
+        ):
+            raise ValueError("Job timeouts must be positive finite seconds.")
+        if type(self.allow_concurrent_runs) is not bool:
+            raise TypeError("allow_concurrent_runs must be a boolean.")
+
+
+class SchedulerPort(Protocol):
+    """Registriert Jobs ausschließlich im Namespace des gebundenen Moduls."""
+
+    @overload
+    def register(self, definition: JobDefinition) -> None: ...
+
+    @overload
+    def register(self, job_id: str, handler: LegacyJobHandler) -> None: ...
 
 
 class ModuleSettingsPort(Protocol):
@@ -479,9 +565,12 @@ __all__ = [
     "HttpClientFactoryPort",
     "HttpClientPort",
     "HttpResponsePort",
+    "JobDefinition",
     "JobHandler",
+    "JobSchedule",
     "JsonScalar",
     "JsonValue",
+    "LegacyJobHandler",
     "LifecycleRegistrar",
     "MetricsPort",
     "ModuleContext",
@@ -494,6 +583,7 @@ __all__ = [
     "ModuleSettingsPort",
     "ObservabilityPort",
     "PermissionPort",
+    "RetryPolicy",
     "SchedulerPort",
     "SerializableDomainEvent",
     "ServiceRegistryPort",

--- a/backend/app/platform/modules/testing.py
+++ b/backend/app/platform/modules/testing.py
@@ -4,7 +4,7 @@ import json
 import logging
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager, contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import TypeVar, cast
 
@@ -17,7 +17,8 @@ from app.platform.modules.sdk import (
     EventHandler,
     HttpClientPort,
     HttpResponsePort,
-    JobHandler,
+    JobDefinition,
+    LegacyJobHandler,
     ModuleContext,
     ObservabilityPort,
     SerializableDomainEvent,
@@ -294,13 +295,40 @@ class FakeHttpClientFactory:
 
 
 class FakeScheduler:
-    def __init__(self) -> None:
-        self.jobs: dict[str, JobHandler] = {}
+    def __init__(self, module_id: str | None = None) -> None:
+        self.module_id = module_id
+        self.jobs: dict[str, JobDefinition] = {}
 
-    def register(self, job_id: str, handler: JobHandler) -> None:
-        if job_id in self.jobs:
-            raise ValueError(f'Test job "{job_id}" is already registered.')
-        self.jobs[job_id] = handler
+    def register(
+        self,
+        definition: JobDefinition | str,
+        handler: LegacyJobHandler | None = None,
+    ) -> None:
+        if isinstance(definition, str):
+            if handler is None:
+                raise TypeError("Compatibility job registration requires a handler.")
+
+            async def invoke(_context: ModuleContext) -> object | None:
+                return await handler()
+
+            definition = JobDefinition(job_id=definition, handler=invoke)
+        elif handler is not None:
+            raise TypeError("JobDefinition registration does not accept a second handler.")
+        if "." not in definition.job_id and self.module_id is not None:
+            definition = replace(
+                definition,
+                job_id=f"{self.module_id}.{definition.job_id}",
+            )
+        if definition.job_id in self.jobs:
+            raise ValueError(f'Test job "{definition.job_id}" is already registered.')
+        self.jobs[definition.job_id] = definition
+
+    async def run(self, job_id: str, context: ModuleContext) -> object | None:
+        return await self.jobs[job_id].handler(context)
+
+
+class FakeJobRegistry(FakeScheduler):
+    """Benannter Job-Registry-Fake für Modultests ohne Host-Runner."""
 
 
 class FakeModuleSettings:
@@ -365,7 +393,7 @@ def create_test_module_context(
         cache=FakeCache(module_id),
         storage=FakeStorage(module_id),
         http=FakeHttpClientFactory(),
-        scheduler=FakeScheduler(),
+        scheduler=FakeJobRegistry(module_id),
         settings=FakeModuleSettings(settings, model=settings_model),
     )
 
@@ -376,6 +404,7 @@ __all__ = [
     "FakeHttpClient",
     "FakeHttpClientFactory",
     "FakeHttpResponse",
+    "FakeJobRegistry",
     "FakeMetrics",
     "FakeModuleSettings",
     "FakeObservability",

--- a/backend/tests/test_module_jobs.py
+++ b/backend/tests/test_module_jobs.py
@@ -1,0 +1,490 @@
+import ast
+import asyncio
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from prometheus_client import generate_latest
+
+from app.observability.metrics import (
+    MODULE_JOB_DURATION,
+    MODULE_JOB_FAILURES,
+    MODULE_JOB_LAST_SUCCESS,
+    MODULE_JOB_RETRIES,
+    MODULE_JOB_RUNS,
+    REGISTRY,
+)
+from app.platform.events import jobs as event_jobs
+from app.platform.modules.context import ModuleContextFactory, ModuleHostServices
+from app.platform.modules.contracts import ModuleDiscoveryProvider
+from app.platform.modules.errors import (
+    DuplicateJobRegistrationError,
+    JobExecutionError,
+    JobRegistryError,
+    JobRegistrySealedError,
+    JobTimeoutError,
+    UnknownJobError,
+)
+from app.platform.modules.jobs import JobRegistry, JobRunner, LegacyJobAdapter
+from app.platform.modules.runtime import create_module_runtime
+from app.platform.modules.sdk import (
+    JobDefinition,
+    JobSchedule,
+    ModuleContext,
+    ModuleDefinition,
+    RetryPolicy,
+    parse_manifest,
+)
+from app.platform.modules.testing import (
+    FakeEventBus,
+    FakeModuleSettings,
+    FakeServiceRegistry,
+    create_test_module_context,
+)
+
+FIXED_RUN_ID = UUID("00000000-0000-4000-8000-000000000100")
+
+
+@dataclass(frozen=True)
+class JobCompleted:
+    event_type: str = "job-module.completed"
+    event_version: int = 1
+
+
+class RecordingMetric:
+    def __init__(self) -> None:
+        self.labels_calls: list[tuple[str, ...]] = []
+        self.values: list[float] = []
+
+    def labels(self, *values: str) -> "RecordingMetric":
+        self.labels_calls.append(values)
+        return self
+
+    def inc(self) -> None:
+        self.values.append(1)
+
+    def observe(self, value: float) -> None:
+        self.values.append(value)
+
+    def set_to_current_time(self) -> None:
+        self.values.append(1)
+
+
+class RecordingJobMetrics:
+    def __init__(self) -> None:
+        self.runs = RecordingMetric()
+        self.failures = RecordingMetric()
+        self.retries = RecordingMetric()
+        self.duration = RecordingMetric()
+        self.last_success = RecordingMetric()
+
+
+async def successful_handler(_context: ModuleContext) -> str:
+    return "done"
+
+
+def job(job_id: str = "example.refresh", **overrides) -> JobDefinition:
+    return JobDefinition(job_id=job_id, handler=successful_handler, **overrides)
+
+
+def test_registry_records_owner_descriptor_schedule_and_on_demand_job() -> None:
+    registry = JobRegistry()
+    context = create_test_module_context(module_id="example")
+    scheduled = job(schedule=JobSchedule(interval_seconds=60))
+    on_demand = job("example.rebuild")
+
+    registry.register(module_id="example", definition=scheduled, context=context)
+    registry.register(module_id="example", definition=on_demand, context=context)
+
+    assert [(item.job_id, item.module_id) for item in registry.jobs] == [
+        ("example.rebuild", "example"),
+        ("example.refresh", "example"),
+    ]
+    assert registry.get("example.refresh").definition.schedule == JobSchedule(
+        interval_seconds=60
+    )
+    assert registry.get("example.rebuild").definition.schedule is None
+
+
+def test_duplicate_job_owner_and_sealed_registry_fail_fast() -> None:
+    registry = JobRegistry()
+    context = create_test_module_context(module_id="example")
+    registry.register(module_id="example", definition=job(), context=context)
+
+    with pytest.raises(DuplicateJobRegistrationError) as duplicate:
+        registry.register(module_id="example", definition=job(), context=context)
+    assert duplicate.value.job_id == "example.refresh"
+    assert duplicate.value.provider_modules == ("example", "example")
+
+    with pytest.raises(JobRegistryError, match="provider module namespace"):
+        registry.register(module_id="foreign", definition=job("example.foreign"), context=context)
+
+    registry.seal()
+    assert registry.sealed
+    with pytest.raises(JobRegistrySealedError):
+        registry.register(module_id="example", definition=job("example.closed"), context=context)
+    with pytest.raises(UnknownJobError):
+        registry.get("example.unknown")
+
+
+@pytest.mark.parametrize(
+    "factory",
+    (
+        lambda: JobSchedule(interval_seconds=0),
+        lambda: RetryPolicy(max_attempts=0),
+        lambda: RetryPolicy(initial_delay_seconds=-1),
+        lambda: JobDefinition(job_id="INVALID", handler=successful_handler),
+        lambda: JobDefinition(job_id="example.timeout", handler=successful_handler, timeout_seconds=0),
+        lambda: JobDefinition(
+            job_id="example.policy", handler=successful_handler, retry=None  # type: ignore[arg-type]
+        ),
+    ),
+)
+def test_invalid_job_contract_is_rejected(factory) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        factory()
+
+
+@dataclass
+class FakeDiscovery(ModuleDiscoveryProvider):
+    definitions: Sequence[ModuleDefinition]
+
+    def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        return self.definitions
+
+
+class JobModule:
+    manifest = parse_manifest(
+        {
+            "manifest_version": 1,
+            "id": "job-module",
+            "name": "Job module",
+            "version": "1.0.0",
+            "requires": {"host": ">=0.2.0,<1.0.0", "sdk": ">=1.5.0,<2.0.0"},
+        }
+    )
+
+    def __init__(self, seen: list[ModuleContext]) -> None:
+        self.seen = seen
+
+    def register(self, context: ModuleContext) -> None:
+        assert context.scheduler is not None
+
+        async def execute(supplied_context: ModuleContext) -> str:
+            self.seen.append(supplied_context)
+            assert supplied_context.database is not None
+            assert supplied_context.events is not None
+            assert supplied_context.services is not None
+            assert supplied_context.settings is not None
+            assert supplied_context.settings.require("value") == "configured"
+            await supplied_context.events.publish(JobCompleted())
+            return "module-result"
+
+        context.scheduler.register(
+            JobDefinition(
+                job_id="refresh",
+                handler=execute,
+                schedule=JobSchedule(interval_seconds=300),
+            )
+        )
+
+
+def module_definition(seen: list[ModuleContext]) -> ModuleDefinition:
+    return ModuleDefinition(
+        manifest=JobModule.manifest,
+        loader=lambda: JobModule(seen),
+        origin="tests:job-module",
+        declared_id="job-module",
+    )
+
+
+@pytest.mark.asyncio
+async def test_enabled_module_registers_job_and_runner_supplies_complete_context() -> None:
+    seen: list[ModuleContext] = []
+    definition = module_definition(seen)
+    database = object()
+    events = FakeEventBus()
+    services = FakeServiceRegistry()
+    settings = FakeModuleSettings({"value": "configured"})
+    runtime = create_module_runtime(
+        enabled_module_ids=("job-module",),
+        discovery_providers=(FakeDiscovery((definition,)),),
+        host_version="0.2.0",
+        context_factory=ModuleContextFactory(
+            ModuleHostServices(
+                database=database,  # type: ignore[arg-type]
+                events=events,
+                services=services,
+                settings=settings,
+            )
+        ),
+    )
+    runtime.register(FastAPI())
+    assert runtime.job_registry is not None
+    assert runtime.job_registry.sealed
+    assert runtime.job_registry.jobs[0].job_id == "job-module.refresh"
+
+    result = await JobRunner(runtime.job_registry).run("job-module.refresh")
+
+    assert result == "module-result"
+    assert seen == [runtime.registry.get("job-module").context]
+    assert events.published == [JobCompleted()]
+
+
+def test_disabled_module_contributes_no_jobs() -> None:
+    runtime = create_module_runtime(
+        enabled_module_ids=(),
+        discovery_providers=(FakeDiscovery((module_definition([]),)),),
+        host_version="0.2.0",
+    )
+    runtime.register(FastAPI())
+    assert runtime.job_registry is not None
+    assert runtime.job_registry.jobs == ()
+
+
+@pytest.mark.asyncio
+async def test_runner_retries_failed_handler_and_stops_at_max_attempts() -> None:
+    attempts = 0
+
+    async def failing(_context: ModuleContext) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("provider unavailable")
+
+    definition = JobDefinition(
+        job_id="example.retry",
+        handler=failing,
+        retry=RetryPolicy(max_attempts=3, initial_delay_seconds=0),
+    )
+    registry = sealed_registry(definition)
+    metrics = RecordingJobMetrics()
+
+    with pytest.raises(JobExecutionError) as error:
+        await JobRunner(
+            registry, metrics=metrics, run_id_factory=lambda: FIXED_RUN_ID
+        ).run(definition.job_id)
+
+    assert attempts == 3
+    assert error.value.attempt == 3
+    assert len(metrics.failures.values) == 3
+    assert len(metrics.retries.values) == 2
+    assert metrics.runs.labels_calls == [("example", "example.retry", "failed")]
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_a_failed_attempt_and_uses_retry_policy() -> None:
+    attempts = 0
+
+    async def hanging(_context: ModuleContext) -> None:
+        nonlocal attempts
+        attempts += 1
+        await asyncio.sleep(1)
+
+    definition = JobDefinition(
+        job_id="example.timeout",
+        handler=hanging,
+        retry=RetryPolicy(max_attempts=2),
+        timeout_seconds=0.01,
+    )
+    metrics = RecordingJobMetrics()
+
+    with pytest.raises(JobTimeoutError) as error:
+        await JobRunner(sealed_registry(definition), metrics=metrics).run(definition.job_id)
+
+    assert attempts == 2
+    assert error.value.attempt == 2
+    assert len(metrics.failures.values) == 2
+    assert len(metrics.retries.values) == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_timeout_error_without_deadline_is_a_regular_failure() -> None:
+    async def provider_timeout(_context: ModuleContext) -> None:
+        raise TimeoutError("provider timeout")
+
+    definition = JobDefinition(job_id="example.provider-timeout", handler=provider_timeout)
+
+    with pytest.raises(JobExecutionError) as error:
+        await JobRunner(
+            sealed_registry(definition), metrics=RecordingJobMetrics()
+        ).run(definition.job_id)
+
+    assert not isinstance(error.value, JobTimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_failed_job_does_not_block_another_registered_job() -> None:
+    async def failing(_context: ModuleContext) -> None:
+        raise RuntimeError("isolated failure")
+
+    registry = JobRegistry()
+    context = create_test_module_context(module_id="example")
+    registry.register(
+        module_id="example",
+        definition=JobDefinition(job_id="example.fail", handler=failing),
+        context=context,
+    )
+    registry.register(module_id="example", definition=job("example.succeed"), context=context)
+    registry.seal()
+    runner = JobRunner(registry, metrics=RecordingJobMetrics())
+
+    with pytest.raises(JobExecutionError):
+        await runner.run("example.fail")
+
+    assert await runner.run("example.succeed") == "done"
+
+
+@pytest.mark.asyncio
+async def test_success_updates_metrics_and_structured_logs(caplog) -> None:
+    definition = job("example.observe")
+    metrics = RecordingJobMetrics()
+    runner = JobRunner(
+        sealed_registry(definition),
+        metrics=metrics,
+        run_id_factory=lambda: FIXED_RUN_ID,
+    )
+
+    with caplog.at_level(logging.INFO):
+        assert await runner.run(definition.job_id) == "done"
+
+    succeeded = next(
+        record for record in caplog.records if getattr(record, "job_phase", None) == "succeeded"
+    )
+    assert succeeded.module_id == "example"
+    assert succeeded.job_id == "example.observe"
+    assert succeeded.job_run_id == str(FIXED_RUN_ID)
+    assert succeeded.job_attempt == 1
+    assert succeeded.job_duration_ms >= 0
+    assert metrics.runs.labels_calls == [("example", "example.observe", "succeeded")]
+    assert metrics.last_success.labels_calls == [("example", "example.observe")]
+    assert metrics.duration.values[0] >= 0
+
+
+@pytest.mark.asyncio
+async def test_prometheus_metrics_use_only_bounded_job_labels() -> None:
+    definition = job("metrics-module.observe")
+    registry = sealed_registry(definition, module_id="metrics-module")
+    before = MODULE_JOB_RUNS.labels(
+        "metrics-module", definition.job_id, "succeeded"
+    )._value.get()
+
+    await JobRunner(registry, run_id_factory=lambda: FIXED_RUN_ID).run(definition.job_id)
+
+    assert (
+        MODULE_JOB_RUNS.labels(
+            "metrics-module", definition.job_id, "succeeded"
+        )._value.get()
+        == before + 1
+    )
+    assert MODULE_JOB_FAILURES.labels("metrics-module", definition.job_id)._value.get() == 0
+    assert MODULE_JOB_RETRIES.labels("metrics-module", definition.job_id)._value.get() == 0
+    assert MODULE_JOB_DURATION.labels(
+        "metrics-module", definition.job_id, "succeeded"
+    )._sum.get() >= 0
+    assert MODULE_JOB_LAST_SUCCESS.labels(
+        "metrics-module", definition.job_id
+    )._value.get() > 0
+    assert str(FIXED_RUN_ID) not in generate_latest(REGISTRY).decode()
+
+
+@pytest.mark.asyncio
+async def test_default_concurrency_serializes_same_job() -> None:
+    running = 0
+    maximum = 0
+
+    async def handler(_context: ModuleContext) -> None:
+        nonlocal running, maximum
+        running += 1
+        maximum = max(maximum, running)
+        await asyncio.sleep(0)
+        running -= 1
+
+    definition = JobDefinition(job_id="example.serial", handler=handler)
+    runner = JobRunner(sealed_registry(definition), metrics=RecordingJobMetrics())
+
+    await asyncio.gather(runner.run(definition.job_id), runner.run(definition.job_id))
+
+    assert maximum == 1
+
+
+@pytest.mark.asyncio
+async def test_domain_event_outbox_pilot_uses_injected_worker_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[object, int]] = []
+    session = object()
+
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *_args) -> None:
+            return None
+
+    class FakeDispatcher:
+        def __init__(self, _bus, *, worker_id: str) -> None:
+            assert worker_id == "worker-1"
+
+        async def run_once(self, supplied_session, *, limit: int):
+            calls.append((supplied_session, limit))
+            return {"processed": 2}
+
+    monkeypatch.setattr(event_jobs, "OutboxDispatcher", FakeDispatcher)
+    handler = event_jobs.domain_event_outbox_handler(
+        FakeEventBus(),
+        session_factory=FakeSessionContext,
+        worker_id="worker-1",
+        limit=25,
+    )
+    registry = JobRegistry()
+    LegacyJobAdapter(registry, module_id="host-events").register(
+        job_id="host-events.outbox-dispatch",
+        handler=handler,
+        schedule=JobSchedule(interval_seconds=60),
+    )
+    registry.seal()
+
+    assert await JobRunner(
+        registry, metrics=RecordingJobMetrics()
+    ).run("host-events.outbox-dispatch") == {"processed": 2}
+    assert calls == [(session, 25)]
+
+
+def test_pilot_handler_has_no_forbidden_host_imports_and_deployment_command_is_stable() -> None:
+    source = Path(event_jobs.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    )
+    assert imports.isdisjoint({"app.core.config", "app.db.session", "app.cache.redis"})
+
+    root = Path(__file__).resolve().parents[2]
+    ansible = (root / "deploy/ansible/roles/stadtplaner/tasks/main.yml").read_text(
+        encoding="utf-8"
+    )
+    command = "python -m app.cli.process_domain_event_outbox --limit 50"
+    assert command in ansible
+
+
+def sealed_registry(
+    definition: JobDefinition,
+    *,
+    module_id: str = "example",
+) -> JobRegistry:
+    registry = JobRegistry()
+    context = create_test_module_context(module_id=module_id)
+    registry.register(module_id=module_id, definition=definition, context=context)
+    registry.seal()
+    return registry

--- a/backend/tests/test_module_sdk.py
+++ b/backend/tests/test_module_sdk.py
@@ -79,7 +79,7 @@ def test_runtime_context_is_bound_to_manifest_and_unimplemented_ports_are_absent
     assert context.cache is None
     assert context.storage is None
     assert context.http is None
-    assert context.scheduler is None
+    assert context.scheduler is not None
     assert context.settings is None
     assert context.logger.extra == {
         "module_id": "test-example-module",
@@ -203,7 +203,7 @@ async def test_public_test_context_fakes_need_no_infrastructure() -> None:
         assert (await client.request("GET", "/status")).json() == {"status": "ok"}
 
     context.scheduler.register("refresh", _noop_hook)
-    assert context.scheduler.jobs == {"refresh": _noop_hook}
+    assert tuple(context.scheduler.jobs) == ("example-module.refresh",)
     assert context.settings.require("endpoint") == "https://example.invalid"
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 - [Backend-Module-Runtime](modules/backend-module-runtime.md)
 - [Öffentliches Backend-Module-SDK](modules/backend-module-sdk.md)
 - [Domain Events und transaktionale Outbox](modules/domain-events.md)
+- [Modulare Background Jobs](modules/background-jobs.md)
 - [Modul-Datenbanken und Migrationen](modules/database-and-migrations.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,13 @@ Diese Anleitung bündelt den produktiven Betrieb des aktuellen Repositorys. Spez
 - PostgreSQL mit PostGIS ist die fachliche Datenbank.
 - Redis dient als Cache und als gemeinsames Backend für produktive Sicherheitszähler. Er ist keine fachliche Datenquelle.
 - Ein Reverse Proxy veröffentlicht Frontend und API über HTTPS.
-- systemd-Timer starten OSM-Sync, Statistikimport, E-Mail-Outbox und optional Social Publishing.
+- systemd-Timer starten OSM-Sync, Statistikimport, E-Mail-/Domain-Event-Outbox und optional Social Publishing.
+
+Moduljobs deklarieren fachliche Intervalle über die
+[Job-Registry](modules/background-jobs.md). In V1 bleibt systemd der technische,
+single-owner Scheduler; der Host startet keinen parallelen In-Process-Timer. Der
+bestehende Domain-Event-Outbox-Befehl und seine Unit bleiben unverändert und laufen
+intern über den generischen Job-Runner.
 
 ## Voraussetzungen
 

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -67,7 +67,7 @@ Sub-Interfaces `context.api` und `context.lifecycle`.
 | `observability` | `ObservabilityPort` | immer vorhanden; Logger ist an Modul-ID/-Version gebunden |
 | `storage` | `StoragePort` | optionaler modulgebundener Blob-Storage |
 | `http` | `HttpClientFactoryPort` | optionaler sicherer Client-Port |
-| `scheduler` | `SchedulerPort` | optionaler Port; Job Runtime folgt in #100 |
+| `scheduler` | `SchedulerPort` | modulgebundene Job-Registry und Job-Definitionen aus #100 |
 | `settings` | `ModuleSettingsPort` | typisierte, namespacete Runtime aus #99 |
 
 Ein optionaler Port mit dem Wert `None` ist nicht durch den Host bereitgestellt. Das
@@ -99,9 +99,10 @@ Die Ports machen keine Redis-, Dateisystem- oder Cloud-SDK-Typen öffentlich.
 
 Der Event-Port ist durch die [Domain-Event- und Outbox-Infrastruktur](domain-events.md)
 implementiert. Die [Cross-Module-Service-Registry](service-contracts.md) stellt
-versionierte öffentliche Query-/Service-Contracts bereit. Permission Policy und
-Job-Ausführung bleiben ihren Folge-Issues vorbehalten. Die Service-Auflösung ist
-kein allgemeiner Service Locator.
+versionierte öffentliche Query-/Service-Contracts bereit. Der
+[Background-Job-Vertrag](background-jobs.md) registriert stabile Job-IDs, Retry,
+Timeout und optionale Intervallanforderungen. Permission Policy bleibt #104
+vorbehalten. Die Service-Auflösung ist kein allgemeiner Service Locator.
 
 ### Modulkonfiguration
 
@@ -149,7 +150,9 @@ Persistence-Contracts und der produktive Datenbank-Session-Adapter aus #97 erhö
 sie auf `1.2.0`. Die additive, versionierte Service-Registry aus #98 erhöht sie auf
 `1.3.0`. Die additive typisierte Settings-API und `ModuleSettingsContribution` aus
 #99 erhöhen sie auf `1.4.0`; der minimale `DomainEvent`-Contract aus 1.0 und die
-#94-Proxys bleiben kompatibel.
+#94-Proxys bleiben kompatibel. Die additive Job-Definition, Registry und Ausführung
+aus #100 erhöhen sie auf `1.5.0`; die einfache Scheduler-Registrierung aus #95
+bleibt als Kompatibilitätsform erhalten.
 
 - **MAJOR:** Entfernen oder Umbenennen öffentlicher Methoden, inkompatible Änderungen
   an vorhandener Semantik oder eine inkompatible Context-Struktur.

--- a/docs/modules/background-jobs.md
+++ b/docs/modules/background-jobs.md
@@ -1,0 +1,154 @@
+# Modulare Background Jobs
+
+Die Job-Infrastruktur aus #100 setzt die Job-Grenze aus
+[ADR #92](../architecture/adr-modular-host-and-module-boundaries.md) um. Der Host
+besitzt Registry, Ausführung und Telemetrie. Ein Modul besitzt stabile Job-IDs,
+Handler, Retry-/Timeout-Policy, fachliche Idempotenz und eine optionale
+Schedule-Anforderung.
+
+## Bestehende Background-Flows
+
+Die Einführung ersetzt die vorhandenen Worker nicht flächendeckend. Das Audit der
+Legacy-Basis ergibt:
+
+| Flow | Start und Process Owner | Retry / Timeout | Observability | Status in #100 |
+| --- | --- | --- | --- | --- |
+| Domain-Event-Outbox | CLI `process_domain_event_outbox`, minütlicher systemd-Timer | persistente Delivery-Retries, Dead Letter und verwaiste DB-Claims | Event-Spans, Logs, Event-/Outbox- und Jobmetriken | Pilot über `host-events.outbox-dispatch` |
+| Social/Mastodon | CLI `publish_social_outbox`, optionaler minütlicher Timer | persistenter Provider-Backoff, Max Attempts, HTTP-/Screenshot-Timeouts | `observed_job`, Outbox- und Providermetriken | unverändert |
+| E-Mail-Outbox | CLI `process_email_outbox`, minütlicher Timer | persistente geplante Retries, Max Attempts und terminale Fehler | `observed_job`, Outbox-Metriken und Auditlog | unverändert |
+| Polygon-Outbox | CLI `process_polygon_outbox`; kein verwalteter Ansible-Timer in der aktuellen Rolle | acht Versuche, exponentieller Backoff, Dead Letter und stale Claim Recovery | Outbox-Metriken und Logs | unverändert; neue Events nutzen bereits die gemeinsame Event-Outbox |
+| Notification Cleanup | manuelle CLI `cleanup_notifications` | kein eigener Retry-/Timeout-Contract | Abschlusslog und CLI-Ergebnis | unverändert |
+| Cache Maintenance | manuelle CLIs für Status, Clear und Versions-Bump | kein eigener Retry-/Timeout-Contract | CLI-Ergebnis und Redis-Metriken | unverändert |
+| OSM/Open-Data | systemd-Timer startet das bestehende Sync-Skript; Postprocessing nutzt `observed_job` | systemd-Neustart beim nächsten Intervall, Provider-/DB-Timeouts im jeweiligen Schritt | Job-, OSM-, Provider- und DB-Metriken sowie Fortschrittslogs | unverändert |
+| Statistik-Refresh | CLI `import_flensburg_statistics`, wöchentlicher systemd-Timer | kein unmittelbarer Job-Retry; nächster Timerlauf, HTTP-Client-Timeouts | `observed_job` und Importbericht | unverändert |
+| Map Preview | synchron auf Cache Miss im API-Prozess; separater Renderer-Service | Renderer-HTTP-Timeout; kein Background-Schedule | Provider-Telemetrie und Cache | kein Job und unverändert |
+
+Es existiert keine zentrale Queue, kein Broker und kein produktiver In-Process-
+Scheduler. GitHub-Actions-Cronjobs betreffen Repositoryprüfungen und sind keine
+fachlichen Runtime-Jobs.
+
+## Öffentlicher SDK-Contract
+
+Module registrieren während `module.register(context)` eine `JobDefinition` über
+den bereits in #95 eingeführten `context.scheduler`-Port:
+
+```python
+from app.platform.modules.sdk import JobDefinition, JobSchedule, ModuleContext, RetryPolicy
+
+
+async def refresh(context: ModuleContext) -> None:
+    assert context.settings is not None
+    assert context.database is not None
+    settings = context.settings.require(StatisticsSettings)
+    async with context.database.session() as session:
+        await refresh_statistics(session, settings)
+
+
+def register(context: ModuleContext) -> None:
+    assert context.scheduler is not None
+    context.scheduler.register(
+        JobDefinition(
+            job_id="refresh",
+            handler=refresh,
+            retry=RetryPolicy(
+                max_attempts=3,
+                initial_delay_seconds=5,
+                backoff_multiplier=2,
+                max_delay_seconds=60,
+            ),
+            timeout_seconds=120,
+            schedule=JobSchedule(interval_seconds=86_400),
+        )
+    )
+```
+
+Das Modul deklariert nur den stabilen lokalen Jobnamen. Der gebundene Port leitet
+daraus deterministisch `<module-id>.<job-name>` ab; im Beispiel entsteht
+`statistics.refresh`. Vollqualifizierte IDs bleiben kompatibel, müssen aber dem
+registrierenden Modul gehören. Function-Namen sind keine Job-Identität. Die Registry
+hält den owning `module_id`, den vollständigen Descriptor und den gebundenen
+`ModuleContext`. Nur aktivierte Module werden instanziiert und können Jobs
+registrieren. Nach Abschluss aller `register()`-Hooks wird die Registry versiegelt.
+
+Die einfache Form `context.scheduler.register("refresh", handler)` aus dem frühen
+#95-Port bleibt kompatibel und wird ebenfalls zum Modulnamespace qualifiziert. Neue
+Module verwenden `JobDefinition`, um Retry, Timeout und Schedule explizit zu machen.
+
+## Ausführung, Retry und Timeout
+
+`JobRunner.run(job_id)` erzeugt pro Aufruf eine UUID-Run-ID und übergibt dem Handler
+den owning `ModuleContext`. Damit verwendet Jobcode Settings aus #99, Services aus
+#98, Datenbankprimitives aus #97 und Events aus #96, ohne globale Host-Settings,
+Session-Factories oder Fachimporte anderer Module.
+
+Ein Timeout zählt als fehlgeschlagener Versuch. Nach jedem fehlgeschlagenen Versuch
+steigt der Retry-Zähler; der nächste Abstand ist durch initiale Verzögerung,
+Multiplikator und Maximalverzögerung begrenzt. Nach `max_attempts` endet der Lauf mit
+`JobExecutionError` beziehungsweise `JobTimeoutError`. Es gibt keine endlose
+Wiederholung. Andere Jobs und die Module-Runtime bleiben von diesem Fehler
+unberührt.
+
+Handler müssen retry-sicher sein: Ein Versuch kann nach einem externen Side-Effect
+scheitern. Deduplizierung, Unique Constraints oder providerseitige Idempotency-Keys
+bleiben deshalb fachliche Verantwortung. Der Job-Runner ersetzt nicht die
+persistente Retry-/Dead-Letter-Semantik einer Outbox.
+
+## Scheduling und Parallelität
+
+V1 unterstützt eine optionale, validierte Intervallanforderung in positiven ganzen
+Sekunden. Das Modul beschreibt damit den fachlich gewünschten Rhythmus; der Host
+entscheidet über die technische Umsetzung. Produktionsseitig bleibt systemd der
+einzige Scheduler. Es wird kein zweiter In-Process-Timer gestartet und keine
+verteilte Lock-Infrastruktur behauptet.
+
+`allow_concurrent_runs` ist standardmäßig `False`. Innerhalb eines Prozesses
+serialisiert der Runner gleichzeitige Aufrufe derselben Job-ID. systemd beziehungsweise
+eine spätere technische Scheduler-Ebene muss zusätzlich Single-Owner sicherstellen,
+wenn mehrere Prozesse oder Hosts denselben Schedule sehen. Bereits vorhandenes
+DB-Claiming, etwa `FOR UPDATE SKIP LOCKED` in Outboxes, bleibt erhalten.
+
+## Observability
+
+Strukturierte Logs verwenden `module_id`, `job_id`, `job_run_id`, `job_attempt`,
+`job_phase` und die gemessene Laufzeit. Unterstützte Phasen sind `scheduled`,
+`started`, `succeeded`, `failed`, `retry_scheduled` und `timed_out`. Run-IDs und
+Fehlerdetails werden niemals als Metriklabel verwendet.
+
+Metriken:
+
+- `module_job_runs_total{module_id,job_id,result}`
+- `module_job_failures_total{module_id,job_id}`
+- `module_job_retries_total{module_id,job_id}`
+- `module_job_duration_seconds{module_id,job_id,result}`
+- `module_job_last_success_timestamp_seconds{module_id,job_id}`
+
+Modul- und Job-IDs stammen ausschließlich aus deploy-time registriertem Code und
+sind damit begrenzt. Der letzte Erfolg ist in V1 eine In-Memory-Gauge; Job-Historie
+wird nicht in einer neuen Datenbanktabelle gespeichert.
+
+## Pilot und Deployment-Kompatibilität
+
+Der bestehende Domain-Event-Outbox-Worker registriert vor dem Versiegeln der Runtime
+den Legacy-Adapter `host-events.outbox-dispatch` und führt ihn über `JobRunner` aus.
+Die injizierte Handler-Funktion importiert weder Host-Settings noch globale DB- oder
+Cache-Module. Der Composition-Root injiziert die bestehende Session-Factory, solange
+der Legacy-Worker noch eigene Commit-Grenzen für Claims und Deliveries benötigt.
+
+Der bestehende Befehl bleibt unverändert:
+
+```bash
+python -m app.cli.process_domain_event_outbox --limit 50
+```
+
+Auch `stadtplaner-domain-event-outbox.service` und sein minütlicher Timer bleiben
+unverändert. Der Pilot verwendet `RetryPolicy(max_attempts=1)`, weil die Outbox ihre
+fünf persistierten Zustellversuche bereits selbst kontrolliert. Rollback bedeutet
+daher lediglich, den vorherigen Release auszuführen; Datenmodell und Deployment-
+Units wurden nicht verändert.
+
+## Scope
+
+#100 führt weder Celery, Kafka, RabbitMQ, Redis Queue, APScheduler, Airflow, Temporal
+noch eine Workflow-DAG oder Job-History-Tabelle ein. Domain Events bleiben Events;
+Jobs ersetzen sie nicht. Weitere Legacy-Worker werden erst in eigenen fachlichen
+Migrationen übernommen.

--- a/docs/modules/domain-events.md
+++ b/docs/modules/domain-events.md
@@ -155,13 +155,18 @@ Alter des ältesten noch nicht vollständig verarbeiteten Events.
 
 `python -m app.cli.process_domain_event_outbox --limit 50` führt einen begrenzten
 Dispatch-Lauf aus. Das Deployment startet ihn minütlich über
-`stadtplaner-domain-event-outbox.timer`; es wird kein allgemeines Scheduler- oder
-Job-Framework eingeführt.
+`stadtplaner-domain-event-outbox.timer`. Seit #100 wird dieser bestehende Flow als
+Pilotjob `host-events.outbox-dispatch` durch die modulare Job-Registry ausgeführt;
+CLI und systemd-Unit bleiben kompatibel. Der Job-Runner versucht den Dispatcher
+genau einmal. Die persistente Zustell-Retry-/Dead-Letter-Semantik verbleibt allein
+beim Outbox-Dispatcher und wird nicht durch eine zweite unmittelbare Retry-Schicht
+verdoppelt.
 
 Erfolgreich oder endgültig abgeschlossene Events sollen nach einer betrieblich
 festgelegten Diagnosefrist, empfohlen 30 Tage, gelöscht werden. Dafür existiert der
-explizite Service-Hook `delete_processed_events_before`; automatische Planung bleibt
-#100 vorbehalten. Dead-Letter-Details müssen vor einer Bereinigung ausgewertet sein.
+explizite Service-Hook `delete_processed_events_before`; eine automatische
+Bereinigung ist noch nicht registriert. Dead-Letter-Details müssen vor einer
+Bereinigung ausgewertet sein.
 
 ## Sicherheit und Datenschutz
 


### PR DESCRIPTION
Part of #91

Closes #100

## Ausgangslage

Module konnten über den in #95 eingeführten Scheduler-Port bislang keine Jobs mit einem stabilen, hostseitig kontrollierten Ausführungsvertrag registrieren. Bestehende Background-Worker verwendeten zudem unterschiedliche Start-, Retry- und Observability-Pfade.

## Umsetzung

- `JobDefinition`, `RetryPolicy` und optionale Intervall-Schedules als öffentlichen SDK-Contract ergänzt
- hostseitige Job-Registry mit Modul-Ownership und deterministischen Job-IDs eingeführt
- Registry nach Abschluss der Modulregistrierung versiegelt
- Job-Runner mit begrenzten Retries, Timeouts und Fehlerisolation umgesetzt
- parallele Ausführung derselben Job-ID standardmäßig verhindert
- vollständigen `ModuleContext` mit Settings, Services, Persistence und Events an Moduljobs gebunden
- strukturierte Logs und niedrig-kardinale Prometheus-Metriken ergänzt
- bestehende Background-Flows und Betriebsgrenzen dokumentiert
- Job-Contract explizit in das Backend-CI-Gate aufgenommen

## Pilot

Der bestehende Domain-Event-Outbox-Worker wird als Pilot über den Legacy-Adapter `host-events.outbox-dispatch` registriert und durch den neuen `JobRunner` ausgeführt.

Dabei bleiben unverändert:

- CLI-Aufruf
- systemd-Service und Timer
- persistente Retry- und Dead-Letter-Semantik der Outbox
- bestehende Claim- und Commit-Grenzen

Der Pilot verwendet bewusst nur einen Job-Runner-Versuch, da die Outbox ihre Zustellwiederholungen bereits persistent verwaltet.

## Betrieb und Migration

- kein neuer Broker
- kein produktiver In-Process-Scheduler
- systemd bleibt der einzige produktive Scheduler
- keine Datenbankmigration
- keine neuen Dependencies
- keine Lockfile-Änderungen
- Rollback durch Deployment des vorherigen Releases möglich

## Tests

- `cd backend && .venv/bin/python -m uv lock --check`
- `cd backend && .venv/bin/python -m uv run ruff check app tests`
- `cd backend && .venv/bin/python -m uv run pytest` — **813 bestanden**
- `cd backend && .venv/bin/python -m uv run python -c "from app.main import app; assert app.title"`
- `cd frontend && pnpm vitest run tests/ansible-deployment.test.ts` — **11 bestanden**
- `cd frontend && pnpm audit:language` — **484 Ressourcen geprüft, 0 unerlaubte Treffer**