### PR TITLE
feat(frontend): add module UI contribution SDK

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -38,7 +38,7 @@ jobs:
         run: pnpm test
       - name: Verify frontend module contracts explicitly
         working-directory: frontend
-        run: pnpm vitest run tests/frontend-module-host.test.ts
+        run: pnpm vitest run tests/frontend-module-host.test.ts tests/frontend-ui-contributions.test.ts
       - name: Verify enabled frontend module SSR explicitly
         working-directory: frontend
         run: pnpm test:modules:ssr

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 
 - [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
 - [ADR: Frontend-Module als Build-Time Nuxt Layers](architecture/adr-frontend-build-time-modules.md)
+- [ADR: Frontend UI Extension Points](architecture/adr-frontend-ui-extension-points.md)
 - [ADR: Datenbank- und Migrations-Ownership von Modulen](architecture/adr-module-database-and-migration-ownership.md)
 - [Module Manifest Schema V1](modules/module-manifest-v1.md)
 - [Backend-Module-Runtime](modules/backend-module-runtime.md)
@@ -21,6 +22,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 - [Domain Events und transaktionale Outbox](modules/domain-events.md)
 - [Modulare Background Jobs](modules/background-jobs.md)
 - [Frontend-Host und Build-Time-Module](modules/frontend-host.md)
+- [Frontend UI Contributions](modules/frontend-ui-contributions.md)
 - [Modul-Datenbanken und Migrationen](modules/database-and-migrations.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)

--- a/docs/architecture/adr-frontend-build-time-modules.md
+++ b/docs/architecture/adr-frontend-build-time-modules.md
@@ -152,7 +152,8 @@ Polygon-, Auth-, OSM-, Assistant- und Analysis-Area-Seiten bleiben unverändert.
 - Shared Dependencies bleiben im Host-Bundle und werden nicht pro Modul isoliert.
 - Discovery fügt nur synchrone lokale Dateiprüfungen vor dem bestehenden Nuxt-
   Lifecycle hinzu und erzeugt keinen Runtime-Failure-Mode.
-- Navigation und UI Slots folgen in #102.
+- Navigation und UI Slots sind additiv im [Folge-ADR zu Frontend UI Extension
+  Points](adr-frontend-ui-extension-points.md) definiert.
 - MapLibre Sources, Layers, Controls und Interaktionen folgen in #103.
 - Externe Paketdistribution und Signierung folgen nicht in #101.
 

--- a/docs/architecture/adr-frontend-ui-extension-points.md
+++ b/docs/architecture/adr-frontend-ui-extension-points.md
@@ -1,0 +1,122 @@
+# ADR: Frontend UI Extension Points
+
+- Status: Angenommen
+- Datum: 2026-08-26
+- Entscheidung: [Issue #102](https://github.com/oklabflensburg/open-city-planner/issues/102)
+- Grundlage: [Issue #101](https://github.com/oklabflensburg/open-city-planner/issues/101) / PR #143
+- Epic: [Issue #91](https://github.com/oklabflensburg/open-city-planner/issues/91)
+
+## Kontext
+
+#101 integriert lokale Frontend-Module deterministisch als Nuxt Layers. Ohne einen
+öffentlichen UI-Contract müssten Module zentrale Header-, Navigations- oder
+Profilkomponenten dennoch fachlich patchen. Das würde den Host erneut an konkrete
+Module koppeln und spätere Fachmigrationen erschweren.
+
+Der aktuelle Host besitzt eine gemeinsame Hauptnavigation für Desktop, Mobil und
+Footer. Benutzer- und Adminlinks werden im Account-Menü zusammengesetzt. Es gibt
+noch kein allgemeines Dashboard- oder Sidebar-Layout. Die Map hat eigene GIS-
+Panels, deren fachliche Extension API erst #103 definiert.
+
+## Entscheidung
+
+Der Frontend-Modulcontract wird additiv um deklarative UI Contributions erweitert.
+Die SDK-Version steigt gemäß der in #101 festgelegten SemVer-Regel von `1.0.0` auf
+`1.1.0`. Module beschreiben Navigation oder lokale Komponenten in ihrer
+`module.json`; sie erhalten keine allgemeine imperative `setup()`-Funktion und
+keinen unkontrollierten Host-Kontext.
+
+Der host-owned `FrontendContributionRegistry` bindet bei der Registrierung die
+Modul-ID, validiert Struktur und Ownership, weist eine deterministische
+Modulreihenfolge zu und wird vor dem Rendering versiegelt:
+
+```text
+lokale Modulmanifeste
+        |
+        v
+Build-Time Discovery und Modulreihenfolge
+        |
+        v
+Contribution Registration -> Validation -> Seal
+        |
+        v
+immutable Build-Snapshot im Nuxt Runtime Config
+        |
+        v
+SSR-sichere Visibility -> Host Renderer
+```
+
+Kleinere `priority`-Werte werden zuerst gerendert. Bei gleicher Priorität folgen
+die Dependency-/Modulreihenfolge aus #101 und danach die stabile Contribution-ID.
+IDs sind global eindeutig und beginnen mit `<module-id>.`. Zufällige UUIDs und
+Component-Namen als alleinige Identität sind unzulässig.
+
+## Slots und Payloads
+
+Die stabilen Slot-IDs sind eine TypeScript-Literal-Union:
+
+- `navigation.primary`, `navigation.user`, `navigation.admin` verwenden sichere
+  Navigation-Descriptoren mit Label, internem Pfad und optionalem Exact-Matching;
+- `header.actions`, `sidebar`, `dashboard.widgets` und `profile.sections` verwenden
+  lokale Component-Descriptoren;
+- `map.controls`, `map.bottomSheet` und `map.contextMenu` reservieren ausschließlich
+  generische Vue-UI-Flächen für #103.
+
+Es gibt keinen HTML-String-Payload, keine Remote-Komponente, keine URL-Imports und
+keine Auswertung von JavaScript-Strings. Component-Quellen müssen im eigenen
+Nuxt-Layer unter `app/components` liegen. Der Preflight verbietet direkte Imports
+aus fremden Modulen und private `~/`-/`@/`-Hostimporte. Das Alias
+`#frontend-module-sdk` ist der stabile öffentliche TypeScript-Einstieg. Die bereits
+globalen Host-Komponenten `Button`, `Card`, `StatusBadge` und `AppModal` bleiben die
+bewusst freigegebenen UI-Primitives; weitere Freigaben benötigen eine additive
+SDK-Entscheidung.
+
+## Visibility und Sicherheit
+
+Visibility ist getrennt von der statischen Definition. Der kleine deklarative
+Contract unterstützt `public`, `authenticated` und `anonymous` sowie optionale
+Permission-, Feature- und Modulzustands-Identifier. Ohne Regel ist ein Beitrag
+sichtbar. Unbekannte Permissions und Features werden standardmäßig verweigert.
+Aktuell adaptiert der Host nur `platform.verwaltung` und `platform.superuser` an
+die bestehenden Auth-Primitives. #104 kann den Resolver später ersetzen, ohne
+Manifest-Payloads zu ändern.
+
+Visibility ist ausschließlich Darstellung und niemals Autorisierung. Backend-
+Endpoints, Daten und Mutationen müssen weiterhin serverseitig geschützt sein. Der
+Registry-Snapshot enthält keine Secrets oder ungefilterten Environment-Werte.
+
+Der Modulzustand stammt primär aus dem Build-Time-Enablement: Ein deaktivierter
+Layer besitzt weder Code noch Contributions im Build. Optionale Visibility-
+Abhängigkeiten auf weitere aktivierte Module werden gegen denselben immutable
+Build-Snapshot ausgewertet.
+
+## SSR und Hydration
+
+Registration geschieht nicht in `onMounted`, sondern vollständig vor dem Nuxt-
+Build. Server und Client erhalten denselben sortierten Snapshot. Nur die
+Sichtbarkeit wird aus SSR-/Hydration-stabilem Auth- und Hostzustand ausgewertet;
+es gibt keine zufälligen IDs, Zeitwerte oder mutable globale Registry. Die
+Pinia-Auth-Instanz bleibt Host-owned, die Registry selbst besitzt keinen Store.
+
+## Accessibility und Responsive Ownership
+
+Der Host verantwortet Landmark- und Navigationssemantik, Reihenfolge, aktiven Link,
+Focus Styles, Keyboard-Erreichbarkeit, Menü-Schließen und responsive Platzierung.
+Ein Primary-Beitrag erscheint durch dieselbe Liste in Desktop- und Mobile-
+Navigation; Module kennen keine Host-Breakpoints.
+
+Module verantworten verständliche Labels, die interne Semantik ihrer Komponente,
+Form-Labels und das Vermeiden von Keyboard Traps. `header.actions` verlangt
+zusätzlich ein `accessibleLabel`, das der Host an die gerenderte Komponente bindet.
+
+## Grenzen
+
+#102 migriert keine bestehende Fachdomäne. Vorhandene Hostlinks bleiben zunächst
+erhalten und werden mit Modulbeiträgen zusammengesetzt. Ein generischer Renderer
+beweist `header.actions`; Slots ohne aktuelle Hostfläche werden nicht durch eine
+neue Layout Engine erzwungen.
+
+Insbesondere entstehen keine MapLibre Source-/Layer-Registry, Feature-Query-,
+Draw-, Interaction- oder Map-State-API. Diese gehören zu #103. Ebenso entsteht
+keine vollständige Permission Registry oder Feature-Flag-Plattform; diese Adapter
+sind bewusst klein für #104 vorbereitet.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,7 +12,7 @@ bei reinen Dokumentationsänderungen nicht.
 | Backend CI | `backend-lint` | Ruff sowie Import- und Startkonfigurations-Smoke-Test |
 | Backend CI | `backend-tests` | vollständige Pytest-Suite |
 | Backend CI | `backend-migrations` | genau ein Alembic-Head, Upgrade einer frischen PostGIS-Datenbank sowie Modul-Persistence-, Schema- und Migrationscontracts |
-| Frontend CI | `frontend-tests` | vollständige Vitest-Suite sowie explizite Frontend-Modul-Contract- und SSR-Smoke-Tests |
+| Frontend CI | `frontend-tests` | vollständige Vitest-Suite sowie explizite Frontend-Modul-, UI-Contribution- und SSR-Smoke-Tests |
 | Frontend CI | `frontend-typecheck` | Nuxt-/Vue-Typecheck ohne optionale Module und mit dem Example-Modul |
 | Frontend CI | `frontend-build` | Modul-Preflight, produktive Nuxt-Builds mit und ohne Example-Modul sowie zentraler SSR-/SEO-Audit über Sitemap-, Noindex-, Redirect- und Fehler-Routen |
 | Frontend CI | `frontend-language-audit` | Audit der sichtbaren Sprache |
@@ -89,7 +89,8 @@ Der Frontend-Modul-Preflight läuft zusätzlich beim Laden von `nuxt.config.ts` 
 kann daher nicht durch einen direkten Nuxt-Aufruf umgangen werden. CI prüft den
 deaktivierten Host als produktiven Endzustand und davor denselben Commit mit dem
 lokal entdeckten `example-module`. Duplicate IDs, fehlende Module, inkompatible
-Versionen und Routenkollisionen werden durch gezielte negative Tests abgedeckt.
+Versionen, Routenkollisionen, Contribution-Ownership, Visibility und versiegelte
+Registry-Lifecycles werden durch gezielte negative Tests abgedeckt.
 
 E2E benötigt eine leere PostGIS-Datenbank. `DATABASE_URL` muss auf diese
 Testdatenbank zeigen:

--- a/docs/modules/frontend-host.md
+++ b/docs/modules/frontend-host.md
@@ -42,7 +42,8 @@ typisierte Contract liegt in `frontend/module-host/contract.ts`:
         "path": "/module-example",
         "source": "layer/app/pages/module-example.vue"
       }
-    ]
+    ],
+    "ui": []
   }
 }
 ```
@@ -115,9 +116,10 @@ Ein aktivierter Layer wird durch denselben Nuxt-Build verarbeitet wie der Host:
 - Browser-only Code benötigt weiterhin `import.meta.client`, `ClientOnly` oder
   geeignete Lifecycle-Guards.
 
-Das `example-module` demonstriert Page, Component, Composable und Store, registriert
-aber bewusst keine Navigation. Die Route ist `noindex`, weil sie nur ein technischer
-Architekturbeweis ist.
+Das `example-module` demonstriert Page, Component, Composable und Store sowie die
+in #102 ergänzten Navigation- und Component-Contributions. Details stehen unter
+[Frontend UI Contributions](frontend-ui-contributions.md). Die Route ist `noindex`,
+weil sie nur ein technischer Architekturbeweis ist.
 
 ## Neues Modul hinzufügen
 
@@ -133,9 +135,9 @@ Der Host wird dafür nicht um fachliche Imports oder eine ID-Liste erweitert.
 
 ## Bewusste Grenzen von V1
 
-Der Contract enthält noch keine Navigation-/UI-Slot-Registry (#102) und keine Map-
-Extension-Points (#103). Module dürfen keine unbekannten Bundles nachladen, keine
-eigene Pinia-Root oder Tailwind-Pipeline starten und nicht direkt in Interna anderer
-Module importieren. Externe npm-Pakete können später als bereits installierte,
-lokale Quellen an denselben Contract angebunden werden; Download und Packaging sind
-nicht Teil von #101.
+Der Contract enthält eine kleine Navigation-/UI-Slot-Registry aus #102, aber keine
+Map-Runtime-Extension-Points aus #103. Module dürfen keine unbekannten Bundles
+nachladen, keine eigene Pinia-Root oder Tailwind-Pipeline starten und nicht direkt
+in Interna anderer Module importieren. Externe npm-Pakete können später als bereits
+installierte, lokale Quellen an denselben Contract angebunden werden; Download und
+Packaging sind nicht Teil von #101.

--- a/docs/modules/frontend-ui-contributions.md
+++ b/docs/modules/frontend-ui-contributions.md
@@ -1,0 +1,137 @@
+# Frontend UI Contributions
+
+Frontend-Module können dem Host deklarative Navigation und lokale Vue-Komponenten
+bereitstellen. Die Architekturentscheidung steht im
+[ADR zu Frontend UI Extension Points](../architecture/adr-frontend-ui-extension-points.md).
+
+## Öffentlicher Contract
+
+Das öffentliche SDK wird über `#frontend-module-sdk` exportiert. Die wichtigsten
+Typen sind `UiSlotId`, `FrontendModuleUiContribution`, `NavigationContribution`,
+`HeaderActionContribution`, `UiVisibilityRule` und `UiVisibilityContext`.
+`FRONTEND_MODULE_SDK_VERSION` ist `1.1.0`.
+
+Unterstützte Slots:
+
+| Slot | Payload | Aktueller Host-Renderer |
+| --- | --- | --- |
+| `navigation.primary` | Navigation | Desktop, Mobil und Footer |
+| `navigation.user` | Navigation | Account-Menü bei Anmeldung |
+| `navigation.admin` | Navigation | berechtigungsgefiltertes Account-Menü |
+| `header.actions` | lokale Vue-Komponente mit Accessible Label | Desktop-Header |
+| `sidebar` | lokale Vue-Komponente | Contract für spätere Shell-Erweiterung |
+| `dashboard.widgets` | lokale Vue-Komponente | Contract für ein späteres Dashboard |
+| `profile.sections` | lokale Vue-Komponente | Contract für spätere Profilbereiche |
+| `map.controls` | lokale Vue-Komponente | für #103 reserviert |
+| `map.bottomSheet` | lokale Vue-Komponente | für #103 reserviert |
+| `map.contextMenu` | lokale Vue-Komponente | für #103 reserviert |
+
+Die letzten sechs Slots definieren bereits stabile Payloads, erzwingen aber keine
+neue Host-Layout- oder Map-Runtime.
+
+## Manifest-Beispiel
+
+```json
+{
+  "publicContributions": {
+    "routes": [
+      {
+        "path": "/module-example",
+        "source": "layer/app/pages/module-example.vue"
+      }
+    ],
+    "ui": [
+      {
+        "id": "example-module.primary-navigation",
+        "slot": "navigation.primary",
+        "priority": 250,
+        "label": "Beispielmodul",
+        "to": "/module-example",
+        "exact": true
+      },
+      {
+        "id": "example-module.header-action",
+        "slot": "header.actions",
+        "component": "ExampleModuleAction",
+        "source": "layer/app/components/ExampleModuleAction.vue",
+        "accessibleLabel": "Frontend-Modulbeispiel öffnen"
+      }
+    ]
+  }
+}
+```
+
+Der Host leitet `moduleId` aus dem bereits validierten Modul ab. Ein Modul kann
+diese Ownership nicht überschreiben. Statische Navigation muss auf eine bekannte
+Host- oder aktivierte Modulroute zeigen. Component-Quellen müssen innerhalb des
+eigenen `layer/app/components`-Verzeichnisses liegen.
+
+## IDs und Reihenfolge
+
+Contribution-IDs folgen `<module-id>.<beitragsname>` und bleiben über Releases
+stabil. Doppelte IDs stoppen den Preflight und nennen beide Module und Slots.
+
+Die globale Sortierung lautet:
+
+1. `priority`, kleinere Zahl zuerst; Standard ist `100`;
+2. deterministische Dependency-/Modulreihenfolge aus #101;
+3. Contribution-ID als stabiler Tie-Breaker.
+
+Hostnavigation und Modulnavigation werden anschließend mit denselben Regeln zu
+einer Liste zusammengesetzt. Active Styling, `aria-current` und responsive
+Darstellung bleiben Aufgabe des Hosts.
+
+## Visibility
+
+Eine Regel kann folgende einfache Felder kombinieren:
+
+```json
+{
+  "auth": "authenticated",
+  "permission": "platform.superuser",
+  "feature": "mein-modul.preview",
+  "module": "mein-modul"
+}
+```
+
+- Ohne `auth` gilt `public`; außerdem sind `authenticated` und `anonymous` möglich.
+- Unbekannte Permission-Identifier werden standardmäßig verweigert.
+- Feature-Identifier verwenden einen kleinen Resolver; #102 führt keine eigene
+  Feature-Flag-Plattform ein.
+- Modulzustand basiert auf dem immutable Build-Inventar.
+
+Visibility muss für Server und Hydration denselben Zustand verwenden. Sie ist kein
+Ersatz für Backend-Autorisierung und darf nie den alleinigen Schutz vertraulicher
+Daten oder Aktionen bilden.
+
+## Component Contributions
+
+Components werden im lokalen Nuxt Layer gebaut und durch ihren registrierten
+PascalCase-Namen referenziert. Props sind auf JSON-sichere Werte begrenzt. Nicht
+erlaubt sind HTML-Strings, Script-Injection, Remote-URLs, Runtime-Eval, iframes als
+Modulmechanismus und Deep Imports in fremde Module oder private Hostdateien.
+
+Module können die vorhandenen globalen Primitives `Button`, `Card`, `StatusBadge`
+und `AppModal` sowie normale Vue-/Nuxt-Autoimports verwenden. Neue öffentliche
+Host-APIs werden ausschließlich additiv über `#frontend-module-sdk` eingeführt.
+
+## Accessibility-Verantwortung
+
+| Host | Modul |
+| --- | --- |
+| Landmark- und Navigationssemantik | verständliche sichtbare und Accessible Labels |
+| Reihenfolge und aktiver Link | interne Component-Semantik |
+| Keyboard-Erreichbarkeit und Focus Styles | Form- und Eingabelabels |
+| Öffnen, Schließen und Focus-Verhalten der Shell | keine Keyboard Traps |
+| Desktop-/Mobile-Platzierung | keine Abhängigkeit von Host-Breakpoints |
+
+## Example-Modul und deaktivierter Zustand
+
+`example-module` registriert einen Primary-Link, einen permission-sensitiven
+Adminlink und `ExampleModuleAction` in `header.actions`. Der Host importiert keine
+dieser Dateien und kennt die Modul-ID nicht. Mit leerem `OCP_FRONTEND_MODULES`
+werden weder Layer, Links noch Component-Snapshot gebaut.
+
+Die Map-Slots sind ausschließlich UI-Platzhalter. MapLibre Sources, Layers,
+Controls, Draw- und Interaction-APIs folgen in #103; die vollständige Permission-
+Registry folgt in #104.

