### PR TITLE
test(modules): add architecture and contract CI gate

### DIFF
--- a/.github/workflows/module-contract.yml
+++ b/.github/workflows/module-contract.yml
@@ -3,8 +3,6 @@ name: Module Contract Gate
 on:
   workflow_dispatch:
   workflow_call:
-  push:
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/module-contract.yml
+++ b/.github/workflows/module-contract.yml
@@ -1,0 +1,68 @@
+name: Module Contract Gate
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: module-contract-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-contracts:
+    name: Backend module contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: .python-version
+      - name: Install pinned uv
+        run: python -m pip install 'uv==0.12.5'
+      - name: Install locked backend dependencies
+        working-directory: backend
+        run: uv sync --frozen --extra dev --no-editable
+      - name: Run backend module contract gate
+        run: scripts/module-contract-gate backend
+
+  frontend-contracts:
+    name: Frontend module contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11.22.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Install locked frontend dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+      - name: Run frontend module contract gate
+        run: scripts/module-contract-gate frontend
+
+  gate:
+    name: Module contract gate
+    needs: [backend-contracts, frontend-contracts]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    steps:
+      - name: Require both contract suites to pass
+        env:
+          BACKEND_RESULT: ${{ needs.backend-contracts.result }}
+          FRONTEND_RESULT: ${{ needs.frontend-contracts.result }}
+        run: |
+          set -euo pipefail
+          test "${BACKEND_RESULT}" = success
+          test "${FRONTEND_RESULT}" = success

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -44,9 +44,13 @@ jobs:
     name: Supply-chain gate
     uses: ./.github/workflows/supply-chain.yml
 
+  module-contract:
+    name: Module contract gate
+    uses: ./.github/workflows/module-contract.yml
+
   gate:
     name: Release gate
-    needs: [backend, frontend, e2e, security, supply-chain]
+    needs: [backend, frontend, e2e, security, supply-chain, module-contract]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ always() }}
@@ -59,10 +63,11 @@ jobs:
           E2E_RESULT: ${{ needs.e2e.result }}
           SECURITY_RESULT: ${{ needs.security.result }}
           SUPPLY_CHAIN_RESULT: ${{ needs.supply-chain.result }}
+          MODULE_CONTRACT_RESULT: ${{ needs.module-contract.result }}
         run: |
           set -euo pipefail
 
-          for name in BACKEND_RESULT FRONTEND_RESULT E2E_RESULT SECURITY_RESULT SUPPLY_CHAIN_RESULT; do
+          for name in BACKEND_RESULT FRONTEND_RESULT E2E_RESULT SECURITY_RESULT SUPPLY_CHAIN_RESULT MODULE_CONTRACT_RESULT; do
             value="${!name}"
             echo "${name}=${value}"
             if [[ "${value}" != "success" ]]; then

--- a/architecture/module-boundary-baseline.json
+++ b/architecture/module-boundary-baseline.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "rule": "ARCH-BE-HOST-001",
+      "source": "backend/app/platform/modules/persistence.py",
+      "target": "app.models",
+      "tracking_issue": "#108",
+      "reason": "Kontrollierter Legacy-Persistence-Adapter bis zur Migration der Fachmodelle."
+    }
+  ]
+}

--- a/architecture/module-contract-rules.json
+++ b/architecture/module-contract-rules.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "id": "ARCH-BASELINE-001",
+      "area": "shared",
+      "summary": "Architektur-Ausnahmen sind exakt, begründet und mit einem Issue verknüpft.",
+      "checker": "backend/tests/test_module_architecture_gate.py"
+    },
+    {
+      "id": "ARCH-BE-HOST-001",
+      "area": "backend",
+      "summary": "Der generische Modul-Host importiert keine Fachdomänen.",
+      "checker": "scripts/check_module_architecture.py"
+    },
+    {
+      "id": "ARCH-BE-MODULE-001",
+      "area": "backend",
+      "summary": "Backend-Module importieren fremde Module nur über öffentliche Contracts.",
+      "checker": "scripts/check_module_architecture.py"
+    },
+    {
+      "id": "ARCH-BE-PRIVATE-001",
+      "area": "backend",
+      "summary": "Backend-Module verwenden Host-Funktionen nur über das öffentliche Modul-SDK.",
+      "checker": "scripts/check_module_architecture.py"
+    },
+    {
+      "id": "ARCH-FE-HOST-001",
+      "area": "frontend",
+      "summary": "Der generische Frontend-Host kennt keine konkreten Module.",
+      "checker": "frontend/module-host/import-boundaries.ts"
+    },
+    {
+      "id": "ARCH-FE-MODULE-001",
+      "area": "frontend",
+      "summary": "Frontend-Module importieren weder Host-Interna noch fremde Module.",
+      "checker": "frontend/module-host/import-boundaries.ts"
+    },
+    {
+      "id": "CONTRACT-MANIFEST-001",
+      "area": "shared",
+      "summary": "Manifest-Schema, IDs, SemVer und Kompatibilitaet sind fail-closed.",
+      "checker": "backend/tests/test_module_manifest.py and frontend/tests/frontend-module-host.test.ts"
+    },
+    {
+      "id": "CONTRACT-REGISTRY-001",
+      "area": "shared",
+      "summary": "Beitraege haben genau einen Owner; Duplikate und spaete Registrierung scheitern.",
+      "checker": "backend/tests/test_module_runtime.py and frontend/tests/frontend-ui-contributions.test.ts"
+    },
+    {
+      "id": "CONTRACT-COMPAT-001",
+      "area": "shared",
+      "summary": "Fehlende, zyklische oder inkompatible Abhaengigkeiten blockieren den Start.",
+      "checker": "backend/tests/test_module_manifest.py and frontend/tests/frontend-module-host.test.ts"
+    },
+    {
+      "id": "CONTRACT-TESTHOST-001",
+      "area": "backend",
+      "summary": "Module lassen sich ohne FastAPI-App, Datenbank, Redis oder Netzwerk registrieren.",
+      "checker": "backend/tests/test_module_test_host.py"
+    }
+  ]
+}

--- a/backend/app/platform/modules/testing.py
+++ b/backend/app/platform/modules/testing.py
@@ -10,8 +10,11 @@ from typing import TypeVar, cast
 
 from pydantic import BaseModel
 
