### PR TITLE
feat(modules): add reference module

### DIFF
--- a/backend/app/auth/module_sdk.py
+++ b/backend/app/auth/module_sdk.py
@@ -1,0 +1,25 @@
+"""Host-Auth-Adapter für permission-geschützte Routen externer Module."""
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from app.auth.dependencies import require_permission
+from app.platform.modules.sdk import ModulePrincipal
+
+
+class HostPermissionDependencies:
+    """Gibt Modulen nur eine stabile Principal-ID statt privater User-Typen."""
+
+    def require(self, permission_id: str, *, csrf: bool = False):
+        host_dependency = require_permission(permission_id, csrf=csrf)
+
+        async def dependency(
+            user: Annotated[object, Depends(host_dependency)],
+        ) -> ModulePrincipal:
+            principal_id = getattr(user, "id", None)
+            if principal_id is None:
+                raise TypeError("The authenticated host principal has no stable ID.")
+            return ModulePrincipal(id=str(principal_id))
+
+        return dependency

--- a/backend/app/cli/module_migrations.py
+++ b/backend/app/cli/module_migrations.py
@@ -1,0 +1,52 @@
+"""Preflight und Ausführung des gemeinsamen Host-/Modul-Migrationsgraphen."""
+
+import argparse
+from pathlib import Path
+
+from alembic.config import Config
+
+from app.core.config import get_settings
+from app.platform.modules import EntryPointModuleDiscovery, FirstPartyModuleDiscovery
+from app.platform.modules.migrations import MigrationCoordinator
+from app.platform.modules.persistence import build_persistence_registry
+from app.platform.modules.runtime import resolve_module_definitions
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def coordinator() -> MigrationCoordinator:
+    settings = get_settings()
+    resolved = resolve_module_definitions(
+        enabled_module_ids=settings.enabled_module_list,
+        discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
+        host_version=settings.api_version,
+    )
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    config.attributes["database_url"] = settings.database_url
+    return MigrationCoordinator(config, build_persistence_registry(resolved))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate or migrate the enabled host/module revision graph."
+    )
+    parser.add_argument("action", choices=("preflight", "upgrade", "downgrade"))
+    parser.add_argument("revision", nargs="?", help="Explicit target for downgrade.")
+    args = parser.parse_args()
+    active = coordinator()
+    if args.action == "preflight":
+        plan = active.preflight()
+    elif args.action == "upgrade":
+        plan = active.upgrade()
+    else:
+        if not args.revision:
+            parser.error("downgrade requires an explicit revision")
+        active.downgrade(args.revision)
+        return 0
+    for step in plan:
+        print(f"{step.module_id}: {step.revision}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from fastapi.responses import Response as FastAPIResponse
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from app.api.router import api_router
+from app.auth.module_sdk import HostPermissionDependencies
 from app.cache.redis import close_redis, initialize_redis, redis_health
 from app.core.config import BACKEND_ENV_FILE, get_settings
 from app.db.session import AsyncSessionLocal, database_health, engine
@@ -84,7 +85,10 @@ module_runtime = create_module_runtime(
     discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
     host_version=settings.api_version,
     context_factory=ModuleContextFactory(
-        ModuleHostServices(database=HostDatabaseSessionProvider()),
+        ModuleHostServices(
+            database=HostDatabaseSessionProvider(),
+            permission_dependencies=HostPermissionDependencies(),
+        ),
         event_bus=event_bus,
         permission_engine=permission_engine,
         permission_subject_loader=load_permission_subject,

--- a/backend/app/modules/__init__.py
+++ b/backend/app/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Installierbare First-Party-Module ohne Host-Imports."""

--- a/backend/app/modules/reference/README.md
+++ b/backend/app/modules/reference/README.md
@@ -1,0 +1,201 @@
+# Reference Module
+
+Dieses bewusst kleine Modul ist ausführbare SDK-Dokumentation. Es zeigt eine neutrale
+`ReferenceItem`-Domäne vom eigenen PostgreSQL-Schema bis zur Nuxt-Seite und zum
+MapLibre-Layer. Es ist kein produktives Fachfeature.
+
+## 1. Was demonstriert dieses Modul?
+
+Das Modul nutzt Manifest und Entry-Point-Discovery, Backend- und Frontend-SDK,
+Persistence, Migration, Permission und CSRF, Settings, Domain Event, Subscriber,
+Background Job, Seite, Navigation, UI-Slot, Kartenquelle, Kartenlayer und Feature-Info.
+Es importiert keine fremde Fachdomäne und benötigt keinen externen Dienst.
+
+## 2. Ordnerstruktur
+
+```text
+backend/app/modules/reference/
+├── api/                 # FastAPI-Schemas und Router
+├── application/         # Use Cases und Permission Enforcement
+├── domain/              # Entity und Domain Event
+├── persistence/         # eigene Metadata, Repository und Migration
+├── module.py            # Composition Root und passive Definition
+└── settings.py          # typisierte Konfiguration
+
+frontend/frontend-modules/reference/
+├── module.json          # Build-Time-Manifest und Contributions
+└── layer/app/           # lokale Seite, Komponenten und Composable
+```
+
+## 3. Manifest
+
+`module.py` definiert das Backend-Manifest V1 mit der stabilen ID `reference`, Version
+`1.0.0`, Host-/SDK-Bereichen, Capabilities, Permission, Config-Namespace und
+Schema-Ownership. `frontend/frontend-modules/reference/module.json` verwendet dieselbe
+ID und deklariert die kompatible Backend-Version. Es wird keine neue Manifest-Version
+eingeführt.
+
+## 4. Backend Registration
+
+Der Python-Entry-Point `open_city_planner.modules` in `backend/pyproject.toml` liefert
+die passive `DEFINITION`. Erst wenn `ENABLED_MODULES=reference` gesetzt ist, lädt die
+generische Runtime `ReferenceModule` und ruft `register(context)` auf. Weder
+`app.main` noch der zentrale API-Router kennen die Modul-ID.
+
+## 5. Route
+
+Das Modul registriert selbst:
+
+- `GET /api/v1/modules/reference/items`
+- `GET /api/v1/modules/reference/items.geojson`
+- `POST /api/v1/modules/reference/items`
+
+Die GET-Routen lesen ausschließlich Beispieldaten. POST nutzt die öffentliche
+Permission-Dependency des SDK und die bestehende Host-Authentifizierung samt CSRF.
+
+## 6. Persistence
+
+`persistence/models.py` besitzt eine eigene `MetaData(schema="reference")` und die
+Tabelle `reference.items`. Das Repository erhält seine `AsyncSession` ausschließlich
+über `context.database.session()`; globale Engine, Host-Base und fremde Tabellen
+werden nicht importiert.
+
+## 7. Migration
+
+`persistence/migrations/20260826_mod_reference_0001.py` erstellt nur das Schema
+`reference` und seine Tabelle und fügt zwei deterministische Marker ein. Der
+`ModuleMigrationSource` verwendet den vorgeschriebenen Namespace `mod_reference`.
+Der gezielte Downgrade entfernt ausschließlich die eigene Tabelle und das eigene
+Schema.
+
+## 8. Permission
+
+Das Manifest besitzt `reference.items-write`. Die POST-Route fordert sie mit
+`csrf=True`; anschließend prüft der Application-Service nochmals fail-closed über
+`context.permissions`. Rollen und Superuser-Regeln bleiben vollständig Eigentum der
+Host-Permission-Engine.
+
+## 9. Settings
+
+`ReferenceSettings` ist ein eingefrorenes Pydantic-Modell. Defaults sind
+`max_items=100` und `job_interval_seconds=3600`. Overrides sind ausschließlich
+namespaced:
+
+```bash
+OCP_MODULE_REFERENCE_MAX_ITEMS=50
+OCP_MODULE_REFERENCE_JOB_INTERVAL_SECONDS=1800
+```
+
+Das erste Feld ist explizit öffentlich; es gibt keine Secrets.
+
+## 10. Events
+
+Ein erfolgreicher Create-Use-Case stellt `reference.item-created` in Version 1 mit
+`item_id` und `title` über `publish_after_commit()` in die transaktionale Outbox.
+
+## 11. Job
+
+`reference.count-items` zählt die eigenen Datensätze und schreibt die begrenzte
+Metrik `items-total`. Der Job läuft nach dem konfigurierten Intervall, hat ein
+30-Sekunden-Timeout und verwendet nur Scheduler-, Database- und Observability-Ports.
+
+## 12. Frontend Page
+
+Das lokale Nuxt-Layer liefert `/referenzmodul`. Das modulinterne Composable lädt die
+eigene API SSR-sicher über die konfigurierte API-Basis. Lade- und Fehlerzustände
+bleiben verständlich und barrierearm.
+
+## 13. Navigation
+
+`reference.primary-navigation` trägt den öffentlichen Link deklarativ zu
+`navigation.primary` bei. `reference.admin-navigation` zeigt denselben Einstieg im
+Admin-Bereich nur authentifiziert mit `reference.items-write`. Die Host-Navigation
+wird nicht geändert.
+
+## 14. UI Slot
+
+`reference.map-feature-info` rendert `ReferenceFeatureInfoControl` im vorhandenen
+Slot `map.controls`. Die Komponente wird ausschließlich aus dem lokalen Layer geladen.
+
+## 15. Map Extension
+
+Das Frontend-Manifest registriert die zunächst leere GeoJSON-Quelle `reference.items`
+und den gleichnamigen Circle-Layer in der Gruppe `overlay`. Die Slot-Komponente lädt
+`/modules/reference/items.geojson` über die konfigurierte API-Basis und aktualisiert
+die Quelle über den ausdrücklich öffentlichen `unsafeMapLibre()`-Escape-Hatch des
+Map SDK. So funktionieren getrennte lokale Frontend-/Backend-Origins ebenso wie ein
+Same-Origin-Deployment. `MapCanvas.vue` wird nicht gepatcht.
+
+## 16. Feature Info
+
+Die Slot-Komponente bezieht `MapContext` über `#frontend-module-sdk`, registriert den
+Provider `reference.items-info` und die Klick-Interaction `reference.items-click`.
+Ein Klick zeigt `title` und `description`; beim Unmount werden beide Contributions
+abgemeldet.
+
+## 17. Tests
+
+```bash
+cd backend
+uv run pytest tests/modules/reference
+
+cd ../frontend
+pnpm vitest run tests/reference-module/reference-module.test.ts
+
+cd ..
+scripts/module-contract-gate
+```
+
+Die Tests decken Manifest, Compatibility, enabled/disabled, Ownership, Permission,
+Event, Subscriber, Job sowie Frontend-Contributions ab. Das Architektur-Gate prüft
+den Produktionscode selbst als positives Contract-Fixture.
+
+## 18. Aktivieren
+
+Backend und Migration:
+
+```bash
+cd backend
+ENABLED_MODULES=reference uv run python -m app.cli.module_migrations preflight
+ENABLED_MODULES=reference uv run python -m app.cli.module_migrations upgrade
+ENABLED_MODULES=reference uv run uvicorn app.main:app --reload
+```
+
+Frontend:
+
+```bash
+cd frontend
+OCP_FRONTEND_MODULES=reference \
+OCP_BACKEND_MODULES=reference@1.0.0 \
+pnpm dev
+```
+
+Für einen Produktionsbuild gelten dieselben beiden Frontend-Variablen mit
+`pnpm build`.
+
+## 19. Deaktivieren
+
+`reference` aus `ENABLED_MODULES`, `OCP_FRONTEND_MODULES` und dem Backend-Inventar
+entfernen und Backend/Frontend neu starten beziehungsweise neu bauen. Dann fehlen
+Route, Permission, Subscriber, Job, Seite, Navigation, Slot und Map-Layer. Die
+Tabelle und historische Migration bleiben absichtlich erhalten; Deaktivieren löscht
+keine Daten. Ein physisches Entfernen braucht eine separat geprüfte Cleanup-Migration
+mit Backup- und Rollback-Plan.
+
+## 20. How to create your own module
+
+1. Beide Verzeichnisse kopieren, zum Beispiel
+   `cp -R backend/app/modules/reference backend/app/modules/my_module` und
+   `cp -R frontend/frontend-modules/reference frontend/frontend-modules/my-module`.
+2. Modul-ID und Python-/Frontend-Verzeichnis, Version und Entry-Point umbenennen.
+3. Manifest-, Config-, Schema- und Revision-Namespace konsistent ändern.
+4. Permission-, Route-, Event-, Job-, Source-, Layer- und Contribution-IDs umbenennen.
+5. Tabelle, Migration, Entity, API-Schemas und sichtbare Texte auf die neue kleine
+   Domäne zuschneiden; die alte Revision-ID nicht wiederverwenden.
+6. Tests kopieren und zuerst enabled, disabled und inkompatible Versionen prüfen.
+7. Architektur-Gate, vollständige Tests, Typecheck und beide Builds ausführen.
+
+Kopiere keine Host-Interna. Modulcode importiert Plattformverträge nur aus
+`app.platform.modules.sdk` beziehungsweise `#frontend-module-sdk`. Wenn ein nötiger
+Contract fehlt, wird das SDK bewusst erweitert; private DB-, Runtime-, Auth-, Router-,
+Navigations- oder MapCanvas-Implementierungen sind keine Abkürzung.

--- a/backend/app/modules/reference/__init__.py
+++ b/backend/app/modules/reference/__init__.py
@@ -1,0 +1,5 @@
+"""Ausführbares Backend-Referenzmodul für das öffentliche Module SDK."""
+
+from .module import DEFINITION
+
+__all__ = ["DEFINITION"]

--- a/backend/app/modules/reference/api/__init__.py
+++ b/backend/app/modules/reference/api/__init__.py
@@ -1,0 +1,3 @@
+from .router import create_router
+
+__all__ = ["create_router"]

--- a/backend/app/modules/reference/api/router.py
+++ b/backend/app/modules/reference/api/router.py
@@ -1,0 +1,115 @@
+"""Öffentliche HTTP-Schnittstelle des Referenzmoduls."""
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.platform.modules.sdk import ModulePrincipal, PermissionDependencyFactory
+
+from ..application.service import (
+    CreateReferenceItem,
+    ReferenceItemService,
+    ReferencePermissionDenied,
+)
+from ..domain.models import ReferenceItem
+
+
+class ReferenceItemRead(BaseModel):
+    id: str
+    title: str
+    description: str
+    longitude: float
+    latitude: float
+
+    model_config = ConfigDict(frozen=True)
+
+
+class ReferenceItemCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=120)
+    description: str = Field(default="", max_length=500)
+    longitude: float = Field(ge=-180, le=180)
+    latitude: float = Field(ge=-90, le=90)
+
+    model_config = ConfigDict(frozen=True)
+
+
+class PointGeometry(BaseModel):
+    type: Literal["Point"] = "Point"
+    coordinates: tuple[float, float]
+
+
+class ReferenceFeature(BaseModel):
+    type: Literal["Feature"] = "Feature"
+    id: str
+    properties: dict[str, str]
+    geometry: PointGeometry
+
+
+class ReferenceFeatureCollection(BaseModel):
+    type: Literal["FeatureCollection"] = "FeatureCollection"
+    features: list[ReferenceFeature]
+
+
+def _read(item: ReferenceItem) -> ReferenceItemRead:
+    return ReferenceItemRead(
+        id=item.id,
+        title=item.title,
+        description=item.description,
+        longitude=item.longitude,
+        latitude=item.latitude,
+    )
+
+
+def create_router(
+    service: ReferenceItemService,
+    permission_dependencies: PermissionDependencyFactory,
+) -> APIRouter:
+    router = APIRouter()
+    require_write = permission_dependencies.require("reference.items-write", csrf=True)
+
+    @router.get("/items", response_model=list[ReferenceItemRead])
+    async def list_items() -> list[ReferenceItemRead]:
+        return [_read(item) for item in await service.list_items()]
+
+    @router.get("/items.geojson", response_model=ReferenceFeatureCollection)
+    async def list_items_geojson() -> ReferenceFeatureCollection:
+        return ReferenceFeatureCollection(
+            features=[
+                ReferenceFeature(
+                    id=item.id,
+                    properties={"title": item.title, "description": item.description},
+                    geometry=PointGeometry(coordinates=(item.longitude, item.latitude)),
+                )
+                for item in await service.list_items()
+            ]
+        )
+
+    @router.post("/items", response_model=ReferenceItemRead, status_code=201)
+    async def create_item(
+        payload: ReferenceItemCreate,
+        principal: Annotated[ModulePrincipal, Depends(require_write)],
+    ) -> ReferenceItemRead:
+        try:
+            item = await service.create_item(
+                CreateReferenceItem(
+                    title=payload.title,
+                    description=payload.description,
+                    longitude=payload.longitude,
+                    latitude=payload.latitude,
+                ),
+                principal_id=principal.id,
+            )
+        except ReferencePermissionDenied as exc:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": {
+                        "code": "PERMISSION_REQUIRED",
+                        "message": "Berechtigung fehlt.",
+                    }
+                },
+            ) from exc
+        return _read(item)
+
+    return router

--- a/backend/app/modules/reference/application/__init__.py
+++ b/backend/app/modules/reference/application/__init__.py
@@ -1,0 +1,3 @@
+from .service import CreateReferenceItem, ReferenceItemService, ReferencePermissionDenied
+
+__all__ = ["CreateReferenceItem", "ReferenceItemService", "ReferencePermissionDenied"]

--- a/backend/app/modules/reference/application/service.py
+++ b/backend/app/modules/reference/application/service.py
@@ -1,0 +1,74 @@
+"""Use Cases des Referenzmoduls; alle Host-Dienste kommen über SDK-Ports."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.platform.modules.sdk import ModuleContext
+
+from ..domain.events import ReferenceItemCreated
+from ..domain.models import ReferenceItem
+from ..persistence.repository import SqlAlchemyReferenceItemRepository
+from ..settings import ReferenceSettings
+
+
+@dataclass(frozen=True, slots=True)
+class CreateReferenceItem:
+    title: str
+    description: str
+    longitude: float
+    latitude: float
+
+
+class ReferencePermissionDenied(Exception):
+    """Der Host hat die modulspezifische Schreibberechtigung abgelehnt."""
+
+
+class ReferenceItemService:
+    def __init__(self, context: ModuleContext) -> None:
+        if context.database is None:
+            raise RuntimeError("The reference module requires the database port.")
+        self._context = context
+        self._database = context.database
+        self._settings = (
+            context.settings.require(ReferenceSettings)
+            if context.settings is not None
+            else ReferenceSettings()
+        )
+
+    async def list_items(self) -> tuple[ReferenceItem, ...]:
+        async with self._database.session() as session:
+            return await SqlAlchemyReferenceItemRepository(session).list(
+                limit=self._settings.max_items
+            )
+
+    async def count_items(self) -> int:
+        async with self._database.session() as session:
+            return await SqlAlchemyReferenceItemRepository(session).count()
+
+    async def create_item(
+        self,
+        command: CreateReferenceItem,
+        *,
+        principal_id: str | None,
+    ) -> ReferenceItem:
+        if self._context.permissions is None or not await self._context.permissions.is_allowed(
+            "reference.items-write", principal_id=principal_id
+        ):
+            raise ReferencePermissionDenied
+        item = ReferenceItem(
+            id=str(uuid4()),
+            title=command.title,
+            description=command.description,
+            longitude=command.longitude,
+            latitude=command.latitude,
+            created_at=datetime.now(UTC),
+        )
+        async with self._database.session() as session:
+            SqlAlchemyReferenceItemRepository(session).add(item)
+            if self._context.events is not None:
+                await self._context.events.publish_after_commit(
+                    ReferenceItemCreated(item_id=item.id, title=item.title),
+                    session=session,
+                )
+        return item

--- a/backend/app/modules/reference/domain/__init__.py
+++ b/backend/app/modules/reference/domain/__init__.py
@@ -1,0 +1,4 @@
+from .events import ReferenceItemCreated
+from .models import ReferenceItem
+
+__all__ = ["ReferenceItem", "ReferenceItemCreated"]

--- a/backend/app/modules/reference/domain/events.py
+++ b/backend/app/modules/reference/domain/events.py
@@ -1,0 +1,18 @@
+"""Vom Referenzmodul besessene, serialisierbare Domain Events."""
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from app.platform.modules.sdk import JsonValue
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceItemCreated:
+    item_id: str
+    title: str
+
+    event_name: ClassVar[str] = "reference.item-created"
+    event_version: ClassVar[int] = 1
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {"item_id": self.item_id, "title": self.title}

--- a/backend/app/modules/reference/domain/models.py
+++ b/backend/app/modules/reference/domain/models.py
@@ -1,0 +1,14 @@
+"""Fachkern des Referenzmoduls ohne Framework-Abhängigkeiten."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceItem:
+    id: str
+    title: str
+    description: str
+    longitude: float
+    latitude: float
+    created_at: datetime

--- a/backend/app/modules/reference/module.py
+++ b/backend/app/modules/reference/module.py
@@ -1,0 +1,104 @@
+"""Composition Root des ausführbaren Referenzmoduls."""
+
+from app.platform.modules.sdk import (
+    EventEnvelope,
+    JobDefinition,
+    JobSchedule,
+    ModuleContext,
+    ModuleDefinition,
+    ModuleMigrationSource,
+    ModulePersistenceContribution,
+    ModuleSettingsContribution,
+    parse_manifest,
+)
+
+from .api import create_router
+from .application import ReferenceItemService
+from .persistence import METADATA
+from .settings import ReferenceSettings
+
+MANIFEST = parse_manifest(
+    {
+        "manifest_version": 1,
+        "id": "reference",
+        "name": "Reference Notes",
+        "version": "1.0.0",
+        "requires": {"host": ">=0.2.0,<1.0.0", "sdk": ">=1.7.0,<2.0.0"},
+        "backend": {"package": "open-city-map-backend"},
+        "frontend": {"package": "reference"},
+        "capabilities": ["reference.items", "reference.map-layer"],
+        "permissions": ["reference.items-write"],
+        "config": {"namespace": "reference"},
+        "persistence": {"schema": "reference", "migrations": True},
+    },
+    origin=__name__,
+)
+
+
+class ReferenceModule:
+    manifest = MANIFEST
+
+    def register(self, context: ModuleContext) -> None:
+        if context.permission_dependencies is None:
+            raise RuntimeError("The reference module requires request permission dependencies.")
+        service = ReferenceItemService(context)
+        context.api.include_router(
+            create_router(service, context.permission_dependencies),
+            prefix="/api/v1/modules/reference",
+            tags=("Reference module",),
+        )
+
+        if context.events is None:
+            raise RuntimeError("The reference module requires the event port.")
+
+        async def observe_created(event: EventEnvelope) -> None:
+            context.observability.metrics.increment("items-created")
+            context.logger.info("Reference item event handled", extra={"event_id": str(event.event_id)})
+
+        context.events.subscribe(
+            "reference.item-created",
+            handler_id="reference.observe-item-created",
+            versions=frozenset({1}),
+            handler=observe_created,
+        )
+
+        if context.scheduler is None:
+            raise RuntimeError("The reference module requires the scheduler port.")
+        settings = context.settings.require(ReferenceSettings) if context.settings else ReferenceSettings()
+
+        async def count_items(_context: ModuleContext) -> int:
+            count = await service.count_items()
+            context.observability.metrics.observe("items-total", float(count))
+            return count
+
+        context.scheduler.register(
+            JobDefinition(
+                job_id="count-items",
+                handler=count_items,
+                schedule=JobSchedule(interval_seconds=settings.job_interval_seconds),
+                timeout_seconds=30,
+            )
+        )
+
+
+DEFINITION = ModuleDefinition(
+    manifest=MANIFEST,
+    loader=ReferenceModule,
+    origin=__name__,
+    declared_id=MANIFEST.id,
+    persistence=ModulePersistenceContribution(
+        module_id=MANIFEST.id,
+        metadata=METADATA,
+        schema="reference",
+        migration_source=ModuleMigrationSource(
+            package="app.modules.reference.persistence",
+            resource="migrations",
+            revision_namespace="mod_reference",
+        ),
+    ),
+    settings=ModuleSettingsContribution(
+        module_id=MANIFEST.id,
+        namespace="reference",
+        model=ReferenceSettings,
+    ),
+)

--- a/backend/app/modules/reference/persistence/__init__.py
+++ b/backend/app/modules/reference/persistence/__init__.py
@@ -1,0 +1,4 @@
+from .models import METADATA
+from .repository import SqlAlchemyReferenceItemRepository
+
+__all__ = ["METADATA", "SqlAlchemyReferenceItemRepository"]

--- a/backend/app/modules/reference/persistence/migrations/20260826_mod_reference_0001.py
+++ b/backend/app/modules/reference/persistence/migrations/20260826_mod_reference_0001.py
@@ -1,0 +1,63 @@
+"""Create and seed the reference module's owned items table."""
+
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "mod_reference_20260826_0001"
+down_revision = "20260825_0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS reference")
+    op.create_table(
+        "items",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("title", sa.String(length=120), nullable=False),
+        sa.Column("description", sa.String(length=500), nullable=False),
+        sa.Column("longitude", sa.Float(), nullable=False),
+        sa.Column("latitude", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        schema="reference",
+    )
+    items = sa.table(
+        "items",
+        sa.column("id", sa.String()),
+        sa.column("title", sa.String()),
+        sa.column("description", sa.String()),
+        sa.column("longitude", sa.Float()),
+        sa.column("latitude", sa.Float()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        schema="reference",
+    )
+    op.bulk_insert(
+        items,
+        [
+            {
+                "id": "4fbc9831-0d31-4a8a-963b-111111111111",
+                "title": "Referenzmarker Hafen",
+                "description": "Beispieldatensatz des installierbaren Referenzmoduls.",
+                "longitude": 9.4338,
+                "latitude": 54.7952,
+                "created_at": datetime(2026, 8, 26, tzinfo=UTC),
+            },
+            {
+                "id": "4fbc9831-0d31-4a8a-963b-222222222222",
+                "title": "Referenzmarker Innenstadt",
+                "description": "Zeigt den Weg von der Modultabelle bis zur Karte.",
+                "longitude": 9.4362,
+                "latitude": 54.7836,
+                "created_at": datetime(2026, 8, 26, tzinfo=UTC),
+            },
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("items", schema="reference")
+    op.execute("DROP SCHEMA reference")

--- a/backend/app/modules/reference/persistence/migrations/__init__.py
+++ b/backend/app/modules/reference/persistence/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Alembic-Ressourcen des Referenzmoduls."""

--- a/backend/app/modules/reference/persistence/models.py
+++ b/backend/app/modules/reference/persistence/models.py
@@ -1,0 +1,23 @@
+"""Eigene ORM-Metadaten im ausschließlich vom Modul besessenen Schema."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, MetaData, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+METADATA = MetaData(schema="reference")
+
+
+class ReferenceBase(DeclarativeBase):
+    metadata = METADATA
+
+
+class ReferenceItemRecord(ReferenceBase):
+    __tablename__ = "items"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    title: Mapped[str] = mapped_column(String(120), nullable=False)
+    description: Mapped[str] = mapped_column(String(500), nullable=False, default="")
+    longitude: Mapped[float] = mapped_column(Float, nullable=False)
+    latitude: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/app/modules/reference/persistence/repository.py
+++ b/backend/app/modules/reference/persistence/repository.py
@@ -1,0 +1,49 @@
+"""SQLAlchemy-Adapter hinter dem Application-Port des Referenzmoduls."""
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..domain.models import ReferenceItem
+from .models import ReferenceItemRecord
+
+
+class SqlAlchemyReferenceItemRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list(self, *, limit: int) -> tuple[ReferenceItem, ...]:
+        records = (
+            await self._session.scalars(
+                select(ReferenceItemRecord)
+                .order_by(ReferenceItemRecord.created_at, ReferenceItemRecord.id)
+                .limit(limit)
+            )
+        ).all()
+        return tuple(self._to_domain(record) for record in records)
+
+    async def count(self) -> int:
+        value = await self._session.scalar(select(func.count(ReferenceItemRecord.id)))
+        return int(value or 0)
+
+    def add(self, item: ReferenceItem) -> None:
+        self._session.add(
+            ReferenceItemRecord(
+                id=item.id,
+                title=item.title,
+                description=item.description,
+                longitude=item.longitude,
+                latitude=item.latitude,
+                created_at=item.created_at,
+            )
+        )
+
+    @staticmethod
+    def _to_domain(record: ReferenceItemRecord) -> ReferenceItem:
+        return ReferenceItem(
+            id=record.id,
+            title=record.title,
+            description=record.description,
+            longitude=record.longitude,
+            latitude=record.latitude,
+            created_at=record.created_at,
+        )

--- a/backend/app/modules/reference/settings.py
+++ b/backend/app/modules/reference/settings.py
@@ -1,0 +1,10 @@
+"""Typisierte und ausschließlich namespacete Einstellungen des Referenzmoduls."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ReferenceSettings(BaseModel):
+    max_items: int = Field(default=100, ge=1, le=500, json_schema_extra={"public": True})
+    job_interval_seconds: int = Field(default=3600, ge=60, le=86400)
+
+    model_config = ConfigDict(frozen=True)

--- a/backend/app/platform/modules/context.py
+++ b/backend/app/platform/modules/context.py
@@ -24,6 +24,7 @@ from app.platform.modules.sdk import (
     ModuleContext,
     ModuleSettingsPort,
     ObservabilityPort,
+    PermissionDependencyFactory,
     PermissionPort,
     SchedulerPort,
     ServiceRegistryPort,
@@ -93,6 +94,7 @@ class ModuleHostServices:
     events: EventBusPort | None = None
     services: ServiceRegistryPort | None = None
     permissions: PermissionPort | None = None
+    permission_dependencies: PermissionDependencyFactory | None = None
     cache: CachePort | None = None
     storage: StoragePort | None = None
     http: HttpClientFactoryPort | None = None
@@ -194,6 +196,7 @@ class ModuleContextFactory:
             events=event_adapter,
             services=service_adapter,
             permissions=self._permission_port,
+            permission_dependencies=self._services.permission_dependencies,
             cache=self._services.cache,
             storage=self._services.storage,
             http=self._services.http,

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -33,7 +33,7 @@ from app.platform.modules.settings import (
 )
 
 logger = logging.getLogger(__name__)
-MODULE_SDK_VERSION = "1.6.0"
+MODULE_SDK_VERSION = "1.7.0"
 
 
 @dataclass(slots=True)

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -286,6 +286,27 @@ class PermissionPort(Protocol):
     ) -> bool: ...
 
 
+@dataclass(frozen=True, slots=True)
+class ModulePrincipal:
+    """Minimale, fachneutrale Identität einer authentifizierten Request-Person."""
+
+    id: str
+
+
+type ModulePrincipalDependency = Callable[..., Awaitable[ModulePrincipal]]
+
+
+class PermissionDependencyFactory(Protocol):
+    """Erzeugt Host-authentifizierte FastAPI-Dependencies für Modulrouten."""
+
+    def require(
+        self,
+        permission_id: str,
+        *,
+        csrf: bool = False,
+    ) -> ModulePrincipalDependency: ...
+
+
 class CachePort(Protocol):
     """Modulgebundener Byte-Cache mit TTL in positiven ganzen Sekunden."""
 
@@ -516,6 +537,7 @@ class ModuleContext:
     events: EventBusPort | None = None
     services: ServiceRegistryPort | None = None
     permissions: PermissionPort | None = None
+    permission_dependencies: PermissionDependencyFactory | None = None
     cache: CachePort | None = None
     storage: StoragePort | None = None
     http: HttpClientFactoryPort | None = None
@@ -591,10 +613,13 @@ __all__ = [
     "ModuleManifestV1",
     "ModuleMigrationSource",
     "ModulePersistenceContribution",
+    "ModulePrincipal",
+    "ModulePrincipalDependency",
     "ModuleSettingsContribution",
     "ModuleSettingsPort",
     "ObservabilityPort",
     "PermissionDefinition",
+    "PermissionDependencyFactory",
     "PermissionPort",
     "RetryPolicy",
     "SchedulerPort",

--- a/backend/app/platform/modules/testing.py
+++ b/backend/app/platform/modules/testing.py
@@ -25,6 +25,7 @@ from app.platform.modules.sdk import (
     ModuleContext,
     ModuleDefinition,
     ModuleManifestV1,
+    ModulePrincipal,
     ObservabilityPort,
     SerializableDomainEvent,
     SpanPort,
@@ -164,6 +165,20 @@ class FakePermissions:
     ) -> bool:
         self.checks.append((permission_id, principal_id, resource_id))
         return permission_id in self.allowed
+
+
+class FakePermissionDependencies:
+    def __init__(self, principal_id: str = "test-user") -> None:
+        self.principal_id = principal_id
+        self.requirements: list[tuple[str, bool]] = []
+
+    def require(self, permission_id: str, *, csrf: bool = False):
+        self.requirements.append((permission_id, csrf))
+
+        async def dependency() -> ModulePrincipal:
+            return ModulePrincipal(id=self.principal_id)
+
+        return dependency
 
 
 class FakeMetrics:
@@ -461,6 +476,7 @@ def create_test_module_context(
         events=FakeEventBus(),
         services=FakeServiceRegistry(),
         permissions=FakePermissions(),
+        permission_dependencies=FakePermissionDependencies(),
         cache=FakeCache(module_id),
         storage=FakeStorage(module_id),
         http=FakeHttpClientFactory(),
@@ -479,6 +495,7 @@ __all__ = [
     "FakeMetrics",
     "FakeModuleSettings",
     "FakeObservability",
+    "FakePermissionDependencies",
     "FakePermissions",
     "FakeScheduler",
     "FakeServiceRegistry",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,6 +54,9 @@ security = [
   "pyyaml==6.0.3"
 ]
 
+[project.entry-points."open_city_planner.modules"]
+reference = "app.modules.reference.module:DEFINITION"
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/backend/tests/modules/reference/__init__.py
+++ b/backend/tests/modules/reference/__init__.py
@@ -1,0 +1,1 @@
+"""Tests für das installierbare Referenzmodul."""

--- a/backend/tests/modules/reference/test_reference_module.py
+++ b/backend/tests/modules/reference/test_reference_module.py
@@ -1,0 +1,239 @@
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from importlib import resources
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.modules.reference.application import (
+    CreateReferenceItem,
+    ReferenceItemService,
+    ReferencePermissionDenied,
+)
+from app.modules.reference.domain import ReferenceItem
+from app.modules.reference.module import DEFINITION, MANIFEST, ReferenceModule
+from app.modules.reference.settings import ReferenceSettings
+from app.platform.modules.discovery import FirstPartyModuleDiscovery
+from app.platform.modules.runtime import resolve_module_definitions
+from app.platform.modules.testing import (
+    FakeEventBus,
+    FakeJobRegistry,
+    FakeMetrics,
+    FakePermissions,
+    create_test_module_context,
+)
+
+
+class FakeDatabase:
+    @asynccontextmanager
+    async def session(self):
+        yield object()
+
+
+def reference_context(*, allowed: set[str] | None = None):
+    context = create_test_module_context(
+        module_id="reference",
+        module_version="1.0.0",
+        settings_model=ReferenceSettings(),
+    )
+    return replace(
+        context,
+        database=FakeDatabase(),
+        permissions=FakePermissions(allowed),
+    )
+
+
+def test_manifest_and_passive_contributions_have_one_owner() -> None:
+    assert MANIFEST.id == "reference"
+    assert MANIFEST.permissions == ["reference.items-write"]
+    assert MANIFEST.persistence is not None
+    assert MANIFEST.persistence.schema_name == "reference"
+    assert DEFINITION.persistence is not None
+    assert DEFINITION.persistence.metadata.tables["reference.items"].schema == "reference"
+    assert DEFINITION.settings is not None
+    assert DEFINITION.settings.model is ReferenceSettings
+    migration = DEFINITION.persistence.migration_source
+    assert migration is not None
+    assert resources.files(migration.package).joinpath(migration.resource).is_dir()
+
+
+def test_enabled_and_disabled_discovery_and_compatibility() -> None:
+    provider = FirstPartyModuleDiscovery({"reference": DEFINITION})
+    disabled = resolve_module_definitions(
+        enabled_module_ids=(), discovery_providers=(provider,), host_version="0.2.0"
+    )
+    enabled = resolve_module_definitions(
+        enabled_module_ids=("reference",),
+        discovery_providers=(provider,),
+        host_version="0.2.0",
+    )
+    assert disabled == ()
+    assert [manifest.id for _, manifest in enabled] == ["reference"]
+
+    with pytest.raises(Exception, match="requires sdk"):
+        resolve_module_definitions(
+            enabled_module_ids=("reference",),
+            discovery_providers=(provider,),
+            host_version="0.2.0",
+            sdk_version="1.6.0",
+        )
+
+
+def test_registration_contributes_routes_event_subscriber_and_job() -> None:
+    context = reference_context()
+    ReferenceModule().register(context)
+
+    registration = context.api
+    assert [router.prefix for router in registration.routers] == [
+        "/api/v1/modules/reference"
+    ]
+    events = context.events
+    assert isinstance(events, FakeEventBus)
+    assert [(event, handler_id, versions) for event, handler_id, versions, _ in events.subscriptions] == [
+        ("reference.item-created", "reference.observe-item-created", frozenset({1}))
+    ]
+    scheduler = context.scheduler
+    assert isinstance(scheduler, FakeJobRegistry)
+    assert set(scheduler.jobs) == {"reference.count-items"}
+    permission_dependencies = context.permission_dependencies
+    assert permission_dependencies is not None
+    assert permission_dependencies.requirements == [("reference.items-write", True)]
+
+
+@pytest.mark.asyncio
+async def test_write_use_case_enforces_module_permission_fail_closed() -> None:
+    context = reference_context()
+    service = ReferenceItemService(context)
+    command = CreateReferenceItem(
+        title="Nicht gespeichert",
+        description="Der Permission-Check läuft vor Persistence und Event.",
+        longitude=9.43,
+        latitude=54.78,
+    )
+
+    with pytest.raises(ReferencePermissionDenied):
+        await service.create_item(command, principal_id="user-1")
+
+    permissions = context.permissions
+    assert isinstance(permissions, FakePermissions)
+    assert permissions.checks == [("reference.items-write", "user-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_permitted_create_persists_and_publishes_event(monkeypatch) -> None:
+    stored = []
+
+    class Repository:
+        def __init__(self, _session) -> None:
+            pass
+
+        def add(self, item) -> None:
+            stored.append(item)
+
+    monkeypatch.setattr(
+        "app.modules.reference.application.service.SqlAlchemyReferenceItemRepository",
+        Repository,
+    )
+    context = reference_context(allowed={"reference.items-write"})
+    item = await ReferenceItemService(context).create_item(
+        CreateReferenceItem(
+            title="Erlaubter Marker",
+            description="Test",
+            longitude=9.43,
+            latitude=54.78,
+        ),
+        principal_id="user-1",
+    )
+
+    assert stored == [item]
+    events = context.events
+    assert isinstance(events, FakeEventBus)
+    assert events.queued[0].event_name == "reference.item-created"
+    assert events.queued[0].payload["item_id"] == item.id
+
+
+@pytest.mark.asyncio
+async def test_subscriber_and_job_can_execute(monkeypatch) -> None:
+    class Repository:
+        def __init__(self, _session) -> None:
+            pass
+
+        async def count(self) -> int:
+            return 2
+
+    monkeypatch.setattr(
+        "app.modules.reference.application.service.SqlAlchemyReferenceItemRepository",
+        Repository,
+    )
+    context = reference_context()
+    ReferenceModule().register(context)
+    events = context.events
+    scheduler = context.scheduler
+    assert isinstance(events, FakeEventBus)
+    assert isinstance(scheduler, FakeJobRegistry)
+
+    from app.modules.reference.domain import ReferenceItemCreated
+    from app.platform.modules.sdk import event_envelope
+
+    await events.subscriptions[0][3](
+        event_envelope(ReferenceItemCreated(item_id="item-1", title="Marker"))
+    )
+    metrics = context.observability.metrics
+    assert isinstance(metrics, FakeMetrics)
+    assert metrics.increments == [("items-created", 1, {})]
+    assert await scheduler.run("reference.count-items", context) == 2
+    assert metrics.observations == [("items-total", 2.0, {})]
+
+
+@pytest.mark.asyncio
+async def test_enabled_api_creates_and_lists_items(monkeypatch) -> None:
+    stored: list[ReferenceItem] = []
+
+    class Repository:
+        def __init__(self, _session) -> None:
+            pass
+
+        async def list(self, *, limit: int) -> tuple[ReferenceItem, ...]:
+            return tuple(stored[:limit])
+
+        def add(self, item: ReferenceItem) -> None:
+            stored.append(item)
+
+    monkeypatch.setattr(
+        "app.modules.reference.application.service.SqlAlchemyReferenceItemRepository",
+        Repository,
+    )
+    context = reference_context(allowed={"reference.items-write"})
+    ReferenceModule().register(context)
+    app = FastAPI()
+    for contribution in context.api.routers:
+        app.include_router(contribution.router, prefix=contribution.prefix)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        created = await client.post(
+            "/api/v1/modules/reference/items",
+            json={
+                "title": "API-Marker",
+                "description": "End-to-End im Modul",
+                "longitude": 9.43,
+                "latitude": 54.78,
+            },
+        )
+        listed = await client.get("/api/v1/modules/reference/items")
+
+    assert created.status_code == 201
+    assert created.json()["title"] == "API-Marker"
+    assert listed.status_code == 200
+    assert [item["title"] for item in listed.json()] == ["API-Marker"]
+
+
+def test_reference_settings_are_defaulted_typed_and_overridable() -> None:
+    assert ReferenceSettings().max_items == 100
+    overridden = ReferenceSettings.model_validate(
+        {"max_items": "25", "job_interval_seconds": "600"}
+    )
+    assert overridden.max_items == 25
+    assert overridden.job_interval_seconds == 600

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import (
 
 from app.core.config import get_settings
 from app.db.base import Base
+from app.modules.reference.module import DEFINITION as REFERENCE_DEFINITION
 from app.platform.modules import (
     DuplicatePersistenceSchemaError,
     ModuleDefinition,
@@ -436,6 +437,44 @@ async def test_fresh_upgrade_explicit_downgrade_and_reupgrade_module_migrations(
     async with engine.connect() as connection:
         revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
     assert revision == "mod_example_b_20260825_0001"
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reference_module_migration_up_down_and_seed_data(
+    fresh_database_url: str,
+) -> None:
+    resolved = resolve_module_definitions(
+        enabled_module_ids=("reference",),
+        discovery_providers=(FakeDiscovery((REFERENCE_DEFINITION,)),),
+        host_version="0.2.0",
+    )
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    config.attributes["database_url"] = fresh_database_url
+    coordinator = MigrationCoordinator(config, build_persistence_registry(resolved))
+
+    await asyncio.to_thread(coordinator.upgrade)
+    engine = create_async_engine(fresh_database_url)
+    async with engine.connect() as connection:
+        count = await connection.scalar(text("SELECT count(*) FROM reference.items"))
+        revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
+    assert count == 2
+    assert revision == "mod_reference_20260826_0001"
+
+    await asyncio.to_thread(coordinator.downgrade, "20260825_0034")
+    async with engine.connect() as connection:
+        schema = await connection.scalar(
+            text(
+                "SELECT schema_name FROM information_schema.schemata "
+                "WHERE schema_name = 'reference'"
+            )
+        )
+    assert schema is None
+
+    await asyncio.to_thread(coordinator.upgrade)
+    async with engine.connect() as connection:
+        revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
+    assert revision == "mod_reference_20260826_0001"
     await engine.dispose()
 
 

--- a/backend/tests/test_module_sdk.py
+++ b/backend/tests/test_module_sdk.py
@@ -21,6 +21,7 @@ from app.platform.modules.sdk import (
     ModuleContext,
     ModuleSettingsPort,
     ObservabilityPort,
+    PermissionDependencyFactory,
     PermissionPort,
     SchedulerPort,
     ServiceRegistryPort,
@@ -58,6 +59,7 @@ def test_module_context_has_typed_public_ports() -> None:
         "events": EventBusPort | None,
         "services": ServiceRegistryPort | None,
         "permissions": PermissionPort | None,
+        "permission_dependencies": PermissionDependencyFactory | None,
         "cache": CachePort | None,
         "storage": StoragePort | None,
         "http": HttpClientFactoryPort | None,
@@ -76,6 +78,7 @@ def test_runtime_context_is_bound_to_manifest_and_unimplemented_ports_are_absent
     assert context.events is None
     assert context.services is not None
     assert context.permissions is None
+    assert context.permission_dependencies is None
     assert context.cache is None
     assert context.storage is None
     assert context.http is None

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 - [Frontend-Host und Build-Time-Module](modules/frontend-host.md)
 - [Frontend UI Contributions](modules/frontend-ui-contributions.md)
 - [Modul-Datenbanken und Migrationen](modules/database-and-migrations.md)
+- [Ausführbares End-to-End-Referenzmodul](modules/reference-module.md)
 - [Frontend-Design und Analyse](frontend-design.md)
 - [Reihenfolge der GIS-Layer](map-layer-order.md)
 - [Intelligente Suche](intelligent-search.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,11 +66,15 @@ uv python install 3.12.14
 uv sync --frozen --no-dev --no-editable --python 3.12.14 --managed-python
 uv run alembic heads
 uv run alembic upgrade head
+uv run python -m app.cli.module_migrations preflight
+uv run python -m app.cli.module_migrations upgrade
 ```
 
-Der bestehende Befehl bleibt für die veröffentlichte Host-/Legacy-Historie
-maßgeblich. Installierte Module mit eigenen Migrationen werden vor ihrer Aktivierung
-zusätzlich über den in
+Die Alembic-Befehle bleiben für die veröffentlichte Host-/Legacy-Historie maßgeblich.
+Der anschließende generische Modul-CLI löst die in `ENABLED_MODULES` konfigurierten,
+installierten Migrationsquellen auf, prüft den gemeinsamen linearen Graph und führt
+ausstehende Modulrevisionen vor der Aktivierung aus. Installierte Module mit eigenen
+Migrationen folgen damit dem in
 [ADR #97](architecture/adr-module-database-and-migration-ownership.md)
 beschriebenen Persistence-Preflight geprüft. Bereits angewandte Migrationsquellen
 müssen auch bei deaktiviertem Modul installiert und im Migrationsinventar auflösbar

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -63,6 +63,7 @@ Sub-Interfaces `context.api` und `context.lifecycle`.
 | `events` | `EventBusPort` | In-Process Dispatch und transaktionale Outbox aus #96 |
 | `services` | `ServiceRegistryPort` | runtime-skopierte Cross-Module-Registry aus #98 |
 | `permissions` | `PermissionPort` | hostseitige, fail-closed Policy-Auswertung aus #104 |
+| `permission_dependencies` | `PermissionDependencyFactory` | authentifizierte FastAPI-Dependency mit optionalem CSRF für Modulrouten |
 | `cache` | `CachePort` | optionaler, modulgebundener Byte-Cache |
 | `observability` | `ObservabilityPort` | immer vorhanden; Logger ist an Modul-ID/-Version gebunden |
 | `storage` | `StoragePort` | optionaler modulgebundener Blob-Storage |
@@ -158,6 +159,10 @@ bleibt als Kompatibilitätsform erhalten.
 Die additive Permission-Definition und hostseitige Registry aus #104 erhöhen die
 SDK-Version auf `1.6.0`; die bestehende `PermissionPort.is_allowed()`-Signatur
 bleibt kompatibel.
+Die additive `PermissionDependencyFactory` erhöht die SDK-Version auf `1.7.0`. Sie
+gibt Modulrouten ausschließlich eine minimale `ModulePrincipal`-ID und adaptiert die
+bestehende Host-Authentifizierung, CSRF-Prüfung und Permission Engine, ohne User- oder
+Auth-Interna Teil des SDK zu machen.
 
 - **MAJOR:** Entfernen oder Umbenennen öffentlicher Methoden, inkompatible Änderungen
   an vorhandener Semantik oder eine inkompatible Context-Struktur.

--- a/docs/modules/database-and-migrations.md
+++ b/docs/modules/database-and-migrations.md
@@ -105,6 +105,17 @@ Owner am einen globalen Head angehängt. `MigrationCoordinator.preflight()` prü
 - passende Revision-Namespaces;
 - Host- und Modulgruppen in Dependency-Reihenfolge.
 
+Der generische CLI-Einstieg verwendet exakt diese Registry und den aktiven
+Modulbestand:
+
+```bash
+ENABLED_MODULES=reference uv run python -m app.cli.module_migrations preflight
+ENABLED_MODULES=reference uv run python -m app.cli.module_migrations upgrade
+```
+
+Ein Downgrade akzeptiert absichtlich nur ein explizites Ziel, zum Beispiel
+`python -m app.cli.module_migrations downgrade <revision>`.
+
 Migrationen sind vertrauenswürdiger Code mit weitreichenden DB-Rechten. Jede
 Revision benötigt manuelles Review; der Preflight ist keine Sandbox.
 

--- a/docs/modules/reference-module.md
+++ b/docs/modules/reference-module.md
@@ -1,0 +1,31 @@
+# End-to-End-Referenzmodul
+
+Das installierbare Modul `reference` ist die ausführbare Entwicklerdokumentation für
+die Backend- und Frontend-Module-SDKs. Es ergänzt das bewusst minimale
+`example-module`: Das Example bleibt ein schnelles Frontend-Contract-Fixture, während
+`reference` den vollständigen Datenweg demonstriert.
+
+```text
+reference.items
+    │ eigene Migration und Tabelle
+    ▼
+Application-Service ── Permission / Event / Job über ModuleContext
+    │
+    ▼
+/api/v1/modules/reference/items(.geojson)
+    │
+    ▼
+lokales Nuxt-Layer ── Seite / Navigation / UI-Slot / Map / Feature-Info
+```
+
+Der Host kennt dabei ausschließlich Entry-Points und öffentliche Contracts. Es gibt
+keinen Reference-Import im zentralen Router, in der Navigation oder im `MapCanvas`.
+Die vollständige, mit dem Code synchron gehaltene Anleitung einschließlich
+Aktivierung, Entfernung und Copy Guide steht im
+[README des Moduls](../../backend/app/modules/reference/README.md).
+
+Für die lokale Contract-Prüfung:
+
+```bash
+scripts/module-contract-gate
+```

--- a/frontend/frontend-modules/reference/README.md
+++ b/frontend/frontend-modules/reference/README.md
@@ -1,0 +1,6 @@
+# Reference Frontend Module
+
+Dieses lokale Nuxt-Layer ist die Frontend-Hälfte der ausführbaren
+[Reference-Module-Dokumentation](../../../backend/app/modules/reference/README.md).
+Manifest, Aktivierung, Deaktivierung, Copy Guide und vollständige Tests sind dort
+gemeinsam für Backend und Frontend beschrieben.

--- a/frontend/frontend-modules/reference/layer/app/components/ReferenceFeatureInfoControl.vue
+++ b/frontend/frontend-modules/reference/layer/app/components/ReferenceFeatureInfoControl.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="w-64 rounded-xl border border-violet-200 bg-white p-3 text-left shadow-lg">
+    <p class="text-xs font-bold uppercase tracking-wide text-violet-700">Referenzmarker</p>
+    <p v-if="info" class="mt-1 font-bold text-slate-900">{{ info.title }}</p>
+    <p v-if="info" class="mt-1 text-xs leading-5 text-slate-600">{{ info.description }}</p>
+    <p v-else-if="loadError" class="mt-1 text-xs leading-5 text-rose-700" role="alert">Marker konnten nicht geladen werden.</p>
+    <p v-else class="mt-1 text-xs leading-5 text-slate-600">Marker auf der Karte auswählen.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { MapContext } from '#frontend-module-sdk'
+import { useMapContext } from '#frontend-module-sdk'
+import { onBeforeUnmount, watch } from 'vue'
+import {
+  createReferenceFeatureInfoProvider,
+  referenceSelectionFrom,
+  type ReferenceFeatureInfo
+} from '../composables/useReferenceFeatureInfo'
+import { referenceApiUrl } from '../composables/referenceApi'
+
+const mapContext = useMapContext()
+const info = ref<ReferenceFeatureInfo | null>(null)
+const loadError = ref(false)
+let unregisterProvider: (() => void) | undefined
+let unregisterInteraction: (() => void) | undefined
+
+const provider = createReferenceFeatureInfoProvider()
+
+async function loadFeatures(context: MapContext) {
+  const config = useRuntimeConfig()
+  try {
+    const collection = await $fetch<GeoJSON.FeatureCollection>(
+      referenceApiUrl(String(config.public.apiBaseUrl), '.geojson')
+    )
+    const source = context.unsafeMapLibre().getSource('reference.items')
+    if (source && 'setData' in source && typeof source.setData === 'function') {
+      source.setData(collection)
+    }
+  } catch {
+    loadError.value = true
+  }
+}
+
+function register(context: MapContext) {
+  unregisterProvider = context.featureInfo.register(provider)
+  unregisterInteraction = context.interactions.register({
+    id: 'reference.items-click',
+    moduleId: 'reference',
+    event: 'click',
+    layerIds: ['reference.items'],
+    handler: async (event, activeContext) => {
+      const selection = referenceSelectionFrom(event)
+      if (!selection) return
+      await activeContext.selection.select(selection)
+      info.value = await provider.resolveFeatureInfo(selection, activeContext)
+      return { handled: true }
+    }
+  })
+  void loadFeatures(context)
+}
+
+watch(mapContext, (context) => {
+  unregisterInteraction?.()
+  unregisterProvider?.()
+  unregisterInteraction = undefined
+  unregisterProvider = undefined
+  if (context) register(context)
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  unregisterInteraction?.()
+  unregisterProvider?.()
+})
+</script>

--- a/frontend/frontend-modules/reference/layer/app/components/ReferenceItemList.vue
+++ b/frontend/frontend-modules/reference/layer/app/components/ReferenceItemList.vue
@@ -1,0 +1,29 @@
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm" aria-labelledby="reference-items-title">
+    <h2 id="reference-items-title" class="text-xl font-bold text-slate-900">Marker aus der Modul-API</h2>
+    <p class="mt-1 text-sm leading-6 text-slate-600">
+      Diese Einträge werden serverseitig aus der eigenen Tabelle des Moduls geladen.
+    </p>
+    <p v-if="pending" class="mt-4 text-sm text-slate-600" role="status">Referenzmarker werden geladen …</p>
+    <p v-else-if="error" class="mt-4 rounded-xl bg-rose-50 p-3 text-sm text-rose-800" role="alert">
+      Die Referenzmarker konnten nicht geladen werden.
+    </p>
+    <ul v-else class="mt-4 grid gap-3 sm:grid-cols-2">
+      <li v-for="item in items" :key="item.id" class="rounded-xl border border-slate-200 p-4">
+        <h3 class="font-bold text-slate-900">{{ item.title }}</h3>
+        <p class="mt-1 text-sm leading-6 text-slate-600">{{ item.description }}</p>
+        <p class="mt-2 font-mono text-xs text-slate-500">{{ item.latitude.toFixed(4) }}, {{ item.longitude.toFixed(4) }}</p>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { ReferenceItemRead } from '../composables/useReferenceItems'
+
+defineProps<{
+  items: readonly ReferenceItemRead[]
+  pending: boolean
+  error: boolean
+}>()
+</script>

--- a/frontend/frontend-modules/reference/layer/app/composables/referenceApi.ts
+++ b/frontend/frontend-modules/reference/layer/app/composables/referenceApi.ts
@@ -1,0 +1,3 @@
+export function referenceApiUrl(baseUrl: string, suffix = '') {
+  return `${baseUrl.replace(/\/$/, '')}/modules/reference/items${suffix}`
+}

--- a/frontend/frontend-modules/reference/layer/app/composables/useReferenceFeatureInfo.ts
+++ b/frontend/frontend-modules/reference/layer/app/composables/useReferenceFeatureInfo.ts
@@ -1,0 +1,48 @@
+import type {
+  MapFeatureInfoProvider,
+  MapInteractionEvent,
+  SelectedMapFeature
+} from '#frontend-module-sdk'
+
+export interface ReferenceFeatureInfo {
+  readonly title: string
+  readonly description: string
+}
+
+interface RenderedReferenceFeature {
+  readonly id?: string | number
+  readonly properties?: Readonly<Record<string, unknown>>
+  readonly geometry?: GeoJSON.Geometry
+}
+
+function textProperty(properties: Readonly<Record<string, unknown>> | undefined, key: string) {
+  const value = properties?.[key]
+  return typeof value === 'string' ? value : ''
+}
+
+export function createReferenceFeatureInfoProvider(): MapFeatureInfoProvider<ReferenceFeatureInfo> {
+  return {
+    id: 'reference.items-info',
+    moduleId: 'reference',
+    canHandle: selection => selection.moduleId === 'reference' && selection.layerId === 'reference.items',
+    resolveFeatureInfo: selection => ({
+      title: textProperty(selection.properties, 'title') || 'Referenzmarker',
+      description: textProperty(selection.properties, 'description')
+    })
+  }
+}
+
+export function referenceSelectionFrom(event: MapInteractionEvent): SelectedMapFeature | null {
+  const feature = event.features?.[0]
+  if (!feature || typeof feature !== 'object') return null
+  const rendered = feature as RenderedReferenceFeature
+  if (rendered.id === undefined) return null
+  return {
+    moduleId: 'reference',
+    sourceId: 'reference.items',
+    layerId: 'reference.items',
+    featureId: rendered.id,
+    properties: rendered.properties,
+    geometry: rendered.geometry
+  }
+}

--- a/frontend/frontend-modules/reference/layer/app/composables/useReferenceItems.ts
+++ b/frontend/frontend-modules/reference/layer/app/composables/useReferenceItems.ts
@@ -1,0 +1,21 @@
+import { useAsyncData, useRuntimeConfig } from '#imports'
+import { referenceApiUrl } from './referenceApi'
+
+export interface ReferenceItemRead {
+  readonly id: string
+  readonly title: string
+  readonly description: string
+  readonly longitude: number
+  readonly latitude: number
+}
+
+export function useReferenceItems() {
+  const config = useRuntimeConfig()
+  const baseUrl = import.meta.server
+    ? String(config.apiInternalBaseUrl || config.public.apiBaseUrl)
+    : String(config.public.apiBaseUrl)
+  return useAsyncData(
+    'reference-items',
+    () => $fetch<ReferenceItemRead[]>(referenceApiUrl(baseUrl))
+  )
+}

--- a/frontend/frontend-modules/reference/layer/app/pages/referenzmodul.vue
+++ b/frontend/frontend-modules/reference/layer/app/pages/referenzmodul.vue
@@ -1,0 +1,29 @@
+<template>
+  <ContentPageShell
+    title="Referenzmodul"
+    description="Ein kleines End-to-End-Modul als ausführbare Dokumentation für das öffentliche Module SDK."
+    eyebrow="Module SDK"
+    :breadcrumbs="[{ label: 'Startseite', to: '/' }, { label: 'Referenzmodul' }]"
+  >
+    <ReferenceItemList
+      :items="data ?? []"
+      :pending="pending"
+      :error="Boolean(error)"
+    />
+  </ContentPageShell>
+</template>
+
+<script setup lang="ts">
+import ReferenceItemList from '../components/ReferenceItemList.vue'
+import { useReferenceItems } from '../composables/useReferenceItems'
+
+const { data, pending, error } = useReferenceItems()
+
+usePageSeo({
+  title: 'Referenzmodul',
+  description: 'Ausführbares End-to-End-Beispiel für das Open City Planner Module SDK.',
+  path: '/referenzmodul',
+  robots: 'noindex,nofollow',
+  structuredData: false
+})
+</script>

--- a/frontend/frontend-modules/reference/layer/nuxt.config.ts
+++ b/frontend/frontend-modules/reference/layer/nuxt.config.ts
@@ -1,0 +1,8 @@
+import { fileURLToPath } from 'node:url'
+
+export default defineNuxtConfig({
+  components: [{
+    path: fileURLToPath(new URL('./app/components', import.meta.url)),
+    pathPrefix: false
+  }]
+})

--- a/frontend/frontend-modules/reference/module.json
+++ b/frontend/frontend-modules/reference/module.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": 1,
+  "id": "reference",
+  "version": "1.0.0",
+  "backendModuleId": "reference",
+  "compatibility": {
+    "host": ">=1.0.0 <2.0.0",
+    "sdk": ">=1.2.0 <2.0.0",
+    "backend": ">=1.0.0 <2.0.0"
+  },
+  "layer": "layer",
+  "requires": { "modules": {} },
+  "publicContributions": {
+    "routes": [
+      {
+        "path": "/referenzmodul",
+        "source": "layer/app/pages/referenzmodul.vue"
+      }
+    ],
+    "ui": [
+      {
+        "id": "reference.primary-navigation",
+        "slot": "navigation.primary",
+        "priority": 260,
+        "visibility": { "auth": "public", "module": "reference" },
+        "label": "Referenzmodul",
+        "to": "/referenzmodul",
+        "exact": true
+      },
+      {
+        "id": "reference.admin-navigation",
+        "slot": "navigation.admin",
+        "priority": 910,
+        "visibility": {
+          "auth": "authenticated",
+          "permission": "reference.items-write",
+          "module": "reference"
+        },
+        "label": "Referenzmarker verwalten",
+        "to": "/referenzmodul",
+        "exact": true
+      },
+      {
+        "id": "reference.map-feature-info",
+        "slot": "map.controls",
+        "priority": 120,
+        "visibility": { "module": "reference" },
+        "component": "ReferenceFeatureInfoControl",
+        "source": "layer/app/components/ReferenceFeatureInfoControl.vue",
+        "accessibleLabel": "Informationen zu Referenzmarkern"
+      }
+    ],
+    "map": {
+      "sources": [
+        {
+          "id": "reference.items",
+          "source": {
+            "type": "geojson",
+            "data": {
+              "type": "FeatureCollection",
+              "features": []
+            }
+          }
+        }
+      ],
+      "layers": [
+        {
+          "id": "reference.items",
+          "sourceId": "reference.items",
+          "group": "overlay",
+          "priority": 520,
+          "layer": {
+            "type": "circle",
+            "paint": {
+              "circle-color": "#7c3aed",
+              "circle-radius": 8,
+              "circle-stroke-color": "#ffffff",
+              "circle-stroke-width": 2
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/frontend/tests/frontend-module-enabled-ssr.test.ts
+++ b/frontend/tests/frontend-module-enabled-ssr.test.ts
@@ -1,8 +1,33 @@
+import { createServer } from 'node:http'
 import { fileURLToPath } from 'node:url'
 import { fetch, setup } from '@nuxt/test-utils/e2e'
 import { afterAll, describe, expect, it } from 'vitest'
 
-process.env.OCP_FRONTEND_MODULES = 'example-module'
+const api = createServer((request, response) => {
+  response.setHeader('content-type', 'application/json')
+  if (request.url === '/api/v1/modules/reference/items') {
+    response.end(JSON.stringify([{
+      id: 'marker-1',
+      title: 'SSR-Referenzmarker',
+      description: 'Antwort der lokalen Test-API',
+      longitude: 9.43,
+      latitude: 54.79
+    }]))
+    return
+  }
+  response.statusCode = 404
+  response.end('{}')
+})
+
+await new Promise<void>(resolve => api.listen(0, '127.0.0.1', resolve))
+const address = api.address()
+if (!address || typeof address === 'string') throw new Error('Reference API test server failed.')
+const apiBaseUrl = `http://127.0.0.1:${address.port}/api/v1`
+
+process.env.OCP_FRONTEND_MODULES = 'example-module,reference'
+process.env.OCP_BACKEND_MODULES = 'reference@1.0.0'
+process.env.NUXT_API_INTERNAL_BASE_URL = apiBaseUrl
+process.env.NUXT_PUBLIC_API_BASE_URL = apiBaseUrl
 
 await setup({
   rootDir: fileURLToPath(new URL('..', import.meta.url)),
@@ -12,8 +37,15 @@ await setup({
   env: { NUXT_PUBLIC_SITE_URL: 'https://stadtplaner.example' }
 })
 
-afterAll(() => {
+afterAll(async () => {
   delete process.env.OCP_FRONTEND_MODULES
+  delete process.env.OCP_BACKEND_MODULES
+  delete process.env.NUXT_API_INTERNAL_BASE_URL
+  delete process.env.NUXT_PUBLIC_API_BASE_URL
+  api.closeAllConnections()
+  await new Promise<void>((resolve, reject) => {
+    api.close(error => error ? reject(error) : resolve())
+  })
 })
 
 describe('enabled frontend module SSR', () => {
@@ -40,5 +72,20 @@ describe('enabled frontend module SSR', () => {
     expect(html).toMatch(/(?:href="\/module-example"[^>]*aria-current="page"|aria-current="page"[^>]*href="\/module-example")/)
     expect(html).toContain('<title>Frontend-Modulbeispiel – OK Lab Flensburg</title>')
     expect(html).toContain('content="noindex,nofollow"')
+  })
+
+  it('renders the reference module API page and map slot through the host', async () => {
+    const page = await fetch('/referenzmodul')
+    expect(page.status).toBe(200)
+    const pageHtml = await page.text()
+    expect(pageHtml).toContain('SSR-Referenzmarker')
+    expect(pageHtml).toContain('href="/referenzmodul"')
+    expect(pageHtml).toContain('<title>Referenzmodul – OK Lab Flensburg</title>')
+
+    const map = await fetch('/karte')
+    expect(map.status).toBe(200)
+    const mapHtml = await map.text()
+    expect(mapHtml).toContain('data-ui-contribution="reference.map-feature-info"')
+    expect(mapHtml).toContain('Informationen zu Referenzmarkern')
   })
 })

--- a/frontend/tests/reference-module/reference-module.test.ts
+++ b/frontend/tests/reference-module/reference-module.test.ts
@@ -1,0 +1,94 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { resolveFrontendModules } from '../../module-host/discovery'
+import { createMapExtensionDefinitionRegistry } from '../../module-host/map-definition-registry'
+import { createFrontendContributionRegistry } from '../../module-host/ui-registry'
+import {
+  createReferenceFeatureInfoProvider,
+  referenceSelectionFrom
+} from '../../frontend-modules/reference/layer/app/composables/useReferenceFeatureInfo'
+import { referenceApiUrl } from '../../frontend-modules/reference/layer/app/composables/referenceApi'
+import { isUiContributionVisible } from '../../module-host/public'
+
+const options = {
+  modulesDirectory: fileURLToPath(new URL('../../frontend-modules', import.meta.url)),
+  appPagesDirectory: fileURLToPath(new URL('../../app/pages', import.meta.url)),
+  backendModules: 'reference@1.0.0'
+}
+
+describe('reference frontend module contract fixture', () => {
+  it('is absent when disabled and resolves as a compatible full-stack module when enabled', () => {
+    expect(resolveFrontendModules({ ...options, enabledModules: '' })).toEqual([])
+    const modules = resolveFrontendModules({ ...options, enabledModules: 'reference' })
+    expect(modules.map(module => module.id)).toEqual(['reference'])
+    expect(modules[0]?.layerPath).toBe(
+      fileURLToPath(new URL('../../frontend-modules/reference/layer', import.meta.url))
+    )
+  })
+
+  it('contributes its route, navigation, slot, API-backed source and layer', () => {
+    const modules = resolveFrontendModules({ ...options, enabledModules: 'reference' })
+    const ui = createFrontendContributionRegistry(modules, ['/']).all()
+    const map = createMapExtensionDefinitionRegistry(modules).snapshot()
+
+    expect(modules[0]?.publicContributions.routes).toContainEqual(expect.objectContaining({
+      path: '/referenzmodul'
+    }))
+    expect(ui.map(contribution => contribution.id)).toEqual([
+      'reference.map-feature-info',
+      'reference.primary-navigation',
+      'reference.admin-navigation'
+    ])
+    expect(map.sources).toContainEqual(expect.objectContaining({
+      id: 'reference.items',
+      source: expect.objectContaining({
+        data: expect.objectContaining({ type: 'FeatureCollection', features: [] })
+      })
+    }))
+    expect(map.layers).toContainEqual(expect.objectContaining({
+      id: 'reference.items',
+      sourceId: 'reference.items'
+    }))
+  })
+
+  it('uses the configured API origin and keeps management navigation permission-aware', () => {
+    expect(referenceApiUrl('https://api.example/api/v1/', '.geojson'))
+      .toBe('https://api.example/api/v1/modules/reference/items.geojson')
+    const modules = resolveFrontendModules({ ...options, enabledModules: 'reference' })
+    const contribution = createFrontendContributionRegistry(modules, ['/']).all()
+      .find(item => item.id === 'reference.admin-navigation')
+    expect(contribution).toBeDefined()
+    if (!contribution) return
+    const visibility = {
+      authenticated: true,
+      featureEnabled: () => true,
+      moduleEnabled: () => true
+    }
+    expect(isUiContributionVisible(contribution, { ...visibility, can: () => false })).toBe(false)
+    expect(isUiContributionVisible(contribution, { ...visibility, can: permission => permission === 'reference.items-write' })).toBe(true)
+  })
+
+  it('selects its rendered feature and resolves title and description', async () => {
+    const selection = referenceSelectionFrom({
+      type: 'click',
+      features: [{
+        id: 'marker-1',
+        properties: { title: 'Hafen', description: 'Beispielmarker' },
+        geometry: { type: 'Point', coordinates: [9.43, 54.79] }
+      }]
+    })
+    expect(selection).toEqual(expect.objectContaining({
+      moduleId: 'reference',
+      layerId: 'reference.items',
+      featureId: 'marker-1'
+    }))
+    expect(selection).not.toBeNull()
+    if (!selection) return
+    const provider = createReferenceFeatureInfoProvider()
+    expect(provider.canHandle(selection)).toBe(true)
+    expect(await provider.resolveFeatureInfo(selection, {} as never)).toEqual({
+      title: 'Hafen',
+      description: 'Beispielmarker'
+    })
+  })
+})

--- a/scripts/module-contract-gate
+++ b/scripts/module-contract-gate
@@ -7,7 +7,7 @@ scope="${1:-all}"
 run_backend() {
   cd "${repository_root}/backend"
   uv run python ../scripts/check_module_architecture.py
-  uv run pytest tests/test_module_*.py tests/test_domain_events.py
+  uv run pytest tests/test_module_*.py tests/test_domain_events.py tests/modules/reference
 }
 
 run_frontend() {
@@ -19,7 +19,8 @@ run_frontend() {
     tests/frontend-module-host.test.ts \
     tests/frontend-ui-contributions.test.ts \
     tests/map-runtime.test.ts \
-    tests/map-sdk.test.ts
+    tests/map-sdk.test.ts \
+    tests/reference-module/reference-module.test.ts
   pnpm test:modules:ssr
 }
 


### PR DESCRIPTION
## Ausgangslage

Nach den Module-SDK- und Contract-Grundlagen aus #94–#105 fehlte ein kleines, vollständig ausführbares Beispielmodul, das den gesamten Integrationsweg dokumentiert.

Das bestehende `example-module` bleibt bewusst als minimales Frontend-Contract-Fixture erhalten. Das neue `reference`-Modul dient als ausführbare SDK-Dokumentation und kopierbare Grundlage für externe Modulentwickler:innen.

## Umsetzung

- vollständiges Backend- und Frontend-Referenzmodul mit stabiler ID `reference`
- generische Entry-Point-Discovery ohne fachlichen Import im Host
- eigene Domain-, Application-, API- und Persistence-Struktur
- eigene PostgreSQL-Tabelle und Modulmigration mit deterministischen Beispieldaten
- generischer CLI-Einstieg für Migrations-Preflight, Upgrade und gezielten Downgrade
- eigene Permission mit serverseitiger Durchsetzung und CSRF-Schutz
- typisierte, namespacete Moduleinstellungen
- versioniertes Domain Event mit internem Subscriber
- registrierter Background Job
- eigenes lokales Nuxt-Layer mit SSR-fähiger Seite
- Primary- und permission-sensitive Admin-Navigation-Contributions
- UI-Slot-Contribution für die Kartenansicht
- API-gespeiste GeoJSON-Source und eigener Map-SDK-Layer
- Klick-Interaction und FeatureInfo Provider
- Enabled-/Disabled- und Compatibility-Tests
- Integration als positives Fixture in das Module Contract Gate
- ausführlicher Copy-as-template Guide inklusive Aktivierung, Deaktivierung und Datenhaltbarkeit

## Architektur

Das Referenzmodul verwendet ausschließlich die öffentlichen Backend- und Frontend-SDK-Verträge.

Es wurden keine Reference-spezifischen Änderungen vorgenommen an:

- zentralem Backend-Router
- zentraler Host-Navigation
- `MapCanvas.vue`
- bestehenden Fachmodulen

Die Deaktivierung entfernt API, Permission, Subscriber, Job, Seite, Navigation, UI-Slot und Kartenbeiträge. Bereits persistierte Moduldaten bleiben bewusst erhalten.

## Validierung

- `uv run ruff check app tests`
- `uv run pytest` – 842 Tests erfolgreich
- Referenzmigration auf einer frischen PostgreSQL-Datenbank:
  - Upgrade
  - Prüfung der Seed-Daten
  - gezielter Downgrade
  - erneutes Upgrade
- `pnpm test` – 493 Tests erfolgreich
- `pnpm typecheck` mit aktiviertem und deaktiviertem Modul
- `pnpm build` mit aktiviertem und deaktiviertem Modul
- `pnpm test:modules:ssr`
- `scripts/module-contract-gate`
  - 236 Backend-Contracttests
  - 43 Frontend-Contracttests
  - 3 SSR-Tests
- `pnpm audit:language`
- `pnpm audit:seo`
- Supply-Chain-Verifikation und Policy-Tests
- `git diff --check`

Keine neue Runtime-Abhängigkeit wurde eingeführt.

Part of #91  
Closes #106