--- a/frontend/app/components/layout/AppFooter.vue
+++ b/frontend/app/components/layout/AppFooter.vue
@@ -18,14 +18,14 @@
 
         <nav aria-label="Projekt" class="grid content-start gap-3 lg:col-span-2">
           <h2 class="text-xs font-semibold uppercase tracking-wider text-slate-400">Projekt</h2>
-          <NuxtLink v-for="item in primaryNavigation" :key="item.to" class="text-sm font-medium text-slate-300 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#9ed0dd]" :to="item.to">
+          <NuxtLink v-for="item in primaryNavigation" :key="item.id" class="text-sm font-medium text-slate-300 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#9ed0dd]" :to="item.to">
             {{ item.label }}
           </NuxtLink>
         </nav>
 
         <nav aria-label="Rechtliches" class="grid content-start gap-3 lg:col-span-2">
           <h2 class="text-xs font-semibold uppercase tracking-wider text-slate-400">Rechtliches</h2>
-          <NuxtLink v-for="item in legalNavigation" :key="item.to" class="text-sm font-medium text-slate-300 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#9ed0dd]" :to="item.to">
+          <NuxtLink v-for="item in legalNavigation" :key="item.id" class="text-sm font-medium text-slate-300 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#9ed0dd]" :to="item.to">
             {{ item.label }}
           </NuxtLink>
           <a