-from app.platform.modules.contracts import ModuleRegistrationContext
+from app.platform.modules.contracts import LifecycleContribution, ModuleRegistrationContext
+from app.platform.modules.manifest import validate_manifest
+from app.platform.modules.runtime import MODULE_SDK_VERSION
 from app.platform.modules.sdk import (
+    BackendModule,
     DomainEvent,
     EventEnvelope,
     EventHandler,
@@ -20,10 +23,13 @@ from app.platform.modules.sdk import (
     JobDefinition,
     LegacyJobHandler,
     ModuleContext,
+    ModuleDefinition,
+    ModuleManifestV1,
     ObservabilityPort,
     SerializableDomainEvent,
     SpanPort,
     event_envelope,
+    parse_manifest,
 )
 
 T = TypeVar("T")
@@ -363,6 +369,71 @@ class FakeModuleSettings:
         return value
 
 
+class ModuleTestHost:
+    """Kleiner Modul-Lifecycle fuer Contract-Tests ohne produktive Infrastruktur."""
+
+    def __init__(
+        self,
+        definition: ModuleDefinition,
+        *,
+        host_version: str = "0.2.0",
+        sdk_version: str = MODULE_SDK_VERSION,
+        settings: Mapping[str, object] | None = None,
+    ) -> None:
+        manifest = (
+            definition.manifest
+            if isinstance(definition.manifest, ModuleManifestV1)
+            else parse_manifest(definition.manifest, origin=definition.origin)
+        )
+        if definition.declared_id != manifest.id:
+            raise ValueError("The test module discovery ID does not match its manifest ID.")
+        self.manifest = validate_manifest(
+            manifest,
+            host_version=host_version,
+            sdk_version=sdk_version,
+        )
+        self.definition = definition
+        self.module: BackendModule = definition.loader()
+        if self.module.manifest.id != self.manifest.id:
+            raise ValueError("The loaded test module does not match its definition manifest.")
+        self.context = create_test_module_context(
+            module_id=self.manifest.id,
+            module_version=self.manifest.version,
+            settings=settings,
+        )
+        self._registered = False
+        self._started: list[LifecycleContribution] = []
+
+    def register(self) -> ModuleContext:
+        if self._registered:
+            raise RuntimeError("The test module is already registered.")
+        registration = cast(ModuleRegistrationContext, self.context.api)
+        try:
+            self.module.register(self.context)
+        finally:
+            registration.close()
+            services = self.context.services
+            if isinstance(services, FakeServiceRegistry):
+                services.seal()
+            self._registered = True
+        return self.context
+
+    async def startup(self) -> None:
+        if not self._registered:
+            self.register()
+        registration = cast(ModuleRegistrationContext, self.context.lifecycle)
+        for contribution in registration.lifecycle:
+            if contribution.startup is not None:
+                await contribution.startup()
+                self._started.append(contribution)
+
+    async def shutdown(self) -> None:
+        for contribution in reversed(self._started):
+            if contribution.shutdown is not None:
+                await contribution.shutdown()
+        self._started.clear()
+
+
 def create_test_module_context(
     *,
     module_id: str = "test-module",
@@ -414,5 +485,6 @@ __all__ = [
     "FakeSpan",
     "FakeStorage",
     "FakeTracer",
+    "ModuleTestHost",
     "create_test_module_context",
 ]

--- a/backend/tests/fixtures/module_contracts/cycle-a.json
+++ b/backend/tests/fixtures/module_contracts/cycle-a.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 1,
+  "id": "cycle-a",
+  "name": "Cycle A fixture",
+  "version": "1.0.0",
+  "requires": {
+    "host": ">=0.2.0,<1.0.0",
+    "sdk": ">=1.0.0,<2.0.0",
+    "modules": { "cycle-b": ">=1.0.0,<2.0.0" }
+  }
+}

--- a/backend/tests/fixtures/module_contracts/cycle-b.json
+++ b/backend/tests/fixtures/module_contracts/cycle-b.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 1,
+  "id": "cycle-b",
+  "name": "Cycle B fixture",
+  "version": "1.0.0",
+  "requires": {
+    "host": ">=0.2.0,<1.0.0",
+    "sdk": ">=1.0.0,<2.0.0",
+    "modules": { "cycle-a": ">=1.0.0,<2.0.0" }
+  }
+}

--- a/backend/tests/fixtures/module_contracts/incompatible-sdk.json
+++ b/backend/tests/fixtures/module_contracts/incompatible-sdk.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 1,
+  "id": "future-sdk",
+  "name": "Incompatible SDK fixture",
+  "version": "1.0.0",
+  "requires": {
+    "host": ">=0.2.0,<1.0.0",
+    "sdk": ">=99.0.0,<100.0.0"
+  }
+}

--- a/backend/tests/test_module_architecture_gate.py
+++ b/backend/tests/test_module_architecture_gate.py
@@ -1,0 +1,104 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/check_module_architecture.py"
+SPEC = importlib.util.spec_from_file_location("module_architecture_check", SCRIPT)
+assert SPEC and SPEC.loader
+architecture = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = architecture
+SPEC.loader.exec_module(architecture)
+
+
+def write_contract_files(root: Path, entries: list[dict[str, str]] | None = None) -> None:
+    directory = root / "architecture"
+    directory.mkdir(parents=True)
+    (directory / "module-contract-rules.json").write_text(
+        json.dumps({"version": 1, "rules": [{"id": "ARCH-BE-HOST-001"}]}),
+        encoding="utf-8",
+    )
+    (directory / "module-boundary-baseline.json").write_text(
+        json.dumps({"version": 1, "entries": entries or []}), encoding="utf-8"
+    )
+
+
+def test_repository_backend_boundaries_are_clean() -> None:
+    assert architecture.active_violations(ROOT) == ()
+
+
+def test_forbidden_host_import_is_reported_with_stable_rule(tmp_path: Path) -> None:
+    write_contract_files(tmp_path)
+    source = tmp_path / "backend/app/platform/modules/broken.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("from app.services.users import UserService\n", encoding="utf-8")
+
+    assert architecture.active_violations(tmp_path) == (
+        architecture.Violation(
+            "ARCH-BE-HOST-001",
+            "backend/app/platform/modules/broken.py",
+            "app.services.users",
+            1,
+        ),
+    )
+
+
+def test_module_private_host_and_foreign_internal_imports_are_reported(
+    tmp_path: Path,
+) -> None:
+    write_contract_files(tmp_path)
+    source = tmp_path / "backend/app/modules/alpha/application.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "from app.db.session import AsyncSessionLocal\n"
+        "from app.modules.beta.internal import secret\n",
+        encoding="utf-8",
+    )
+    foreign = tmp_path / "backend/app/modules/beta/internal.py"
+    foreign.parent.mkdir(parents=True)
+    foreign.write_text("secret = True\n", encoding="utf-8")
+
+    violations = architecture.active_violations(tmp_path)
+
+    assert any(item.rule == "ARCH-BE-PRIVATE-001" for item in violations)
+    assert any(item.rule == "ARCH-BE-MODULE-001" for item in violations)
+
+
+def test_exact_documented_baseline_exception_is_accepted(tmp_path: Path) -> None:
+    source = tmp_path / "backend/app/platform/modules/legacy.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("from app.services.legacy import LegacyService\n", encoding="utf-8")
+    write_contract_files(
+        tmp_path,
+        [{
+            "rule": "ARCH-BE-HOST-001",
+            "source": "backend/app/platform/modules/legacy.py",
+            "target": "app.services.legacy",
+            "tracking_issue": "#999",
+            "reason": "Temporary migration fixture.",
+        }],
+    )
+
+    assert architecture.active_violations(tmp_path) == ()
+
+
+def test_baseline_rejects_wildcards_and_missing_issue(tmp_path: Path) -> None:
+    source = tmp_path / "backend/app/platform/modules/legacy.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("# fixture\n", encoding="utf-8")
+    write_contract_files(
+        tmp_path,
+        [{
+            "rule": "ARCH-BE-HOST-001",
+            "source": "backend/app/platform/modules/*.py",
+            "target": "app.services.*",
+            "tracking_issue": "later",
+            "reason": "Too broad.",
+        }],
+    )
+
+    with pytest.raises(ValueError, match="non-wildcard|tracking_issue"):
+        architecture.load_baseline(tmp_path)