--- a/frontend/app/components/layout/AppHeader.vue
+++ b/frontend/app/components/layout/AppHeader.vue
@@ -9,10 +9,10 @@
         <nav class="hidden items-center gap-1 lg:flex" aria-label="Hauptnavigation">
           <NuxtLink
             v-for="item in primaryNavigation"
-            :key="item.to"
+            :key="item.id"
             class="rounded-lg px-3.5 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#154d73]"
-            :class="isActive(item.to) ? 'bg-[#edf4f8] text-slate-950' : ''"
-            :aria-current="isActive(item.to) ? 'page' : undefined"
+            :class="isActive(item) ? 'bg-[#edf4f8] text-slate-950' : ''"
+            :aria-current="isActive(item) ? 'page' : undefined"
             :to="item.to"
           >
             {{ item.label }}
@@ -21,13 +21,14 @@
       </div>
 
       <div class="hidden min-w-0 items-center gap-3 lg:flex">
+        <UiContributionSlot slot="header.actions" class="flex items-center gap-2" />
         <nav class="hidden items-center gap-1 min-[1400px]:flex" aria-label="Rechtliche Navigation">
           <NuxtLink
             v-for="item in legalNavigation"
-            :key="item.to"
+            :key="item.id"
             class="rounded-lg px-3 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-50 hover:text-slate-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#154d73]"
-            :class="isActive(item.to) ? 'bg-slate-100 text-slate-950' : ''"
-            :aria-current="isActive(item.to) ? 'page' : undefined"
+            :class="isActive(item) ? 'bg-slate-100 text-slate-950' : ''"
+            :aria-current="isActive(item) ? 'page' : undefined"
             :to="item.to"
           >
             {{ item.label }}
@@ -139,17 +140,18 @@ const mobileOpen = ref(false)
 const accountOpen = ref(false)
 const accountButton = ref<HTMLElement | null>(null)
 const accountMenu = ref<HTMLElement | null>(null)
-const { primaryNavigation, legalNavigation } = useSiteNavigation()
-const accountNavigation = computed(() => [
+const { primaryNavigation, legalNavigation, userNavigation, adminNavigation } = useSiteNavigation()
+const accountNavigation = computed(() => sortNavigationItems([...composeNavigation([
   { label: 'Profil', to: '/profil' },
   { label: 'Meine Flächen', to: '/meine-flaechen' },
   { label: 'Sicherheit', to: '/profil/sicherheit' },
   ...(hasVerwaltungRole(authStore.user) ? [{ label: 'Kennzahlen verwalten', to: '/verwaltung/kennzahlen' }] : []),
   ...(authStore.user?.is_superuser ? [{ label: 'Administration', to: '/admin/benutzer' }, { label: 'E-Mail-Zentrale', to: '/admin/email-vorlagen' }, { label: 'Social Publishing', to: '/admin/social' }, { label: 'Auditlog', to: '/admin/audit-log' }] : [])
-])
+]), ...userNavigation.value, ...adminNavigation.value]))
 
-function isActive(path: string) {
-  if (path === '/') return route.path === '/'
+function isActive(item: { to: string, exact?: boolean }) {
+  const path = item.to
+  if (item.exact || path === '/') return route.path === path
   return route.path === path || route.path.startsWith(`${path}/`)
 }
 function toggleMenu() {

--- a/frontend/app/components/layout/MobileNavigation.vue
+++ b/frontend/app/components/layout/MobileNavigation.vue
@@ -7,10 +7,10 @@
         <div class="grid gap-1">
           <NuxtLink
             v-for="item in primaryNavigation"
-            :key="item.to"
+            :key="item.id"
             class="flex min-h-12 items-center rounded-xl px-4 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 hover:text-slate-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#154d73]"
-            :class="isActive(item.to) ? 'bg-[#edf4f8] text-slate-950' : ''"
-            :aria-current="isActive(item.to) ? 'page' : undefined"
+            :class="isActive(item) ? 'bg-[#edf4f8] text-slate-950' : ''"
+            :aria-current="isActive(item) ? 'page' : undefined"
             :to="item.to"
             @click="$emit('close')"
           >
@@ -21,10 +21,10 @@
         <div class="grid gap-1">
           <NuxtLink
             v-for="item in secondaryNavigation"
-            :key="item.to"
+            :key="item.id"
             class="flex min-h-12 items-center rounded-xl px-4 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 hover:text-slate-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#154d73]"
-            :class="isActive(item.to) ? 'bg-slate-100 text-slate-950' : ''"
-            :aria-current="isActive(item.to) ? 'page' : undefined"
+            :class="isActive(item) ? 'bg-slate-100 text-slate-950' : ''"
+            :aria-current="isActive(item) ? 'page' : undefined"
             :to="item.to"
             @click="$emit('close')"
           >
@@ -62,13 +62,9 @@
 
 <script setup lang="ts">
 import type { AuthUser } from '~/types/auth'
+import type { NavigationItem } from '~/composables/useSiteNavigation'
 
 const route = useRoute()
-
-type NavigationItem = {
-  label: string
-  to: string
-}
 
 defineProps<{
   id: string
@@ -86,8 +82,8 @@ defineEmits<{
   logout: []
 }>()
 
-function isActive(path: string) {
-  if (path === '/') return route.path === '/'
-  return route.path === path || route.path.startsWith(`${path}/`)
+function isActive(item: NavigationItem) {
+  if (item.exact || item.to === '/') return route.path === item.to
+  return route.path === item.to || route.path.startsWith(`${item.to}/`)
 }
 </script>

--- a/frontend/app/components/ui/UiContributionSlot.vue
+++ b/frontend/app/components/ui/UiContributionSlot.vue
@@ -1,0 +1,24 @@
+<template>
+  <div v-if="contributions.length" :data-ui-slot="slot">
+    <component
+      :is="resolveUiComponent(contribution.component)"
+      v-for="contribution in contributions"
+      :key="contribution.id"
+      v-bind="contribution.props"
+      :data-ui-contribution="contribution.id"
+      :aria-label="contribution.slot === 'header.actions' ? contribution.accessibleLabel : undefined"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ComponentUiSlotId } from '#frontend-module-sdk'
+import { resolveComponent } from 'vue'
+
+const props = defineProps<{ slot: ComponentUiSlotId }>()
+const contributions = useUiContributions(props.slot)
+
+function resolveUiComponent(name: string) {
+  return resolveComponent(name)
+}
+</script>

--- a/frontend/app/composables/useSiteNavigation.ts
+++ b/frontend/app/composables/useSiteNavigation.ts
@@ -1,23 +1,64 @@
+import type { BoundNavigationContribution } from '#frontend-module-sdk'
+
 export type NavigationItem = {
+  id: string
   label: string
   to: string
+  priority: number
+  moduleOrder: number
+  exact?: boolean
 }
 
-export function useSiteNavigation() {
-  const primaryNavigation: NavigationItem[] = [
-    { label: 'Karte', to: '/karte' },
-    { label: 'Gebiete', to: '/gebiete' },
-    { label: 'Über das Projekt', to: '/ueber-das-projekt' },
-    { label: 'Dokumentation', to: '/dokumentation' }
-  ]
+export const hostPrimaryNavigation = [
+  { label: 'Karte', to: '/karte' },
+  { label: 'Gebiete', to: '/gebiete' },
+  { label: 'Über das Projekt', to: '/ueber-das-projekt' },
+  { label: 'Dokumentation', to: '/dokumentation' }
+] as const
 
-  const legalNavigation: NavigationItem[] = [
-    { label: 'Impressum', to: '/impressum' },
-    { label: 'Datenschutz', to: '/datenschutz' }
-  ]
+export const hostLegalNavigation = [
+  { label: 'Impressum', to: '/impressum' },
+  { label: 'Datenschutz', to: '/datenschutz' }
+] as const
+
+export function useSiteNavigation() {
+  const primaryContributions = useUiContributions('navigation.primary')
+  const userContributions = useUiContributions('navigation.user')
+  const adminContributions = useUiContributions('navigation.admin')
 
   return {
-    primaryNavigation,
-    legalNavigation
+    primaryNavigation: computed(() => composeNavigation(hostPrimaryNavigation, primaryContributions.value)),
+    legalNavigation: composeNavigation(hostLegalNavigation),
+    userNavigation: computed(() => composeNavigation([], userContributions.value)),
+    adminNavigation: computed(() => composeNavigation([], adminContributions.value))
   }
+}
+
+export function composeNavigation(
+  hostItems: readonly { label: string, to: string }[],
+  moduleItems: readonly BoundNavigationContribution[] = []
+) {
+  const host = hostItems.map((item, index): NavigationItem => ({
+    id: `host.${item.to === '/' ? 'home' : item.to.slice(1).replaceAll('/', '.')}`,
+    ...item,
+    priority: (index + 1) * 100,
+    moduleOrder: -1
+  }))
+  const modules = moduleItems.map((item): NavigationItem => ({
+    id: item.id,
+    label: item.label,
+    to: item.to,
+    priority: item.priority ?? 100,
+    moduleOrder: item.moduleOrder,
+    exact: item.exact
+  }))
+  return sortNavigationItems([...host, ...modules])
+}
+
+export function sortNavigationItems(items: readonly NavigationItem[]) {
+  return [...items].sort((left, right) =>
+    left.priority - right.priority
+    || left.moduleOrder - right.moduleOrder
+    || left.id.localeCompare(right.id, 'en')
+  )
 }

--- a/frontend/app/composables/useUiContributions.ts
+++ b/frontend/app/composables/useUiContributions.ts
@@ -1,0 +1,38 @@
+import type { AuthUser } from '~/types/auth'
+import { hasVerwaltungRole } from '~/utils/roles'
+import {
+  isUiContributionVisible,
+  type UiContribution,
+  type UiSlotId,
+  type UiVisibilityContext
+} from '#frontend-module-sdk'
+
+export type UiVisibilityOverrides = Partial<Omit<UiVisibilityContext, 'authenticated'>>
+
+export function useUiContributions<S extends UiSlotId>(slot: S, overrides: UiVisibilityOverrides = {}) {
+  const authStore = useAuthStore()
+  const runtimeConfig = useRuntimeConfig().public as unknown as {
+    frontendModules?: readonly string[]
+    frontendUiContributions?: readonly UiContribution[]
+  }
+  const enabledModules = new Set(runtimeConfig.frontendModules ?? [])
+  const contributions = runtimeConfig.frontendUiContributions ?? []
+
+  return computed(() => {
+    const context: UiVisibilityContext = {
+      authenticated: authStore.authenticated,
+      can: overrides.can ?? (permission => resolveHostUiPermission(authStore.user, permission)),
+      featureEnabled: overrides.featureEnabled ?? (() => false),
+      moduleEnabled: overrides.moduleEnabled ?? (moduleId => enabledModules.has(moduleId))
+    }
+    return contributions.filter(
+      contribution => contribution.slot === slot && isUiContributionVisible(contribution, context)
+    ) as unknown as readonly Extract<UiContribution, { slot: S }>[]
+  })
+}
+
+export function resolveHostUiPermission(user: AuthUser | null, permission: string) {
+  if (permission === 'platform.verwaltung') return hasVerwaltungRole(user)
+  if (permission === 'platform.superuser') return Boolean(user?.is_superuser)
+  return false
+}

--- a/frontend/app/types/frontend-module-sdk.type-test.ts
+++ b/frontend/app/types/frontend-module-sdk.type-test.ts
@@ -1,0 +1,24 @@
+import type { FrontendModuleUiContribution } from '#frontend-module-sdk'
+
+export const validNavigationContribution: FrontendModuleUiContribution = {
+  id: 'type-test.primary-navigation',
+  slot: 'navigation.primary',
+  label: 'Typprüfung',
+  to: '/'
+}
+
+export const invalidNavigationContribution: FrontendModuleUiContribution = {
+  id: 'type-test.invalid-navigation',
+  slot: 'navigation.primary',
+  // @ts-expect-error Navigation slots reject component payloads at type-check time.
+  component: 'UnsafeHtmlReplacement',
+  source: 'component.vue'
+}
+
+export const invalidSlotContribution: FrontendModuleUiContribution = {
+  id: 'type-test.invalid-slot',
+  // @ts-expect-error Unknown slot IDs fail the public SDK type-check.
+  slot: 'unknown.slot',
+  label: 'Ungültig',
+  to: '/'
+}

--- a/frontend/frontend-modules/example-module/README.md
+++ b/frontend/frontend-modules/example-module/README.md
@@ -2,4 +2,7 @@
 
 Dieses rein technische Modul beweist die Build-Time-Integration aus #101. Es wird
 nur mit `OCP_FRONTEND_MODULES=example-module` in den Nuxt-Build aufgenommen und
-enthält keine Fachdomäne oder Navigation Contribution.
+enthält keine Fachdomäne.
+Es registriert deklarativ einen Eintrag in `navigation.primary`, einen
+permission-sensitiven Admin-Eintrag und die lokale Komponente
+`ExampleModuleAction` in `header.actions`.

--- a/frontend/frontend-modules/example-module/layer/app/components/ExampleModuleAction.vue
+++ b/frontend/frontend-modules/example-module/layer/app/components/ExampleModuleAction.vue
@@ -1,0 +1,13 @@
+<template>
+  <NuxtLink
+    class="inline-flex min-h-11 items-center rounded-xl border border-[#154d73] bg-white px-3 text-sm font-bold text-[#154d73] transition hover:bg-[#edf4f8] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#154d73]"
+    to="/module-example"
+    aria-label="Frontend-Modulbeispiel öffnen"
+  >
+    {{ label }}
+  </NuxtLink>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{ label?: string }>(), { label: 'Modulbeispiel' })
+</script>

--- a/frontend/frontend-modules/example-module/layer/nuxt.config.ts
+++ b/frontend/frontend-modules/example-module/layer/nuxt.config.ts
@@ -1,1 +1,3 @@
-export default defineNuxtConfig({})
+export default defineNuxtConfig({
+  components: [{ path: './app/components', pathPrefix: false }]
+})

--- a/frontend/frontend-modules/example-module/module.json
+++ b/frontend/frontend-modules/example-module/module.json
@@ -16,6 +16,46 @@
         "path": "/module-example",
         "source": "layer/app/pages/module-example.vue"
       }
+    ],
+    "ui": [
+      {
+        "id": "example-module.primary-navigation",
+        "slot": "navigation.primary",
+        "priority": 250,
+        "visibility": {
+          "auth": "public",
+          "module": "example-module"
+        },
+        "label": "Beispielmodul",
+        "to": "/module-example",
+        "exact": true
+      },
+      {
+        "id": "example-module.admin-navigation",
+        "slot": "navigation.admin",
+        "priority": 900,
+        "visibility": {
+          "auth": "authenticated",
+          "permission": "platform.superuser"
+        },
+        "label": "Modulbeispiel verwalten",
+        "to": "/module-example",
+        "exact": true
+      },
+      {
+        "id": "example-module.header-action",
+        "slot": "header.actions",
+        "priority": 100,
+        "visibility": {
+          "module": "example-module"
+        },
+        "component": "ExampleModuleAction",
+        "source": "layer/app/components/ExampleModuleAction.vue",
+        "accessibleLabel": "Frontend-Modulbeispiel öffnen",
+        "props": {
+          "label": "Modulbeispiel"
+        }
+      }
     ]
   }
 }

--- a/frontend/module-host/contract.ts
+++ b/frontend/module-host/contract.ts
@@ -1,5 +1,7 @@
+import type { FrontendModuleUiContribution } from './ui-contract.ts'
+
 export const FRONTEND_HOST_VERSION = '1.0.0'
-export const FRONTEND_MODULE_SDK_VERSION = '1.0.0'
+export const FRONTEND_MODULE_SDK_VERSION = '1.1.0'
 
 export interface FrontendModuleCompatibility {
   host: string
@@ -13,7 +15,8 @@ export interface FrontendModuleRouteContribution {
 }
 
 export interface FrontendModulePublicContributions {
-  routes: FrontendModuleRouteContribution[]
+  readonly routes: readonly FrontendModuleRouteContribution[]
+  readonly ui: readonly FrontendModuleUiContribution[]
 }
 
 export interface FrontendModuleRequirements {

--- a/frontend/module-host/discovery.ts
+++ b/frontend/module-host/discovery.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
-import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path'
 import { satisfies, valid, validRange } from 'semver'
 import { z } from 'zod'
 import {
@@ -8,8 +8,50 @@ import {
   type FrontendModuleDefinition,
   type ResolvedFrontendModule
 } from './contract.ts'
+import { createFrontendContributionRegistry } from './ui-registry.ts'
 
 const moduleId = z.string().regex(/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/).max(63)
+const uiVisibility = z.strictObject({
+  auth: z.enum(['public', 'authenticated', 'anonymous']).optional(),
+  permission: z.string().min(1).optional(),
+  feature: z.string().min(1).optional(),
+  module: moduleId.optional()
+})
+const uiContributionBase = {
+  id: z.string().min(3),
+  priority: z.number().int().min(-1_000_000).max(1_000_000).optional(),
+  visibility: uiVisibility.optional()
+}
+const navigationContribution = z.strictObject({
+  ...uiContributionBase,
+  slot: z.enum(['navigation.primary', 'navigation.user', 'navigation.admin']),
+  label: z.string().min(1),
+  to: z.string().startsWith('/'),
+  exact: z.boolean().optional()
+})
+const componentContributionBase = {
+  ...uiContributionBase,
+  component: z.string().regex(/^[A-Z][A-Za-z0-9]*$/),
+  source: z.string().min(1),
+  props: z.record(z.string(), z.json()).optional()
+}
+const headerActionContribution = z.strictObject({
+  ...componentContributionBase,
+  slot: z.literal('header.actions'),
+  accessibleLabel: z.string().min(1)
+})
+const componentContribution = z.strictObject({
+  ...componentContributionBase,
+  slot: z.enum([
+    'sidebar',
+    'dashboard.widgets',
+    'profile.sections',
+    'map.controls',
+    'map.bottomSheet',
+    'map.contextMenu'
+  ])
+})
+
 const route = z.strictObject({
   path: z.string().startsWith('/'),
   source: z.string().min(1)
@@ -29,7 +71,8 @@ const definitionSchema = z.strictObject({
     modules: z.record(moduleId, z.string().min(1))
   }),
   publicContributions: z.strictObject({
-    routes: z.array(route)
+    routes: z.array(route),
+    ui: z.array(z.union([navigationContribution, headerActionContribution, componentContribution])).default([])
   })
 })
 
@@ -69,6 +112,7 @@ export function resolveFrontendModules(options: ResolveFrontendModulesOptions): 
   )
   const ordered = resolveModuleOrder(enabled)
   validateRouteCollisions(ordered, options.appPagesDirectory)
+  createFrontendContributionRegistry(ordered, discoverPageRoutes(options.appPagesDirectory))
   return ordered
 }
 
@@ -118,6 +162,22 @@ export function discoverFrontendModules(modulesDirectory: string): ResolvedFront
         throw new FrontendModuleError(`Route "${contribution.path}" of frontend module "${definition.id}" has no file at ${routeSource}.`)
       }
     }