--- a/backend/tests/test_module_test_host.py
+++ b/backend/tests/test_module_test_host.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.platform.modules.dependency_graph import resolve_module_order
+from app.platform.modules.errors import ModuleCompatibilityError, ModuleDependencyCycleError
+from app.platform.modules.manifest import parse_manifest, validate_manifest
+from app.platform.modules.testing import FakeServiceRegistry, ModuleTestHost
+from tests.fixtures.service_modules.analysis_areas.module import DEFINITION
+
+FIXTURES = Path(__file__).parent / "fixtures/module_contracts"
+
+
+def load_fixture(name: str):
+    return parse_manifest(json.loads((FIXTURES / name).read_text(encoding="utf-8")))
+
+
+def test_module_test_host_registers_example_without_infrastructure() -> None:
+    host = ModuleTestHost(DEFINITION)
+
+    context = host.register()
+
+    assert context.database is None
+    assert context.module_id == "analysis-areas-fixture"
+    assert isinstance(context.services, FakeServiceRegistry)
+    assert context.services.sealed is True
+
+
+def test_module_test_host_closes_registration_after_bootstrap() -> None:
+    host = ModuleTestHost(DEFINITION)
+    host.register()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        host.context.lifecycle.add_lifecycle(startup=_noop)
+
+
+async def _noop() -> None:
+    return None
+
+
+def test_broken_cycle_fixture_is_rejected() -> None:
+    with pytest.raises(ModuleDependencyCycleError):
+        resolve_module_order([load_fixture("cycle-a.json"), load_fixture("cycle-b.json")])
+
+
+def test_incompatible_sdk_fixture_is_rejected() -> None:
+    with pytest.raises(ModuleCompatibilityError):
+        validate_manifest(
+            load_fixture("incompatible-sdk.json"),
+            host_version="0.2.0",
+            sdk_version="1.3.0",
+        )