+    for (const contribution of definition.publicContributions.ui) {
+      if (!('source' in contribution)) continue
+      const componentSource = safeChildPath(moduleRoot, contribution.source, `component source of UI contribution "${contribution.id}"`)
+      const componentsDirectory = resolve(layerPath, 'app/components')
+      const sourceFromComponents = relative(componentsDirectory, componentSource)
+      if (sourceFromComponents === '..' || sourceFromComponents.startsWith(`..${sep}`)) {
+        throw new FrontendModuleError(`UI contribution "${contribution.id}" must point into its own layer app/components directory.`)
+      }
+      if (!existsSync(componentSource) || !statSync(componentSource).isFile()) {
+        throw new FrontendModuleError(`UI contribution "${contribution.id}" has no component file at ${componentSource}.`)
+      }
+      if (!componentSource.endsWith('.vue') || basename(componentSource, '.vue') !== contribution.component) {
+        throw new FrontendModuleError(`UI contribution "${contribution.id}" component name "${contribution.component}" must match its local Vue filename.`)
+      }
+    }
+    validateModuleImports(definition.id, moduleRoot, layerPath)
     discovered.push({ ...definition, source, layerPath })
   }
   return discovered
@@ -257,6 +317,26 @@ function walkFiles(directory: string): string[] {
       const path = resolve(directory, entry.name)
       return entry.isDirectory() ? walkFiles(path) : [path]
     })