--- a/docs/architecture/adr-module-contract-ci-gate.md
+++ b/docs/architecture/adr-module-contract-ci-gate.md
@@ -1,0 +1,34 @@
+# ADR: Architektur- und Modulverträge als CI-Gate
+
+- Status: Angenommen
+- Datum: 2026-08-26
+- Entscheidung: [Issue #105](https://github.com/oklabflensburg/open-city-planner/issues/105)
+- Epic: [Issue #91](https://github.com/oklabflensburg/open-city-planner/issues/91)
+
+## Kontext
+
+Manifeste, SDKs und Registries definieren Modulgrenzen, verhindern aber allein keine
+später eingeführten Direktimporte. Reine Textsuche erkennt TypeScript-Re-Exports,
+dynamische Imports und mehrzeilige Syntax nicht zuverlässig. Eine große historische
+Allowlist würde zugleich neue Verstöße verbergen.
+
+## Entscheidung
+
+Ein eigener, verpflichtender CI-Workflow prüft die Modulverträge. Python-Imports
+werden über den Standardbibliotheks-AST analysiert. Frontend-Imports, Re-Exports und
+dynamische Imports werden über den bereits gelockten TypeScript-Parser analysiert;
+Vue-Scriptblöcke werden einzeln geparst. Es wird keine neue schwere Abhängigkeit
+eingeführt.
+
+Bestehende Contract-Tests bleiben die ausführbare Spezifikation für Manifeste,
+Kompatibilität und Registries. Ein kleiner `ModuleTestHost` ergänzt isolierte
+Bootstrap-Tests. Architektur-Ausnahmen sind in einer strukturierten, fail-closed
+Baseline exakt benannt und mit einem Abbau-Issue verknüpft.
+
+## Folgen
+
+Neue Grenzverletzungen blockieren Pull Requests mit stabiler Regel-ID und
+Quellposition. Backend und Frontend laufen parallel und ohne Playwright. Eine
+bewusste Ausnahme erzeugt Review-Aufwand und bleibt sichtbar; pauschale Wildcards
+sind nicht möglich. Das Gate migriert keine Fachdomänen und ersetzt nicht die
+vollständigen Backend-, Frontend-, E2E-, Security- oder Supply-Chain-Gates.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -24,6 +24,7 @@ bei reinen Dokumentationsänderungen nicht.
 | Security | `secret-scan` | Gitleaks gegen die vollständige Historie mit redigierter Ausgabe und SARIF-Upload |
 | Supply Chain | `verify` | Lockfile-Konsistenz, SHA-/Digest-Pins und negative Policy-Regressionstests |
 | Supply Chain | `sbom` | transitive CycloneDX-SBOMs für Backend und Frontend |
+| Module Contract Gate | `Module contract gate` | Backend-/Frontend-Importgrenzen, Manifest-, Dependency-, Registry-, Map- und SSR-Verträge ohne Playwright |
 
 Die Workflows verwenden exakt Python 3.12.14 aus `.python-version`, Node.js 22.23.2
 aus `.node-version`, uv 0.12.5 und die in `frontend/package.json` festgelegte
@@ -44,6 +45,13 @@ Die Testdaten erzeugt
 für die frische CI-Datenbank.
 
 ## Lokale Prüfung
+
+Das fokussierte Modul-Gate läuft mit einem Befehl (nach Installation beider
+gelockten Dependency-Sätze):
+
+```bash
+scripts/module-contract-gate
+```
 
 Backend:
 
@@ -194,6 +202,7 @@ Checks aus:
 - `secret-scan`
 - `verify`
 - `sbom`
+- `Module contract gate`
 - `gate`
 
 Zusätzlich empfehlen sich mindestens eine Freigabe, „Require conversation

--- a/docs/modules/architecture-rules.md
+++ b/docs/modules/architecture-rules.md
@@ -1,0 +1,34 @@
+# Verbindliche Modul-Architekturregeln
+
+Die maschinenlesbare Quelle ist
+[`architecture/module-contract-rules.json`](../../architecture/module-contract-rules.json).
+Regel-IDs bleiben stabil, damit CI-Fehler, Baseline-Einträge und Issues eindeutig
+aufeinander verweisen.
+
+| Regel | Warum | Erlaubtes Beispiel | Verbotenes Beispiel | Durchsetzung |
+| --- | --- | --- | --- | --- |
+| `ARCH-BASELINE-001` | Schulden bleiben sichtbar und abbaubar. | exakte Ausnahme mit `reason` und `#108` | `target: "app.*"` | Baseline-Validator und Negativtests |
+| `ARCH-BE-HOST-001` | Der Host bleibt fachneutral. | `app.platform.modules.sdk` und explizite Infrastrukturadapter | Host importiert `app.services.statistics` | Python-AST-Checker |
+| `ARCH-BE-MODULE-001` | Provider können ihre Interna ändern. | Alpha importiert `beta.contracts` | Alpha importiert `beta.internal` | Python-AST-Checker |
+| `ARCH-BE-PRIVATE-001` | Host-Ports erzwingen Lifecycle und Isolation. | Modul importiert `app.platform.modules.sdk` | Modul importiert `app.db.session` oder `modules.runtime` | Python-AST-Checker |
+| `ARCH-FE-HOST-001` | Der Build-Time-Host bleibt generisch. | Host liest Contribution-Registries | `nuxt.config.ts` importiert `example-module` | TypeScript-AST-Checker |
+| `ARCH-FE-MODULE-001` | Nuxt-Layer bleiben unabhängig. | eigene relative Datei, `#frontend-module-sdk` oder `#imports` | `~/stores/auth` oder `../../beta/internal` | TypeScript-AST-Checker |
+| `CONTRACT-MANIFEST-001` | Discovery muss deterministisch und kompatibel scheitern. | gültige ID, SemVer und SDK-Range | unbekanntes Feld oder SDK `>=99` | Backend- und Frontend-Contract-Tests |
+| `CONTRACT-REGISTRY-001` | Contributions benötigen eindeutige Ownership. | eine namespacete ID vor dem Seal | doppelte ID oder Registrierung nach Seal | Registry-Contract-Tests |
+| `CONTRACT-COMPAT-001` | Startreihenfolge darf nicht implizit sein. | `A -> B -> C` mit passenden Versionen | `A -> B -> A` oder fehlendes B | Manifest-/Discovery-Tests |
+| `CONTRACT-TESTHOST-001` | Module sollen schnell und isoliert testbar sein. | Bootstrap mit SDK-Fakes | Test benötigt App, DB, Redis oder Internet | `ModuleTestHost`-Tests |
+
+Der Checker meldet Regel-ID, Datei, Zeile und Zielimport. Neue Regeln benötigen
+eine stabile ID, Positiv- und Negativtests sowie eine Aktualisierung dieser Tabelle.
+
+## Baseline
+
+[`architecture/module-boundary-baseline.json`](../../architecture/module-boundary-baseline.json)
+ist keine allgemeine Allowlist. Jeder Eintrag benennt exakt `rule`, `source` und
+`target`, enthält einen sachlichen `reason` und ein `tracking_issue` im Format
+`#123`. Wildcards sind unzulässig; nicht mehr existierende Quelldateien und doppelte
+Einträge brechen das Gate. Neue Ausnahmen sollen im selben Pull Request ein
+Abbau-Issue und einen verantwortbaren Migrationspfad erhalten.
+
+Die vorhandene Ausnahme für den zentralen Legacy-Persistence-Import bleibt bis
+[#108](https://github.com/oklabflensburg/open-city-planner/issues/108) bestehen.

--- a/docs/modules/module-contract-gate.md
+++ b/docs/modules/module-contract-gate.md
@@ -1,0 +1,52 @@
+# Modul-Contract-Gate
+
+Das Gate schützt den modularen Host gegen schleichende Rückkopplungen. Es kombiniert
+statische Importgrenzen mit den bestehenden Manifest-, Dependency-, Registry-,
+Permission-, Map- und SSR-Vertragstests. Es startet keine Browser und benötigt weder
+PostgreSQL noch Redis oder externe Netzwerke.
+
+Nach der Installation der gelockten Backend- und Frontend-Abhängigkeiten reicht lokal:
+
+```bash
+scripts/module-contract-gate
+```
+
+Für eine einzelne Seite können `backend` oder `frontend` als Argument übergeben
+werden. Das vollständige Gate soll auf Entwicklerrechnern und in CI in wenigen
+Minuten laufen. Der lokale Referenzlauf für die fokussierte Matrix benötigte rund
+45 Sekunden (227 Backend- und 41 Frontend-/SSR-Contract-Tests); CI führt beide
+Seiten parallel aus.
+
+GitHub Actions führt Backend und Frontend parallel aus. Der stabile aggregierte
+Required Check heißt `Module contract gate`. Er ist zusätzlich Bestandteil des
+`Release gate`; Fehler werden nicht als optional behandelt.
+
+## Test-Fixtures und Test-Host
+
+Negativ-Fixtures liegen unter `backend/tests/fixtures/module_contracts` und
+`frontend/tests/fixtures/module-contracts`. Sie beweisen unter anderem, dass Zyklen,
+eine inkompatible SDK-Version und ein Export aus einem fremden Frontend-Modul den
+Check tatsächlich fehlschlagen lassen.
+
+`ModuleTestHost` in `app.platform.modules.testing` lädt eine `ModuleDefinition`,
+validiert Manifest und Kompatibilität, stellt die vorhandenen Fakes bereit und
+schließt/sealt die Registrierung. Damit lassen sich Modul-Bootstrap und Lifecycle
+ohne FastAPI-App, Datenbank, Redis oder echte HTTP-Aufrufe testen.
+
+Regeln und Baseline-Verfahren sind in
+[`architecture-rules.md`](architecture-rules.md) dokumentiert. Fachliche
+Legacy-Bereinigung bleibt Aufgabe von #108; das Gate erweitert nicht den Scope der
+Modularisierung.
+
+## Typische Fehler beheben
+
+- `ARCH-BE-MODULE-001`: öffentlichen `contracts`-Namespace oder Service Registry
+  statt fremder Interna verwenden.
+- `ARCH-BE-PRIVATE-001`: passenden `ModuleContext`-/SDK-Port statt Host-Session,
+  Settings oder Runtime-Helper verwenden.
+- `ARCH-FE-HOST-001`: UI-, Navigation- oder Map-Contribution registrieren, statt
+  eine konkrete Modul-ID im Host zu verzweigen.
+- `ARCH-FE-MODULE-001`: `#frontend-module-sdk`, `#imports` oder eigene lokale
+  Dateien verwenden.
+- Inkompatibles SDK/Manifest: deklarierte Range nur anpassen, wenn das Modul den
+  tatsächlich installierten öffentlichen Contract unterstützt.

--- a/frontend/module-host/check-architecture.ts
+++ b/frontend/module-host/check-architecture.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from 'node:url'
+import { activeFrontendViolations } from './import-boundaries.ts'
+
+const defaultRepositoryRoot = fileURLToPath(new URL('../..', import.meta.url))
+const repositoryRoot = process.env.OCP_ARCHITECTURE_ROOT || defaultRepositoryRoot
+const frontendRoot = process.env.OCP_ARCHITECTURE_FRONTEND_ROOT
+
+try {
+  const violations = activeFrontendViolations({ repositoryRoot, frontendRoot })
+  for (const item of violations) {
+    const guidance = item.rule === 'ARCH-FE-HOST-001'
+      ? 'Use the contribution registry instead of concrete module knowledge.'
+      : 'Use #frontend-module-sdk, #imports or a public contribution contract.'
+    console.error(`::error file=${item.source},line=${item.line},title=${item.rule}::Forbidden dependency ${item.target}. ${guidance}`)
+  }
+  if (violations.length) {
+    console.error(`Frontend module architecture check failed with ${violations.length} violation(s).`)
+    process.exitCode = 1
+  } else {
+    console.log('Frontend module architecture check passed.')
+  }
+} catch (error) {
+  console.error(`Frontend architecture check configuration error: ${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 2
+}

--- a/frontend/module-host/import-boundaries.ts
+++ b/frontend/module-host/import-boundaries.ts
@@ -1,0 +1,216 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, relative, resolve, sep } from 'node:path'
+import ts from 'typescript'
+
+export type ArchitectureViolation = {
+  rule: 'ARCH-FE-HOST-001' | 'ARCH-FE-MODULE-001'
+  source: string
+  target: string
+  line: number
+}
+
+type BaselineEntry = {
+  rule: string
+  source: string
+  target: string
+  tracking_issue: string
+  reason: string
+}
+
+type ScanOptions = {
+  repositoryRoot: string
+  frontendRoot?: string
+  rulesFile?: string
+  baselineFile?: string
+}
+
+const sourceExtension = /\.(?:vue|[cm]?[jt]sx?)$/
+
+export function scanFrontendArchitecture(options: ScanOptions): ArchitectureViolation[] {
+  const repositoryRoot = resolve(options.repositoryRoot)
+  const frontendRoot = resolve(options.frontendRoot ?? resolve(repositoryRoot, 'frontend'))
+  const modulesRoot = resolve(frontendRoot, 'frontend-modules')
+  const moduleIds = existsSync(modulesRoot)
+    ? readdirSync(modulesRoot, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => entry.name)
+    : []
+  const violations: ArchitectureViolation[] = []
+
+  for (const moduleId of moduleIds) {
+    const moduleRoot = resolve(modulesRoot, moduleId)
+    for (const source of walkSourceFiles(moduleRoot)) {
+      for (const imported of extractImports(source)) {
+        if (isForbiddenModuleImport(imported.specifier, source, moduleRoot, modulesRoot)) {
+          violations.push(makeViolation(repositoryRoot, 'ARCH-FE-MODULE-001', source, imported))
+        }
+      }
+    }
+  }
+
+  const hostSources = [
+    ...walkSourceFiles(resolve(frontendRoot, 'module-host')),
+    ...walkSourceFiles(resolve(frontendRoot, 'app')),
+    resolve(frontendRoot, 'nuxt.config.ts')
+  ].filter((source, index, all) => existsSync(source) && all.indexOf(source) === index)
+  for (const source of hostSources) {
+    for (const imported of extractImports(source)) {
+      if (resolvesInside(imported.specifier, source, frontendRoot, modulesRoot)) {
+        violations.push(makeViolation(repositoryRoot, 'ARCH-FE-HOST-001', source, imported))
+      }
+    }
+    for (const literal of extractStringLiterals(source)) {
+      if (moduleIds.includes(literal.value)) {
+        violations.push(makeViolation(
+          repositoryRoot,
+          'ARCH-FE-HOST-001',
+          source,
+          { specifier: literal.value, line: literal.line }
+        ))
+      }
+    }
+  }
+
+  return unique(violations).sort((left, right) =>
+    left.source.localeCompare(right.source, 'en') || left.line - right.line || left.rule.localeCompare(right.rule, 'en')
+  )
+}
+
+export function activeFrontendViolations(options: ScanOptions): ArchitectureViolation[] {
+  const repositoryRoot = resolve(options.repositoryRoot)
+  const rulesFile = options.rulesFile ?? resolve(repositoryRoot, 'architecture/module-contract-rules.json')
+  const baselineFile = options.baselineFile ?? resolve(repositoryRoot, 'architecture/module-boundary-baseline.json')
+  const baseline = loadBaseline(repositoryRoot, rulesFile, baselineFile)
+  return scanFrontendArchitecture(options).filter(item => !baseline.has(key(item)))
+}
+
+function loadBaseline(repositoryRoot: string, rulesFile: string, baselineFile: string): Set<string> {
+  const rules = JSON.parse(readFileSync(rulesFile, 'utf8')) as { version?: number, rules?: Array<{ id?: string }> }
+  const baseline = JSON.parse(readFileSync(baselineFile, 'utf8')) as { version?: number, entries?: BaselineEntry[] }
+  if (rules.version !== 1 || baseline.version !== 1 || !Array.isArray(rules.rules) || !Array.isArray(baseline.entries)) {
+    throw new Error('Architecture rule and baseline files must use schema version 1.')
+  }
+  const knownRules = new Set(rules.rules.map(rule => rule.id))
+  const result = new Set<string>()
+  for (const entry of baseline.entries) {
+    if (!knownRules.has(entry.rule)) throw new Error(`Unknown baseline rule: ${entry.rule}`)
+    if ([entry.rule, entry.source, entry.target].some(value => !value || value.includes('*'))) {
+      throw new Error('Baseline rule, source and target must be exact non-wildcard strings.')
+    }
+    if (!/^#\d+$/.test(entry.tracking_issue) || !entry.reason?.trim()) {
+      throw new Error('Every baseline entry needs a reason and a tracking issue like #123.')
+    }
+    if (!existsSync(resolve(repositoryRoot, entry.source))) {
+      throw new Error(`Baseline source does not exist: ${entry.source}`)
+    }
+    const entryKey = key(entry)
+    if (result.has(entryKey)) throw new Error(`Duplicate baseline entry: ${entryKey}`)
+    result.add(entryKey)
+  }
+  return result
+}
+
+function isForbiddenModuleImport(specifier: string, source: string, moduleRoot: string, modulesRoot: string): boolean {
+  if (specifier.startsWith('~/') || specifier.startsWith('@/')) return true
+  if (specifier.includes('frontend-modules/')) return true
+  if (!specifier.startsWith('.')) return false
+  const target = resolve(dirname(source), specifier)
+  return !isInside(moduleRoot, target) || (isInside(modulesRoot, target) && !isInside(moduleRoot, target))
+}
+
+function resolvesInside(specifier: string, source: string, frontendRoot: string, targetRoot: string): boolean {
+  let target: string | undefined
+  if (specifier.startsWith('~/') || specifier.startsWith('@/')) {
+    target = resolve(frontendRoot, specifier.slice(2))
+  } else if (specifier.startsWith('.')) {
+    target = resolve(dirname(source), specifier)
+  } else if (specifier.includes('frontend-modules/')) {
+    target = resolve(frontendRoot, specifier.slice(specifier.indexOf('frontend-modules/')))
+  }
+  return target !== undefined && isInside(targetRoot, target)
+}
+
+function isInside(parent: string, child: string): boolean {
+  const path = relative(parent, child)
+  return path === '' || (path !== '..' && !path.startsWith(`..${sep}`))
+}
+
+function walkSourceFiles(directory: string): string[] {
+  if (!existsSync(directory)) return []
+  return readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name, 'en'))
+    .flatMap(entry => {
+      const path = resolve(directory, entry.name)
+      return entry.isDirectory() ? walkSourceFiles(path) : sourceExtension.test(path) ? [path] : []
+    })
+}
+
+function scriptFragments(source: string): Array<{ text: string, startLine: number }> {
+  const contents = readFileSync(source, 'utf8')
+  if (!source.endsWith('.vue')) return [{ text: contents, startLine: 1 }]
+  const fragments: Array<{ text: string, startLine: number }> = []
+  for (const match of contents.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)) {
+    const text = match[1] ?? ''
+    const contentStart = (match.index ?? 0) + match[0].indexOf(text)
+    fragments.push({ text, startLine: contents.slice(0, contentStart).split('\n').length })
+  }
+  return fragments
+}
+
+function extractImports(source: string): Array<{ specifier: string, line: number }> {
+  const imports: Array<{ specifier: string, line: number }> = []
+  for (const fragment of scriptFragments(source)) {
+    const file = ts.createSourceFile(source, fragment.text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+    const visit = (node: ts.Node) => {
+      let literal: ts.StringLiteralLike | undefined
+      if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+        literal = node.moduleSpecifier && ts.isStringLiteralLike(node.moduleSpecifier) ? node.moduleSpecifier : undefined
+      } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        const argument = node.arguments[0]
+        literal = argument && ts.isStringLiteralLike(argument) ? argument : undefined
+      }
+      if (literal) {
+        const line = file.getLineAndCharacterOfPosition(literal.getStart(file)).line + fragment.startLine
+        imports.push({ specifier: literal.text, line })
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(file)
+  }
+  return imports
+}
+
+function extractStringLiterals(source: string): Array<{ value: string, line: number }> {
+  const literals: Array<{ value: string, line: number }> = []
+  for (const fragment of scriptFragments(source)) {
+    const file = ts.createSourceFile(source, fragment.text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+    const visit = (node: ts.Node) => {
+      if (ts.isStringLiteralLike(node)) {
+        literals.push({
+          value: node.text,
+          line: file.getLineAndCharacterOfPosition(node.getStart(file)).line + fragment.startLine
+        })
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(file)
+  }
+  return literals
+}
+
+function makeViolation(
+  repositoryRoot: string,
+  rule: ArchitectureViolation['rule'],
+  source: string,
+  imported: { specifier: string, line: number }
+): ArchitectureViolation {
+  return { rule, source: relative(repositoryRoot, source).split(sep).join('/'), target: imported.specifier, line: imported.line }
+}
+
+function key(item: { rule: string, source: string, target: string }): string {
+  return JSON.stringify([item.rule, item.source, item.target])
+}
+
+function unique(items: ArchitectureViolation[]): ArchitectureViolation[] {
+  return [...new Map(items.map(item => [key(item), item])).values()]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "modules:check": "node module-host/check.ts",
+    "modules:architecture": "node module-host/check-architecture.ts",
     "typecheck": "nuxt typecheck",
     "test": "vitest run",
     "test:modules:ssr": "vitest run --config vitest.frontend-modules.config.ts",

--- a/frontend/tests/fixtures/module-contracts/broken-import/architecture/module-boundary-baseline.json
+++ b/frontend/tests/fixtures/module-contracts/broken-import/architecture/module-boundary-baseline.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": []
+}

--- a/frontend/tests/fixtures/module-contracts/broken-import/architecture/module-contract-rules.json
+++ b/frontend/tests/fixtures/module-contracts/broken-import/architecture/module-contract-rules.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "rules": [
+    { "id": "ARCH-FE-MODULE-001" },
+    { "id": "ARCH-FE-HOST-001" }
+  ]
+}

--- a/frontend/tests/fixtures/module-contracts/broken-import/frontend-modules/alpha/layer/app/pages/alpha.vue
+++ b/frontend/tests/fixtures/module-contracts/broken-import/frontend-modules/alpha/layer/app/pages/alpha.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+export { secret } from '../../../../beta/layer/internal/secret'
+</script>
+
+<template><p>Broken architecture fixture</p></template>

--- a/frontend/tests/fixtures/module-contracts/broken-import/frontend-modules/alpha/module.json
+++ b/frontend/tests/fixtures/module-contracts/broken-import/frontend-modules/alpha/module.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "id": "alpha"
+}

--- a/frontend/tests/fixtures/module-contracts/broken-import/frontend-modules/beta/layer/internal/secret.ts
+++ b/frontend/tests/fixtures/module-contracts/broken-import/frontend-modules/beta/layer/internal/secret.ts
@@ -1,0 +1,1 @@
+export const secret = 'must not cross module boundaries'

--- a/frontend/tests/fixtures/module-contracts/broken-import/frontend-modules/beta/module.json
+++ b/frontend/tests/fixtures/module-contracts/broken-import/frontend-modules/beta/module.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "id": "beta"
+}

--- a/frontend/tests/frontend-module-architecture.test.ts
+++ b/frontend/tests/frontend-module-architecture.test.ts
@@ -1,0 +1,42 @@
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { activeFrontendViolations, scanFrontendArchitecture } from '../module-host/import-boundaries'
+
+const repositoryRoot = resolve(import.meta.dirname, '../..')
+
+describe('frontend module architecture gate', () => {
+  it('keeps production host and modules independent', () => {
+    expect(activeFrontendViolations({ repositoryRoot })).toEqual([])
+  })
+
+  it('detects a foreign re-export with a stable rule ID', () => {
+    const fixtureRoot = resolve(import.meta.dirname, 'fixtures/module-contracts/broken-import')
+    expect(scanFrontendArchitecture({ repositoryRoot: fixtureRoot, frontendRoot: fixtureRoot }))
+      .toContainEqual(expect.objectContaining({
+        rule: 'ARCH-FE-MODULE-001',
+        source: 'frontend-modules/alpha/layer/app/pages/alpha.vue',
+        target: '../../../../beta/layer/internal/secret'
+      }))
+  })
+
+  it('returns non-zero for the committed broken import fixture', () => {
+    const fixtureRoot = resolve(import.meta.dirname, 'fixtures/module-contracts/broken-import')
+    const result = spawnSync(
+      process.execPath,
+      [resolve(import.meta.dirname, '../module-host/check-architecture.ts')],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          OCP_ARCHITECTURE_ROOT: fixtureRoot,
+          OCP_ARCHITECTURE_FRONTEND_ROOT: fixtureRoot
+        }
+      }
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('ARCH-FE-MODULE-001')
+    expect(result.stderr).toContain('alpha/layer/app/pages/alpha.vue')
+  })
+})
+import { spawnSync } from 'node:child_process'

--- a/scripts/check_module_architecture.py
+++ b/scripts/check_module_architecture.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Fail-closed architecture check for backend module boundaries."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND = ROOT / "backend"
+sys.path.insert(0, str(BACKEND))
+
+from app.platform.modules.import_boundaries import (
+    find_cross_module_import_violations,
+    find_host_settings_import_violations,
+)
+
+RULES = ROOT / "architecture/module-contract-rules.json"
+BASELINE = ROOT / "architecture/module-boundary-baseline.json"
+HOST_FORBIDDEN = (
+    "app.api",
+    "app.auth",
+    "app.cli",
+    "app.models",
+    "app.schemas",
+    "app.security",
+    "app.services",
+)
+MODULE_PRIVATE = (
+    "app.api",
+    "app.auth",
+    "app.cache",
+    "app.cli",
+    "app.core",
+    "app.db",
+    "app.models",
+    "app.observability",
+    "app.platform.modules",
+    "app.schemas",
+    "app.security",
+    "app.services",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Violation:
+    rule: str
+    source: str
+    target: str
+    line: int
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.rule, self.source, self.target)
+
+
+def imported_names(source: Path, python_root: Path) -> list[tuple[str, int]]:
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    relative = source.relative_to(python_root)
+    current_package = relative.parent.parts
+    found: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.extend((alias.name, node.lineno) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                keep = max(len(current_package) - (node.level - 1), 0)
+                suffix = tuple(node.module.split(".")) if node.module else ()
+                base_parts = (*current_package[:keep], *suffix)
+                base = ".".join(base_parts)
+            else:
+                base = node.module or ""
+            if base:
+                found.append((base, node.lineno))
+                found.extend(
+                    (f"{base}.{alias.name}", node.lineno)
+                    for alias in node.names
+                    if alias.name != "*"
+                )
+    return found
+
+
+def forbidden_imports(
+    source: Path,
+    python_root: Path,
+    prefixes: tuple[str, ...],
+) -> list[tuple[str, int]]:
+    matches = [
+        item for item in imported_names(source, python_root) if item[0].startswith(prefixes)
+    ]
+    selected: list[tuple[str, int]] = []
+    for target, line in sorted(matches, key=lambda item: (item[1], len(item[0]))):
+        if any(line == prior_line and target.startswith(f"{prior}.") for prior, prior_line in selected):
+            continue
+        selected.append((target, line))
+    return selected
+
+
+def scan_backend(root: Path = ROOT) -> tuple[Violation, ...]:
+    backend = root / "backend"
+    violations: list[Violation] = []
+    host_root = backend / "app/platform/modules"
+    if host_root.exists():
+        for source in sorted(host_root.rglob("*.py")):
+            for target, line in forbidden_imports(source, backend, HOST_FORBIDDEN):
+                violations.append(_violation(root, "ARCH-BE-HOST-001", source, target, line))
+
+    for modules_root, package_prefix in (
+        (backend / "app/modules", "app.modules"),
+        (backend / "modules", "modules"),
+    ):
+        if not modules_root.exists():
+            continue
+        for item in find_cross_module_import_violations(
+            modules_root, package_prefix=package_prefix
+        ):
+            violations.append(
+                _violation(
+                    root,
+                    "ARCH-BE-MODULE-001",
+                    item.source,
+                    item.imported_module,
+                    item.line,
+                )
+            )
+        for item in find_host_settings_import_violations(modules_root):
+            violations.append(
+                _violation(
+                    root,
+                    "ARCH-BE-PRIVATE-001",
+                    item.source,
+                    item.imported_module,
+                    item.line,
+                )
+            )
+        for source in sorted(modules_root.rglob("*.py")):
+            for target, line in forbidden_imports(source, backend, MODULE_PRIVATE):
+                if not target.startswith("app.platform.modules.sdk"):
+                    violations.append(
+                        _violation(root, "ARCH-BE-PRIVATE-001", source, target, line)
+                    )
+    return tuple(sorted(set(violations), key=lambda item: (item.source, item.line, item.rule)))
+
+
+def load_baseline(root: Path = ROOT) -> frozenset[tuple[str, str, str]]:
+    rules_data = json.loads((root / RULES.relative_to(ROOT)).read_text(encoding="utf-8"))
+    baseline_data = json.loads((root / BASELINE.relative_to(ROOT)).read_text(encoding="utf-8"))
+    if rules_data.get("version") != 1 or baseline_data.get("version") != 1:
+        raise ValueError("Architecture rule and baseline versions must be 1.")
+    known = {rule["id"] for rule in rules_data.get("rules", [])}
+    entries = baseline_data.get("entries")
+    if not isinstance(entries, list):
+        raise TypeError("Architecture baseline entries must be a list.")
+    keys: set[tuple[str, str, str]] = set()
+    for entry in entries:
+        key = (entry.get("rule"), entry.get("source"), entry.get("target"))
+        if key[0] not in known:
+            raise ValueError(f"Unknown baseline rule: {key[0]}")
+        if not all(isinstance(value, str) and value and "*" not in value for value in key):
+            raise ValueError("Baseline rule, source and target must be exact non-wildcard strings.")
+        if not re.fullmatch(r"#\d+", entry.get("tracking_issue", "")):
+            raise ValueError("Every baseline entry needs a tracking_issue like #123.")
+        if not str(entry.get("reason", "")).strip():
+            raise ValueError("Every baseline entry needs a reason.")
+        if not (root / key[1]).is_file():
+            raise ValueError(f"Baseline source does not exist: {key[1]}")
+        if key in keys:
+            raise ValueError(f"Duplicate baseline entry: {key}")
+        keys.add(key)
+    return frozenset(keys)
+
+
+def active_violations(root: Path = ROOT) -> tuple[Violation, ...]:
+    baseline = load_baseline(root)
+    return tuple(item for item in scan_backend(root) if item.key not in baseline)
+
+
+def _violation(root: Path, rule: str, source: Path, target: str, line: int) -> Violation:
+    return Violation(rule, source.relative_to(root).as_posix(), target, line)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=ROOT)
+    args = parser.parse_args()
+    try:
+        violations = active_violations(args.root.resolve())
+    except (OSError, TypeError, ValueError, json.JSONDecodeError, SyntaxError) as error:
+        print(f"Architecture check configuration error: {error}", file=sys.stderr)
+        return 2
+    for item in violations:
+        guidance = {
+            "ARCH-BE-HOST-001": "Use a registration entry point or public contribution contract.",
+            "ARCH-BE-MODULE-001": "Use the provider module's public contracts namespace.",
+            "ARCH-BE-PRIVATE-001": "Use the matching ModuleContext/SDK port.",
+        }[item.rule]
+        print(
+            f"::error file={item.source},line={item.line},title={item.rule}::"
+            f"Forbidden import {item.target}. {guidance}"
+        )
+    if violations:
+        print(f"Backend module architecture check failed with {len(violations)} violation(s).")
+        return 1
+    print("Backend module architecture check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/module-contract-gate
+++ b/scripts/module-contract-gate
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+scope="${1:-all}"
+
+run_backend() {
+  cd "${repository_root}/backend"
+  uv run python ../scripts/check_module_architecture.py
+  uv run pytest tests/test_module_*.py tests/test_domain_events.py
+}
+
+run_frontend() {
+  cd "${repository_root}/frontend"
+  pnpm modules:architecture
+  pnpm modules:check
+  pnpm vitest run \
+    tests/frontend-module-architecture.test.ts \
+    tests/frontend-module-host.test.ts \
+    tests/frontend-ui-contributions.test.ts \
+    tests/map-runtime.test.ts \
+    tests/map-sdk.test.ts
+  pnpm test:modules:ssr
+}
+
+case "${scope}" in
+  all)
+    run_backend
+    run_frontend
+    ;;
+  backend)
+    run_backend
+    ;;
+  frontend)
+    run_frontend
+    ;;
+  *)
+    echo "Usage: scripts/module-contract-gate [all|backend|frontend]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Ausgangslage

Die Modulgrenzen aus #92–#104 waren bereits über ADRs und einzelne Tests beschrieben, aber noch nicht als eigenes, schnelles CI-Gate gebündelt. Neue direkte Host- oder Cross-Module-Imports konnten dadurch leichter unbemerkt entstehen.

Part of #91  
Closes #105

## Umsetzung

- Architecture as Code mit zentralem Regelkatalog und stabilen Rule IDs
- AST-basierter Backend-Checker für:
  - Host → Fachdomäne
  - Modul → fremde Modul-Interna
  - Modul → private Host-Interna
- TypeScript-AST-basierter Frontend-Checker für:
  - TypeScript- und Vue-SFC-Imports
  - Re-Exports und dynamische Imports
  - Nuxt-Aliases
  - konkrete Modulkenntnis im generischen Host
- Strukturierte, fail-closed Legacy-Baseline:
  - exakte Source-/Target-Angaben
  - verpflichtende Begründung
  - verpflichtendes Tracking-Issue
  - keine Wildcards
  - bestehende Persistence-Ausnahme mit Abbaupfad über #108
- Wiederverwendbarer `ModuleTestHost` auf Basis der vorhandenen Test-Fakes
- Negative Fixtures für:
  - verbotene Cross-Module-Imports
  - Dependency Cycles
  - inkompatible SDK-Versionen
- Fokussierte Contract-Matrix für:
  - Manifest und SemVer-Kompatibilität
  - Dependencies und enabled/disabled-Verhalten
  - Events, Services, Settings und Jobs
  - Permissions und Registry-Duplikate
  - Persistence- und Migration-Ownership
  - Frontend UI Contributions und Map SDK
- Lokaler One-Command-Entry-Point:
  - `scripts/module-contract-gate`
- Neuer paralleler GitHub-Actions-Workflow mit stabilem Aggregator:
  - `Module contract gate`
- Einbindung des neuen Gates in das bestehende Release Gate
- Dokumentation des Regelkatalogs, der Baseline-Strategie und typischer Fehlerbehebungen
- Neues ADR zur Entscheidung „Architecture as Code“

## Tests

- `scripts/module-contract-gate`
  - Backend-Contract-Matrix: 227 Tests bestanden
  - Frontend-Contract-Matrix: 39 Tests bestanden
  - Example-Module-SSR: 2 Tests im isolierten Lauf bestanden
  - Referenzlaufzeit: ungefähr 45 Sekunden
- `cd backend && uv run ruff check app tests`
  - erfolgreich
- `cd backend && uv run pytest`
  - 833 Tests bestanden
- `cd frontend && pnpm modules:check`
  - erfolgreich
- `cd frontend && pnpm test`
  - 489 Tests bestanden
- `cd frontend && pnpm typecheck`
  - erfolgreich
- `cd frontend && pnpm build`
  - erfolgreich
- `cd frontend && pnpm audit:language`
  - 516 Ressourcen geprüft, 0 unerlaubte Treffer
- `cd frontend && pnpm audit:seo`
  - erfolgreich
- Supply-Chain-Verifikation und negative Policy-Tests
  - erfolgreich

Ein späterer lokaler SSR-Wiederholungslauf parallel zu Build und SEO-Audit erreichte beim Start des Nuxt-Testservers das Timeout. Der vorherige isolierte SSR-Lauf sowie die vollständige Frontend-Suite einschließlich SSR waren erfolgreich.

Playwright wurde bewusst nicht in das neue Contract-Gate aufgenommen und lokal nicht erneut ausgeführt.

## Migration und Konfiguration

- Keine Datenbankmigration
- Keine neue Runtime- oder Produktionskonfiguration
- Keine neue Dependency
- Keine Änderung oder Abschwächung bestehender Security-Gates
- Keine Fachmigration aus #108 vorgezogen

## Rollback

Der neue reusable Workflow kann aus dem Release Gate entfernt und dieser Commit anschließend revertiert werden. Datenbank- oder Konfigurations-Rollbacks sind nicht erforderlich.