+}
+
+function validateModuleImports(moduleId: string, moduleRoot: string, layerPath: string) {
+  const sourceFiles = walkFiles(layerPath).filter(file => /\.(?:vue|[cm]?[jt]sx?)$/.test(file))
+  const importPattern = /(?:from\s*|import\s*\()\s*['"]([^'"]+)['"]/g
+  for (const file of sourceFiles) {
+    const contents = readFileSync(file, 'utf8')
+    for (const match of contents.matchAll(importPattern)) {
+      const specifier = match[1]!
+      if (specifier.startsWith('~/') || specifier.startsWith('@/') || specifier.includes('frontend-modules/')) {
+        throw new FrontendModuleError(`Frontend module "${moduleId}" imports private host or module internals via "${specifier}" in ${file}.`)
+      }
+      if (!specifier.startsWith('.')) continue
+      const target = resolve(dirname(file), specifier)
+      const fromModule = relative(moduleRoot, target)
+      if (fromModule === '..' || fromModule.startsWith(`..${sep}`)) {
+        throw new FrontendModuleError(`Frontend module "${moduleId}" imports outside its own module through "${specifier}" in ${file}.`)
+      }
+    }
+  }
 }
 
 function validateDefinitionVersions(definition: FrontendModuleDefinition, source: string) {

--- a/frontend/module-host/public.ts
+++ b/frontend/module-host/public.ts
@@ -1,0 +1,22 @@
+export {
+  FRONTEND_HOST_VERSION,
+  FRONTEND_MODULE_SDK_VERSION,
+  type FrontendModuleCompatibility,
+  type FrontendModuleDefinition
+} from './contract.ts'
+export {
+  DEFAULT_UI_CONTRIBUTION_PRIORITY,
+  UI_SLOT_IDS,
+  type BoundComponentContribution,
+  type BoundNavigationContribution,
+  type ComponentUiSlotId,
+  type FrontendModuleUiContribution,
+  type HeaderActionContribution,
+  type JsonSafeValue,
+  type NavigationContribution,
+  type UiContribution,
+  type UiSlotId,
+  type UiVisibilityContext,
+  type UiVisibilityRule
+} from './ui-contract.ts'
+export { isUiContributionVisible } from './ui-registry.ts'

--- a/frontend/module-host/ui-contract.ts
+++ b/frontend/module-host/ui-contract.ts
@@ -1,0 +1,83 @@
+export const UI_SLOT_IDS = [
+  'navigation.primary',
+  'navigation.user',
+  'navigation.admin',
+  'header.actions',
+  'sidebar',
+  'dashboard.widgets',
+  'profile.sections',
+  'map.controls',
+  'map.bottomSheet',
+  'map.contextMenu'
+] as const
+
+export type UiSlotId = typeof UI_SLOT_IDS[number]
+export type NavigationUiSlotId = Extract<UiSlotId, `navigation.${string}`>
+export type ComponentUiSlotId = Exclude<UiSlotId, NavigationUiSlotId>
+export type UiAuthVisibility = 'public' | 'authenticated' | 'anonymous'
+
+export type JsonSafeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonSafeValue[]
+  | { readonly [key: string]: JsonSafeValue }
+
+export interface UiVisibilityRule {
+  readonly auth?: UiAuthVisibility
+  readonly permission?: string
+  readonly feature?: string
+  readonly module?: string
+}
+
+interface FrontendModuleUiContributionBase {
+  readonly id: string
+  readonly priority?: number
+  readonly visibility?: UiVisibilityRule
+}
+
+export interface NavigationContribution extends FrontendModuleUiContributionBase {
+  readonly slot: NavigationUiSlotId
+  readonly label: string
+  readonly to: string
+  readonly exact?: boolean
+}
+
+interface ComponentContributionBase extends FrontendModuleUiContributionBase {
+  readonly slot: ComponentUiSlotId
+  readonly component: string
+  readonly source: string
+  readonly props?: Readonly<Record<string, JsonSafeValue>>
+}
+
+export interface HeaderActionContribution extends ComponentContributionBase {
+  readonly slot: 'header.actions'
+  readonly accessibleLabel: string
+}
+
+export interface GenericComponentContribution extends ComponentContributionBase {
+  readonly slot: Exclude<ComponentUiSlotId, 'header.actions'>
+}
+
+export type FrontendModuleUiContribution =
+  | NavigationContribution
+  | HeaderActionContribution
+  | GenericComponentContribution
+
+export type UiContribution = FrontendModuleUiContribution & {
+  readonly moduleId: string
+  readonly moduleOrder: number
+}
+
+export type BoundNavigationContribution = Extract<UiContribution, { slot: NavigationUiSlotId }>
+export type BoundComponentContribution = Extract<UiContribution, { slot: ComponentUiSlotId }>
+
+export interface UiVisibilityContext {
+  readonly authenticated: boolean
+  readonly can: (permission: string) => boolean
+  readonly featureEnabled: (feature: string) => boolean
+  readonly moduleEnabled: (moduleId: string) => boolean
+}
+
+export const DEFAULT_UI_CONTRIBUTION_PRIORITY = 100

--- a/frontend/module-host/ui-registry.ts
+++ b/frontend/module-host/ui-registry.ts
@@ -1,0 +1,146 @@
+import type { ResolvedFrontendModule } from './contract.ts'
+import {
+  DEFAULT_UI_CONTRIBUTION_PRIORITY,
+  UI_SLOT_IDS,
+  type FrontendModuleUiContribution,
+  type UiContribution,
+  type UiSlotId,
+  type UiVisibilityContext
+} from './ui-contract.ts'
+
+const slots = new Set<string>(UI_SLOT_IDS)
+
+export class FrontendContributionError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FrontendContributionError'
+  }
+}
+
+export class DuplicateUiContributionError extends FrontendContributionError {
+  constructor(
+    id: string,
+    first: Pick<UiContribution, 'moduleId' | 'slot'>,
+    second: Pick<UiContribution, 'moduleId' | 'slot'>
+  ) {
+    super(`Duplicate UI contribution "${id}" in slot "${first.slot}" from module "${first.moduleId}" and slot "${second.slot}" from module "${second.moduleId}".`)
+    this.name = 'DuplicateUiContributionError'
+  }
+}
+
+export class FrontendContributionRegistry {
+  readonly #knownRoutes: ReadonlySet<string>
+  readonly #contributions = new Map<string, UiContribution>()
+  #sealed = false
+
+  constructor(knownRoutes: Iterable<string>) {
+    this.#knownRoutes = new Set(knownRoutes)
+  }
+
+  registrar(moduleId: string, moduleOrder: number) {
+    if (!/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(moduleId)) {
+      throw new FrontendContributionError(`Invalid owner module ID "${moduleId}".`)
+    }
+    return {
+      register: (contribution: FrontendModuleUiContribution) => this.#register(moduleId, moduleOrder, contribution)
+    } as const
+  }
+
+  seal() {
+    this.#sealed = true
+    return this
+  }
+
+  get sealed() {
+    return this.#sealed
+  }
+
+  all(): readonly UiContribution[] {
+    if (!this.#sealed) throw new FrontendContributionError('UI contribution registry must be sealed before rendering.')
+    return Object.freeze([...this.#contributions.values()].sort(compareUiContributions))
+  }
+
+  forSlot(slot: UiSlotId, visibility?: UiVisibilityContext): readonly UiContribution[] {
+    if (!slots.has(slot)) throw new FrontendContributionError(`Unknown UI slot "${slot}".`)
+    return this.all().filter(contribution => contribution.slot === slot && (!visibility || isUiContributionVisible(contribution, visibility)))
+  }
+
+  #register(moduleId: string, moduleOrder: number, contribution: FrontendModuleUiContribution) {
+    if (this.#sealed) throw new FrontendContributionError(`Cannot register UI contribution "${contribution.id}" after the registry was sealed.`)
+    const bound = deepFreeze({ ...contribution, moduleId, moduleOrder }) as UiContribution
+    const previous = this.#contributions.get(bound.id)
+    if (previous) throw new DuplicateUiContributionError(bound.id, previous, bound)
+    validateContribution(moduleId, contribution, this.#knownRoutes)
+    this.#contributions.set(bound.id, bound)
+    return bound
+  }
+}
+
+export function createFrontendContributionRegistry(
+  modules: readonly ResolvedFrontendModule[],
+  hostRoutes: readonly string[]
+) {
+  const knownRoutes = [
+    ...hostRoutes,
+    ...modules.flatMap(module => module.publicContributions.routes.map(route => route.path))
+  ]
+  const registry = new FrontendContributionRegistry(knownRoutes)
+  modules.forEach((module, moduleOrder) => {
+    const registrar = registry.registrar(module.id, moduleOrder)
+    for (const contribution of module.publicContributions.ui) registrar.register(contribution)
+  })
+  return registry.seal()
+}
+
+export function compareUiContributions(left: UiContribution, right: UiContribution) {
+  const priority = (left.priority ?? DEFAULT_UI_CONTRIBUTION_PRIORITY) - (right.priority ?? DEFAULT_UI_CONTRIBUTION_PRIORITY)
+  if (priority) return priority
+  const moduleOrder = left.moduleOrder - right.moduleOrder
+  if (moduleOrder) return moduleOrder
+  return left.id.localeCompare(right.id, 'en')
+}
+
+export function isUiContributionVisible(contribution: UiContribution, context: UiVisibilityContext) {
+  const visibility = contribution.visibility
+  if (!visibility) return true
+  const auth = visibility.auth ?? 'public'
+  if (auth === 'authenticated' && !context.authenticated) return false
+  if (auth === 'anonymous' && context.authenticated) return false
+  if (visibility.permission && !context.can(visibility.permission)) return false
+  if (visibility.feature && !context.featureEnabled(visibility.feature)) return false
+  if (visibility.module && !context.moduleEnabled(visibility.module)) return false
+  return true
+}
+
+function validateContribution(
+  moduleId: string,
+  contribution: FrontendModuleUiContribution,
+  knownRoutes: ReadonlySet<string>
+) {
+  if (!slots.has(contribution.slot)) throw new FrontendContributionError(`Unknown UI slot "${contribution.slot}" for contribution "${contribution.id}".`)
+  if (!contribution.id.startsWith(`${moduleId}.`) || !/^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+$/.test(contribution.id)) {
+    throw new FrontendContributionError(`UI contribution "${contribution.id}" must use the stable owner prefix "${moduleId}.".`)
+  }
+  if (contribution.priority !== undefined && (!Number.isSafeInteger(contribution.priority) || Math.abs(contribution.priority) > 1_000_000)) {
+    throw new FrontendContributionError(`UI contribution "${contribution.id}" has an invalid priority.`)
+  }
+  if ('to' in contribution && !knownRoutes.has(normalizeStaticRoute(contribution.to))) {
+    throw new FrontendContributionError(`Navigation contribution "${contribution.id}" points to unknown static route "${contribution.to}".`)
+  }
+  if (contribution.slot === 'header.actions' && !contribution.accessibleLabel.trim()) {
+    throw new FrontendContributionError(`Header action "${contribution.id}" requires an accessible label.`)
+  }
+}
+
+function normalizeStaticRoute(route: string) {
+  if (!route.startsWith('/') || route.includes('?') || route.includes('#') || route.includes(':')) {
+    throw new FrontendContributionError(`Navigation route "${route}" must be a static application path.`)
+  }
+  return route === '/' ? route : route.replace(/\/+$/, '')
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value
+  for (const nested of Object.values(value)) deepFreeze(nested)
+  return Object.freeze(value)
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,13 +1,19 @@
 import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath } from 'node:url'
-import { resolveFrontendModules } from './module-host/discovery'
+import { discoverPageRoutes, resolveFrontendModules } from './module-host/discovery'
+import { createFrontendContributionRegistry } from './module-host/ui-registry'
 
+const appPagesDirectory = fileURLToPath(new URL('./app/pages', import.meta.url))
 const frontendModules = resolveFrontendModules({
   modulesDirectory: fileURLToPath(new URL('./frontend-modules', import.meta.url)),
-  appPagesDirectory: fileURLToPath(new URL('./app/pages', import.meta.url)),
+  appPagesDirectory,
   enabledModules: process.env.OCP_FRONTEND_MODULES,
   backendModules: process.env.OCP_BACKEND_MODULES
 })
+const frontendContributionRegistry = createFrontendContributionRegistry(
+  frontendModules,
+  discoverPageRoutes(appPagesDirectory)
+)
 
 const configuredSiteUrl = process.env.NUXT_PUBLIC_SITE_URL
 const configuredMapStyleUrl = process.env.NUXT_PUBLIC_MAP_STYLE_URL || process.env.NUXT_PUBLIC_VERSATILES_STYLE_URL || ''
@@ -67,6 +73,9 @@ export default defineNuxtConfig({
     }
   },
   modules: ['@pinia/nuxt'],
+  alias: {
+    '#frontend-module-sdk': fileURLToPath(new URL('./module-host/public.ts', import.meta.url))
+  },
   components: [
     {
       path: '~/components',
@@ -79,6 +88,8 @@ export default defineNuxtConfig({
     releaseSha: process.env.STADTPLANER_RELEASE_SHA || 'dev',
     apiInternalBaseUrl: process.env.NUXT_API_INTERNAL_BASE_URL || '',
     public: {
+      frontendModules: frontendModules.map(module => module.id),
+      frontendUiContributions: [...frontendContributionRegistry.all()],
       siteName: 'OK Lab Flensburg',
       siteUrl: configuredSiteUrl || 'http://localhost:3000',
       siteLocale: 'de_DE',

--- a/frontend/tests/frontend-module-enabled-ssr.test.ts
+++ b/frontend/tests/frontend-module-enabled-ssr.test.ts
@@ -17,7 +17,19 @@ afterAll(() => {
 })
 
 describe('enabled frontend module SSR', () => {
-  it('renders the discovered layer page with shared host primitives and SEO', async () => {
+  it('renders module navigation and the component slot in the host SSR shell', async () => {
+    const response = await fetch('/')
+    expect(response.status).toBe(200)
+    const html = await response.text()
+    expect(html).toContain('aria-label="Hauptnavigation"')
+    expect(html).toContain('href="/module-example"')
+    expect(html).toContain('Beispielmodul')
+    expect(html).toContain('data-ui-slot="header.actions"')
+    expect(html).toContain('data-ui-contribution="example-module.header-action"')
+    expect(html).toContain('aria-label="Frontend-Modulbeispiel öffnen"')
+  })
+
+  it('renders the discovered layer page with shared host primitives, active navigation and SEO', async () => {
     const response = await fetch('/module-example')
     expect(response.status).toBe(200)
     const html = await response.text()
@@ -25,6 +37,7 @@ describe('enabled frontend module SSR', () => {
     expect(html).toContain('Gemeinsame Host-Primitives')
     expect(html).toContain('Der gemeinsame Pinia-Store wurde 0 Mal aktualisiert.')
     expect(html).toContain('data-example-module-card')
+    expect(html).toMatch(/(?:href="\/module-example"[^>]*aria-current="page"|aria-current="page"[^>]*href="\/module-example")/)
     expect(html).toContain('<title>Frontend-Modulbeispiel – OK Lab Flensburg</title>')
     expect(html).toContain('content="noindex,nofollow"')
   })

--- a/frontend/tests/frontend-module-host.test.ts
+++ b/frontend/tests/frontend-module-host.test.ts
@@ -77,14 +77,14 @@ describe('frontend build-time module host', () => {
   it('accepts compatible SDK versions and rejects incompatible versions', () => {
     const paths = fixture()
     addModule(paths.modulesDirectory, 'compatible')
-    expect(FRONTEND_MODULE_SDK_VERSION).toBe('1.0.0')
+    expect(FRONTEND_MODULE_SDK_VERSION).toBe('1.1.0')
     expect(resolveFrontendModules({ ...paths, enabledModules: 'compatible' })).toHaveLength(1)
 
     addModule(paths.modulesDirectory, 'future', {
       compatibility: { host: '>=1.0.0 <2.0.0', sdk: '>=2.0.0 <3.0.0' }
     })
     expect(() => resolveFrontendModules({ ...paths, enabledModules: 'future' }))
-      .toThrowError(/requires frontend module SDK >=2.0.0 <3.0.0, but found 1.0.0/)
+      .toThrowError(/requires frontend module SDK >=2.0.0 <3.0.0, but found 1.1.0/)
   })
 
   it('requires one shared module ID and validates an explicit backend inventory', () => {
@@ -151,6 +151,42 @@ describe('frontend build-time module host', () => {
     addModule(plugin.modulesDirectory, 'example')
     mkdirSync(resolve(plugin.modulesDirectory, 'example/layer/app/plugins'), { recursive: true })
     expect(() => discoverFrontendModules(plugin.modulesDirectory)).toThrowError(/may not provide host-owned layer path "app\/plugins"/)
+  })
+
+  it('rejects foreign module imports, arbitrary HTML payloads and foreign component sources', () => {
+    const foreignImport = fixture()
+    addModule(foreignImport.modulesDirectory, 'alpha')
+    writeFileSync(
+      resolve(foreignImport.modulesDirectory, 'alpha/layer/app/pages/alpha.vue'),
+      `<script setup>import value from '../../../../beta/internal'</script><template>{{ value }}</template>`
+    )
+    expect(() => discoverFrontendModules(foreignImport.modulesDirectory))
+      .toThrowError(/imports outside its own module/)
+
+    const arbitraryHtml = fixture()
+    addModule(arbitraryHtml.modulesDirectory, 'alpha', {
+      publicContributions: {
+        routes: [{ path: '/alpha', source: 'layer/app/pages/alpha.vue' }],
+        ui: [{ id: 'alpha.unsafe', slot: 'header.actions', html: '<script>alert(1)</script>' }]
+      }
+    })
+    expect(() => discoverFrontendModules(arbitraryHtml.modulesDirectory))
+      .toThrowError(/Frontend module definition .* is invalid/)
+
+    const foreignComponent = fixture()
+    addModule(foreignComponent.modulesDirectory, 'alpha', {
+      publicContributions: {
+        routes: [{ path: '/alpha', source: 'layer/app/pages/alpha.vue' }],
+        ui: [{
+          id: 'alpha.widget',
+          slot: 'dashboard.widgets',
+          component: 'ForeignWidget',
+          source: '../beta/layer/app/components/ForeignWidget.vue'
+        }]
+      }
+    })
+    expect(() => discoverFrontendModules(foreignComponent.modulesDirectory))
+      .toThrowError(/must remain inside/)
   })
 
   it('keeps Nuxt generic and forbids runtime microfrontend loading', () => {

--- a/frontend/tests/frontend-ui-contributions.test.ts
+++ b/frontend/tests/frontend-ui-contributions.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { FrontendModuleUiContribution, UiVisibilityContext } from '../module-host/ui-contract'
+import {
+  DuplicateUiContributionError,
+  FrontendContributionError,
+  FrontendContributionRegistry,
+  isUiContributionVisible
+} from '../module-host/ui-registry'
+import { composeNavigation } from '../app/composables/useSiteNavigation'
+
+const publicContext: UiVisibilityContext = {
+  authenticated: false,
+  can: () => false,
+  featureEnabled: () => false,
+  moduleEnabled: moduleId => moduleId === 'alpha'
+}
+
+function navigation(
+  id: string,
+  slot: 'navigation.primary' | 'navigation.user' | 'navigation.admin' = 'navigation.primary',
+  priority?: number
+): FrontendModuleUiContribution {
+  return { id, slot, label: id, to: '/known', priority }
+}
+
+describe('frontend UI contribution registry', () => {
+  it('binds ownership and registers multiple contributions', () => {
+    const registry = new FrontendContributionRegistry(['/known'])
+    const registrar = registry.registrar('alpha', 0)
+    registrar.register(navigation('alpha.primary'))
+    registrar.register({
+      id: 'alpha.header-action',
+      slot: 'header.actions',
+      component: 'AlphaAction',
+      source: 'layer/app/components/AlphaAction.vue',
+      accessibleLabel: 'Alpha öffnen'
+    })
+    expect(registry.seal().all()).toHaveLength(2)
+    expect(registry.all().every(item => item.moduleId === 'alpha')).toBe(true)
+  })
+
+  it('sorts by ascending priority, module order and stable ID', () => {
+    const registry = new FrontendContributionRegistry(['/known'])
+    registry.registrar('beta', 1).register(navigation('beta.late-id', 'navigation.primary', 100))
+    registry.registrar('alpha', 0).register(navigation('alpha.second', 'navigation.primary', 100))
+    registry.registrar('alpha', 0).register(navigation('alpha.first', 'navigation.primary', 100))
+    registry.registrar('beta', 1).register(navigation('beta.early-priority', 'navigation.primary', 10))
+    expect(registry.seal().all().map(item => item.id)).toEqual([
+      'beta.early-priority',
+      'alpha.first',
+      'alpha.second',
+      'beta.late-id'
+    ])
+  })
+
+  it('rejects duplicate IDs with both owners and slots', () => {
+    const registry = new FrontendContributionRegistry(['/known'])
+    registry.registrar('alpha', 0).register(navigation('alpha.shared'))
+    expect(() => registry.registrar('beta', 1).register({
+      ...navigation('alpha.shared', 'navigation.user')
+    })).toThrowError(DuplicateUiContributionError)
+    expect(() => registry.registrar('beta', 1).register({
+      ...navigation('alpha.shared', 'navigation.user')
+    })).toThrowError(/alpha\.shared.*navigation\.primary.*alpha.*navigation\.user.*beta/)
+  })
+
+  it('rejects unknown slots, forged ownership and broken static routes', () => {
+    const registry = new FrontendContributionRegistry(['/known'])
+    const registrar = registry.registrar('alpha', 0)
+    expect(() => registrar.register({ ...navigation('alpha.unknown'), slot: 'unknown.slot' } as never))
+      .toThrowError(/Unknown UI slot/)
+    expect(() => registrar.register(navigation('beta.forged')))
+      .toThrowError(/stable owner prefix "alpha\."/)
+    expect(() => registrar.register({ ...navigation('alpha.broken'), to: '/missing' }))
+      .toThrowError(/unknown static route/)
+  })
+
+  it('is read-only after sealing and cannot be read before sealing', () => {
+    const registry = new FrontendContributionRegistry(['/known'])
+    const registrar = registry.registrar('alpha', 0)
+    expect(() => registry.all()).toThrowError(/must be sealed/)
+    registrar.register(navigation('alpha.primary'))
+    registry.seal()
+    expect(() => registrar.register(navigation('alpha.late'))).toThrowError(/after the registry was sealed/)
+    expect(Object.isFrozen(registry.all())).toBe(true)
+    expect(Object.isFrozen(registry.all()[0])).toBe(true)
+  })
+
+  it('supports public, auth, permission, feature and module-state visibility', () => {
+    const contribution = (visibility?: FrontendModuleUiContribution['visibility']) => ({
+      ...navigation('alpha.visibility'),
+      moduleId: 'alpha',
+      moduleOrder: 0,
+      visibility
+    })
+    expect(isUiContributionVisible(contribution(), publicContext)).toBe(true)
+    expect(isUiContributionVisible(contribution({ auth: 'authenticated' }), publicContext)).toBe(false)
+    expect(isUiContributionVisible(contribution({ auth: 'anonymous' }), publicContext)).toBe(true)
+    expect(isUiContributionVisible(contribution({ permission: 'alpha.read' }), publicContext)).toBe(false)
+    expect(isUiContributionVisible(contribution({ feature: 'alpha.preview' }), publicContext)).toBe(false)
+    expect(isUiContributionVisible(contribution({ module: 'alpha' }), publicContext)).toBe(true)
+    expect(isUiContributionVisible(contribution({ module: 'beta' }), publicContext)).toBe(false)
+
+    const authorized = {
+      ...publicContext,
+      authenticated: true,
+      can: (permission: string) => permission === 'alpha.read',
+      featureEnabled: (feature: string) => feature === 'alpha.preview'
+    }
+    expect(isUiContributionVisible(contribution({ auth: 'authenticated', permission: 'alpha.read', feature: 'alpha.preview' }), authorized)).toBe(true)
+    expect(isUiContributionVisible(contribution({ auth: 'anonymous' }), authorized)).toBe(false)
+  })
+
+  it('composes host and primary, user and admin module navigation deterministically', () => {
+    const registry = new FrontendContributionRegistry(['/known'])
+    const registrar = registry.registrar('alpha', 0)
+    registrar.register(navigation('alpha.primary', 'navigation.primary', 150))
+    registrar.register(navigation('alpha.user', 'navigation.user'))
+    registrar.register(navigation('alpha.admin', 'navigation.admin'))
+    registry.seal()
+
+    const primary = composeNavigation([{ label: 'Host', to: '/known' }], registry.forSlot('navigation.primary') as never)
+    expect(primary.map(item => item.id)).toEqual(['host.known', 'alpha.primary'])
+    expect(registry.forSlot('navigation.user')).toHaveLength(1)
+    expect(registry.forSlot('navigation.admin')).toHaveLength(1)
+  })
+
+  it('keeps the host generic and exposes no arbitrary HTML payload', () => {
+    const hostSources = [
+      '../nuxt.config.ts',
+      '../app/composables/useSiteNavigation.ts',
+      '../app/components/layout/AppHeader.vue',
+      '../app/components/layout/MobileNavigation.vue',
+      '../app/components/ui/UiContributionSlot.vue'
+    ].map(path => readFileSync(resolve(import.meta.dirname, path), 'utf8')).join('\n')
+    const contract = readFileSync(resolve(import.meta.dirname, '../module-host/ui-contract.ts'), 'utf8')
+    expect(hostSources).not.toContain('example-module')
+    expect(hostSources).not.toContain('ExampleModuleAction')
+    expect(contract).not.toMatch(/\bhtml\??:/)
+    expect(contract).not.toMatch(/remote|iframe|script/i)
+  })
+})

--- a/frontend/tests/seo-routes-ssr.test.ts
+++ b/frontend/tests/seo-routes-ssr.test.ts
@@ -68,6 +68,9 @@ describe('SEO routes over Nuxt HTTP', () => {
     const meta = tags(html, 'meta').map(attributes)
     const links = tags(html, 'link').map(attributes)
 
+    expect(html).not.toContain('Beispielmodul')
+    expect(html).not.toContain('data-ui-contribution="example-module.')
+
     expect(meta.find(item => item.name === 'theme-color')?.content).toBe('#154d73')
     expect(meta.find(item => item.name === 'twitter:site')?.content).toBe('@oklabflensburg')
     expect(links).toEqual(expect.arrayContaining([

--- a/frontend/tests/site-navigation.test.ts
+++ b/frontend/tests/site-navigation.test.ts
@@ -1,25 +1,30 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { useSiteNavigation } from '~/composables/useSiteNavigation'
+import { composeNavigation, hostPrimaryNavigation } from '~/composables/useSiteNavigation'
 
 const appFile = (path: string) => readFileSync(fileURLToPath(new URL(`../app/${path}`, import.meta.url)), 'utf8')
 
 describe('site navigation', () => {
   it('uses the logo as home link and omits the redundant Start item', () => {
-    const { primaryNavigation } = useSiteNavigation()
+    const primaryNavigation = composeNavigation(hostPrimaryNavigation)
 
     expect(primaryNavigation).toEqual([
-      { label: 'Karte', to: '/karte' },
-      { label: 'Gebiete', to: '/gebiete' },
-      { label: 'Über das Projekt', to: '/ueber-das-projekt' },
-      { label: 'Dokumentation', to: '/dokumentation' }
+      expect.objectContaining({ label: 'Karte', to: '/karte' }),
+      expect.objectContaining({ label: 'Gebiete', to: '/gebiete' }),
+      expect.objectContaining({ label: 'Über das Projekt', to: '/ueber-das-projekt' }),
+      expect.objectContaining({ label: 'Dokumentation', to: '/dokumentation' })
     ])
 
     const header = appFile('components/layout/AppHeader.vue')
     expect(header).toContain('<NuxtLink class="group flex min-h-11 shrink-0 items-center rounded-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#154d73]" to="/"')
     expect(header).toContain('v-for="item in primaryNavigation"')
     expect(header).toContain(':primary-navigation="primaryNavigation"')
-    expect(appFile('components/layout/MobileNavigation.vue')).toContain('v-for="item in primaryNavigation"')
+    const mobile = appFile('components/layout/MobileNavigation.vue')
+    expect(mobile).toContain('aria-label="Mobile Navigation"')
+    expect(mobile).toContain('v-for="item in primaryNavigation"')
+    expect(mobile).toContain(':aria-current="isActive(item) ? \'page\' : undefined"')
+    expect(mobile).toContain('@click="$emit(\'close\')"')
+    expect(mobile).toContain('focus-visible:outline')
   })
 })


### PR DESCRIPTION
Part of #91  
Closes #102

## Ausgangslage

Aufbauend auf #101 / PR #143 konnten Frontend-Module bereits deterministisch als lokale Nuxt Layers gebaut werden. Für Navigation und weitere Host-Flächen fehlte jedoch ein stabiler, typisierter Contribution-Contract.

Module hätten zentrale Host-Komponenten wie Navigation oder Header weiterhin fachlich anpassen müssen. Dieser PR führt deshalb eine generische UI-Contribution-Infrastruktur ein.

## Umsetzung

- Typisierte und deklarative UI-Contribution-Contracts
- Stabile, zentral definierte Slot-IDs
- Host-owned `FrontendContributionRegistry`
- Ownership-Bindung an die validierte Modul-ID
- Fail-fast-Erkennung doppelter Contribution-IDs
- Deterministische Sortierung nach:
  1. Priorität – kleinere Werte zuerst
  2. Modulreihenfolge aus #101
  3. stabiler Contribution-ID
- Versiegelter Registry-Lifecycle:
  - Registration
  - Validation
  - Seal
  - Read-only Rendering
- SSR-sichere Visibility-Auswertung für:
  - Authentifizierungsstatus
  - Permissions
  - Feature State
  - Modulstatus
- Validierung statischer Navigationsziele
- Prüfung der Component-Ownership
- Schutz vor Cross-Module- und privaten Host-Imports
- Keine HTML-String-Payloads oder Remote Components

## Unterstützte Extension Points

Folgende stabilen Slots wurden definiert:

- `navigation.primary`
- `navigation.user`
- `navigation.admin`
- `header.actions`
- `sidebar`
- `dashboard.widgets`
- `profile.sections`
- `map.controls`
- `map.bottomSheet`
- `map.contextMenu`

Die Map-Slots bereiten ausschließlich generische Vue-UI-Flächen für #103 vor. Es wurden keine MapLibre-, Layer-, Draw-, Query- oder Interaction-APIs implementiert.

## Navigation

Die vorhandene Host-Navigation bleibt erhalten und wird mit Modulbeiträgen zusammengesetzt.

Unterstützt werden:

- Primary Navigation
- User Navigation
- Admin Navigation
- Desktop-Navigation
- Mobile Navigation
- Account-Menü
- aktiver Routenstatus über `aria-current`

`useSiteNavigation.ts` kennt keine konkreten Fachmodule. Beiträge werden ausschließlich über die Contribution Registry aufgelöst.

## Component Contributions

Module können lokale Vue-Komponenten für geeignete Slots registrieren.

Component Contributions enthalten unter anderem:

- stabile Contribution-ID
- Slot
- lokale Component
- lokale Quelldatei
- Priorität
- optionale JSON-sichere Props
- optionale Visibility-Regeln

Für `header.actions` ist zusätzlich ein verständliches Accessible Label erforderlich.

Component-Quellen müssen aus dem eigenen Nuxt Layer unter `app/components` stammen. Fremde Moduldateien, private Hostimporte, Remote Components und beliebige HTML-Strings werden abgelehnt.

## Example-Modul

Das bestehende `example-module` wurde erweitert und registriert nun deklarativ:

- einen Eintrag in `navigation.primary`
- einen permission-sensitiven Eintrag in `navigation.admin`
- eine lokale `ExampleModuleAction` in `header.actions`

Der Host importiert weder die Example-Komponente noch kennt er die ID des Example-Moduls.

Bei leerem `OCP_FRONTEND_MODULES` werden weder Navigationseinträge noch Component Contributions eingebunden.

## Visibility und Permissions

Der Visibility-Contract unterstützt:

- `public`
- `authenticated`
- `anonymous`
- Permission-Identifier
- Feature-Identifier
- Modulstatus

Unbekannte Permissions und Features werden standardmäßig verweigert.

Der Host adaptiert aktuell nur die bestehenden Berechtigungen:

- `platform.verwaltung`
- `platform.superuser`

Damit kann #104 später eine vollständige Permission Registry anbinden, ohne die Contribution-Descriptoren ändern zu müssen.

Wichtig: UI Visibility ist ausschließlich Darstellung und ersetzt keine serverseitige Autorisierung.

## SSR und Hydration

Die Registry wird vor dem Nuxt-Build aufgebaut und versiegelt.

Server und Client erhalten denselben sortierten, unveränderlichen Snapshot. Es gibt keine Registrierung in `onMounted`, keine zufälligen IDs und keine mutable globale Registry.

Navigation, aktiver Link und Component Contribution des Example-Moduls wurden serverseitig getestet.

## Accessibility

Der Host verantwortet:

- Landmark- und Navigationssemantik
- Focus-Reihenfolge und sichtbare Focus Styles
- Keyboard-Erreichbarkeit
- aktiven Navigationszustand
- Öffnen und Schließen des mobilen Menüs
- responsive Platzierung

Module verantworten:

- verständliche Labels
- interne Component-Semantik
- korrekte Formularbeschriftungen
- das Vermeiden von Keyboard Traps

Primary-Navigation-Contributions verwenden dieselbe Liste für Desktop und Mobile. Module müssen keine Host-Breakpoints kennen.

## Frontend-SDK-Version

Der öffentliche Frontend-SDK-Contract wurde additiv erweitert.

Die Version wurde gemäß der in #101 dokumentierten SemVer-Regel erhöht:

- vorher: `1.0.0`
- neu: `1.1.0`

Der öffentliche Einstiegspunkt ist:

`#frontend-module-sdk`

## Architekturgrenzen

Bewusst nicht Bestandteil dieses PRs:

- keine vollständige Migration bestehender Fachdomänen
- keine neue Dashboard-Layout-Engine
- keine neue universelle Sidebar
- keine MapLibre Source Registry
- keine MapLibre Layer Registry
- keine Draw- oder Edit-API
- keine Feature-Query- oder Interaction-API
- keine vollständige Permission Registry aus #104
- keine neue Feature-Flag-Plattform
- keine Runtime-Microfrontends
- keine Module Federation
- keine Remote Components
- keine iframe-Module
- keine HTML-String-Payloads
- kein zusätzliches State Management neben Pinia

## Dokumentation

Ergänzt beziehungsweise aktualisiert wurden:

- Folge-ADR zu Frontend UI Extension Points
- Dokumentation der Frontend UI Contributions
- Frontend-Host-Dokumentation
- CI-Dokumentation
- Slot-Matrix
- Visibility- und Permission-Modell
- SSR- und Hydration-Lifecycle
- Accessibility-Verantwortungsmatrix
- Grenzen zu #103 und #104

## Tests

Erfolgreich ausgeführt:

- `pnpm install --frozen-lockfile`
- `pnpm modules:check`
- `OCP_FRONTEND_MODULES=example-module pnpm modules:check`
- `NUXT_PUBLIC_DEFAULT_OG_IMAGE=/branding/stadtplaner-social-card.png pnpm test`
  - 80 Testdateien
  - 465 Tests
- `pnpm test:modules:ssr`
  - 2 SSR-Smoke-Tests
- `pnpm typecheck`
- `OCP_FRONTEND_MODULES=example-module pnpm typecheck`
- `pnpm build`
- `OCP_FRONTEND_MODULES=example-module pnpm build`
- `pnpm audit:language`
  - 491 Ressourcen geprüft
  - 0 unerlaubte Treffer
- `pnpm audit:seo`

Es gibt keine Backend-, Datenbank- oder Migrationsänderungen.