### PR TITLE
feat(modules): add getting started scaffold

### DIFF
--- a/backend/app/modules/reference/README.md
+++ b/backend/app/modules/reference/README.md
@@ -4,6 +4,12 @@ Dieses bewusst kleine Modul ist ausführbare SDK-Dokumentation. Es zeigt eine ne
 `ReferenceItem`-Domäne vom eigenen PostgreSQL-Schema bis zur Nuxt-Seite und zum
 MapLibre-Layer. Es ist kein produktives Fachfeature.
 
+> The reference module is the canonical executable SDK example.
+
+Für ein neues, bewusst minimales Modul beginnt der Weg im
+[Getting-Started-Guide](../../../../docs/modules/getting-started.md), nicht mit einer
+vollständigen Kopie dieses End-to-End-Beispiels.
+
 ## 1. Was demonstriert dieses Modul?
 
 Das Modul nutzt Manifest und Entry-Point-Discovery, Backend- und Frontend-SDK,
@@ -186,20 +192,14 @@ Tabelle und historische Migration bleiben absichtlich erhalten; Deaktivieren lö
 keine Daten. Ein physisches Entfernen braucht eine separat geprüfte Cleanup-Migration
 mit Backup- und Rollback-Plan.
 
-## 20. How to create your own module
+## 20. Ein eigenes Modul beginnen
 
-1. Beide Verzeichnisse kopieren, zum Beispiel
-   `cp -R backend/app/modules/reference backend/app/modules/my_module` und
-   `cp -R frontend/frontend-modules/reference frontend/frontend-modules/my-module`.
-2. Modul-ID und Python-/Frontend-Verzeichnis, Version und Entry-Point umbenennen.
-3. Manifest-, Config-, Schema- und Revision-Namespace konsistent ändern.
-4. Permission-, Route-, Event-, Job-, Source-, Layer- und Contribution-IDs umbenennen.
-5. Tabelle, Migration, Entity, API-Schemas und sichtbare Texte auf die neue kleine
-   Domäne zuschneiden; die alte Revision-ID nicht wiederverwenden.
-6. Tests kopieren und zuerst enabled, disabled und inkompatible Versionen prüfen.
-7. Architektur-Gate, vollständige Tests, Typecheck und beide Builds ausführen.
+Erzeuge ein minimales Modul mit `./scripts/create-module my-module` und folge dem
+[Getting-Started-Guide](../../../../docs/modules/getting-started.md). Kopiere dieses
+Reference-Modul nicht vollständig: Persistence, Permissions, Events, Jobs und Map
+werden nur ergänzt, wenn das neue Modul sie tatsächlich benötigt.
 
-Kopiere keine Host-Interna. Modulcode importiert Plattformverträge nur aus
-`app.platform.modules.sdk` beziehungsweise `#frontend-module-sdk`. Wenn ein nötiger
-Contract fehlt, wird das SDK bewusst erweitert; private DB-, Runtime-, Auth-, Router-,
-Navigations- oder MapCanvas-Implementierungen sind keine Abkürzung.
+Modulcode importiert Plattformverträge ausschließlich aus
+`app.platform.modules.sdk` beziehungsweise `#frontend-module-sdk`. Private DB-,
+Runtime-, Auth-, Router-, Navigations- oder MapCanvas-Implementierungen sind keine
+Abkürzung.

--- a/backend/app/platform/modules/discovery.py
+++ b/backend/app/platform/modules/discovery.py
@@ -1,8 +1,8 @@
 """Kontrollierte First-Party- und Python-Entry-Point-Discovery."""
 
 from collections.abc import Callable, Mapping, Sequence
-from importlib import metadata
-from types import MappingProxyType
+from importlib import import_module, metadata
+from pathlib import Path
 
 from app.platform.modules.errors import ModuleDiscoveryError
 from app.platform.modules.sdk import ModuleDefinition
@@ -10,32 +10,40 @@ from app.platform.modules.sdk import ModuleDefinition
 ENTRY_POINT_GROUP = "open_city_planner.modules"
 type DefinitionSource = ModuleDefinition | Callable[[], ModuleDefinition]
 
-# First-Party-Module werden hier später deklarativ ergänzt. Leer bedeutet, dass die
-# produktive Legacy-Anwendung ohne neue Module unverändert startet.
-FIRST_PARTY_MODULES: Mapping[str, DefinitionSource] = MappingProxyType({})
+BUILTIN_MODULES_DIRECTORY = Path(__file__).resolve().parents[2] / "modules"
 
 
 class FirstPartyModuleDiscovery:
-    """Discovery aus einem fachneutralen, deploy-time kontrollierten Katalog."""
+    """Discovery aus Built-in-Konvention oder explizitem Test-/Composition-Katalog."""
 
-    def __init__(self, catalog: Mapping[str, DefinitionSource] = FIRST_PARTY_MODULES) -> None:
+    def __init__(self, catalog: Mapping[str, DefinitionSource] | None = None) -> None:
         self._catalog = catalog
 
     def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
         definitions: list[ModuleDefinition] = []
-        for module_id in sorted(enabled_module_ids.intersection(self._catalog)):
-            source = self._catalog[module_id]
+        module_ids = (
+            enabled_module_ids
+            if self._catalog is None
+            else enabled_module_ids.intersection(self._catalog)
+        )
+        for module_id in sorted(module_ids):
             try:
-                definition = source() if callable(source) else source
+                definition = (
+                    _load_builtin_definition(module_id)
+                    if self._catalog is None
+                    else _resolve_source(self._catalog[module_id])
+                )
             except Exception as exc:
                 raise ModuleDiscoveryError(
                     "The first-party module definition could not be loaded.",
                     module_id=module_id,
                     origin="first-party",
                 ) from exc
+            if definition is None:
+                continue
             if not isinstance(definition, ModuleDefinition):
                 raise ModuleDiscoveryError(
-                    "The first-party catalog entry is not a ModuleDefinition.",
+                    "The first-party module does not expose a ModuleDefinition.",
                     module_id=module_id,
                     origin="first-party",
                 )
@@ -50,6 +58,20 @@ class FirstPartyModuleDiscovery:
                 )
             )
         return tuple(definitions)
+
+
+def _load_builtin_definition(module_id: str) -> ModuleDefinition | None:
+    """Load an enabled repository module by the built-in directory convention."""
+
+    python_name = module_id.replace("-", "_")
+    if not (BUILTIN_MODULES_DIRECTORY / python_name / "module.py").is_file():
+        return None
+    module = import_module(f"app.modules.{python_name}.module")
+    return module.DEFINITION
+
+
+def _resolve_source(source: DefinitionSource) -> ModuleDefinition:
+    return source() if callable(source) else source
 
 
 class EntryPointModuleDiscovery:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,10 +54,6 @@ security = [
   "pyyaml==6.0.3"
 ]
 
-[project.entry-points."open_city_planner.modules"]
-analysis-areas = "app.modules.analysis_areas.module:DEFINITION"
-reference = "app.modules.reference.module:DEFINITION"
-
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/backend/tests/modules/reference/test_reference_module.py
+++ b/backend/tests/modules/reference/test_reference_module.py
@@ -59,7 +59,7 @@ def test_manifest_and_passive_contributions_have_one_owner() -> None:
 
 
 def test_enabled_and_disabled_discovery_and_compatibility() -> None:
-    provider = FirstPartyModuleDiscovery({"reference": DEFINITION})
+    provider = FirstPartyModuleDiscovery()
     disabled = resolve_module_definitions(
         enabled_module_ids=(), discovery_providers=(provider,), host_version="0.2.0"
     )

--- a/backend/tests/test_module_scaffold.py
+++ b/backend/tests/test_module_scaffold.py
@@ -1,0 +1,236 @@
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CREATE_MODULE = ROOT / "scripts/create-module"
+
+
+def prepare_repository(root: Path) -> None:
+    for directory in (
+        root / "backend/app/modules",
+        root / "backend/tests/modules",
+        root / "frontend/frontend-modules",
+        root / "frontend/tests",
+        root / "frontend/app/pages",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+    (root / "backend/app/__init__.py").write_text(
+        "from pkgutil import extend_path\n__path__ = extend_path(__path__, __name__)\n",
+        encoding="utf-8",
+    )
+    (root / "backend/app/modules/__init__.py").write_text("", encoding="utf-8")
+    (root / "backend/tests/modules/__init__.py").write_text("", encoding="utf-8")
+
+
+def run_scaffold(root: Path, module_id: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CREATE_MODULE), module_id, "--root", str(root)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def generated_files(root: Path) -> set[str]:
+    return {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_valid_module_id_creates_minimal_backend_frontend_and_tests(tmp_path: Path) -> None:
+    prepare_repository(tmp_path)
+
+    result = run_scaffold(tmp_path, "hello-world")
+
+    assert result.returncode == 0, result.stderr
+    expected = {
+        "backend/app/modules/hello_world/__init__.py",
+        "backend/app/modules/hello_world/README.md",
+        "backend/app/modules/hello_world/settings.py",
+        "backend/app/modules/hello_world/module.py",
+        "backend/app/modules/hello_world/api/__init__.py",
+        "backend/app/modules/hello_world/api/router.py",
+        "backend/tests/modules/hello_world/__init__.py",
+        "backend/tests/modules/hello_world/test_module.py",
+        "frontend/frontend-modules/hello-world/module.json",
+        "frontend/frontend-modules/hello-world/layer/nuxt.config.ts",
+        "frontend/frontend-modules/hello-world/layer/app/pages/modules/hello-world.vue",
+        "frontend/tests/hello-world/module.test.ts",
+    }
+    assert expected <= generated_files(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "module_id",
+    ("Hello-World", "hello_world", "-hello", "hello--world", "hello!", "a" * 64),
+)
+def test_invalid_module_id_is_rejected_without_output(
+    tmp_path: Path,
+    module_id: str,
+) -> None:
+    prepare_repository(tmp_path)
+    before = generated_files(tmp_path)
+
+    result = run_scaffold(tmp_path, module_id)
+
+    assert result.returncode == 1
+    assert "lowercase kebab-case" in result.stderr
+    assert generated_files(tmp_path) == before
+
+
+def test_existing_target_is_never_overwritten(tmp_path: Path) -> None:
+    prepare_repository(tmp_path)
+    existing = tmp_path / "backend/app/modules/hello_world"
+    existing.mkdir()
+    marker = existing / "owned.py"
+    marker.write_text("owned = True\n", encoding="utf-8")
+
+    result = run_scaffold(tmp_path, "hello-world")
+
+    assert result.returncode == 1
+    assert "Refusing to overwrite" in result.stderr
+    assert marker.read_text(encoding="utf-8") == "owned = True\n"
+    assert not (tmp_path / "frontend/frontend-modules/hello-world").exists()
+
+
+def test_generated_ids_are_consistent_and_python_module_imports(tmp_path: Path) -> None:
+    prepare_repository(tmp_path)
+    assert run_scaffold(tmp_path, "hello-world").returncode == 0
+
+    definition = json.loads(
+        (tmp_path / "frontend/frontend-modules/hello-world/module.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert definition["id"] == definition["backendModuleId"] == "hello-world"
+    assert definition["publicContributions"]["ui"][0]["id"].startswith("hello-world.")
+
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(tmp_path / "backend"), str(ROOT / "backend"))
+    )
+    imported = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from app.modules.hello_world.module import DEFINITION, MANIFEST; "
+                "assert DEFINITION.declared_id == MANIFEST.id == 'hello-world'"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=environment,
+    )
+    assert imported.returncode == 0, imported.stderr
+    linted = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            str(tmp_path / "backend/app/modules/hello_world"),
+            str(tmp_path / "backend/tests/modules/hello_world"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=ROOT / "backend",
+    )
+    assert linted.returncode == 0, linted.stdout + linted.stderr
+
+
+def test_generated_frontend_satisfies_real_contract(tmp_path: Path) -> None:
+    prepare_repository(tmp_path)
+    assert run_scaffold(tmp_path, "hello-world").returncode == 0
+    discovery = (ROOT / "frontend/module-host/discovery.ts").as_uri()
+    script = f"""
+      import {{ resolveFrontendModules }} from {json.dumps(discovery)};
+      const modules = resolveFrontendModules({{
+        modulesDirectory: {json.dumps(str(tmp_path / 'frontend/frontend-modules'))},
+        appPagesDirectory: {json.dumps(str(tmp_path / 'frontend/app/pages'))},
+        enabledModules: 'hello-world',
+        backendModules: 'hello-world@1.0.0'
+      }});
+      if (modules.length !== 1 || modules[0].id !== 'hello-world') process.exit(1);
+    """
+
+    checked = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=ROOT / "frontend",
+    )
+    assert checked.returncode == 0, checked.stderr
+
+
+def test_generated_module_passes_existing_architecture_checks_without_host_patches(
+    tmp_path: Path,
+) -> None:
+    prepare_repository(tmp_path)
+    protected = {
+        path: f"unchanged: {path}\n"
+        for path in (
+            "backend/app/main.py",
+            "backend/app/api/router.py",
+            "backend/pyproject.toml",
+            "frontend/nuxt.config.ts",
+            "frontend/app/components/layout/AppShell.vue",
+            "frontend/app/components/map/MapCanvas.vue",
+        )
+    }
+    for relative, contents in protected.items():
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
+    assert run_scaffold(tmp_path, "hello-world").returncode == 0
+
+    architecture = tmp_path / "architecture"
+    architecture.mkdir()
+    shutil.copy(ROOT / "architecture/module-contract-rules.json", architecture)
+    (architecture / "module-boundary-baseline.json").write_text(
+        '{"version": 1, "entries": []}\n', encoding="utf-8"
+    )
+    backend_check = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/check_module_architecture.py"),
+            "--root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert backend_check.returncode == 0, backend_check.stderr
+
+    frontend_scanner = (ROOT / "frontend/module-host/import-boundaries.ts").as_uri()
+    frontend_script = f"""
+      import {{ scanFrontendArchitecture }} from {json.dumps(frontend_scanner)};
+      const violations = scanFrontendArchitecture({{
+        repositoryRoot: {json.dumps(str(tmp_path))},
+        frontendRoot: {json.dumps(str(tmp_path / 'frontend'))}
+      }});
+      if (violations.length) {{ console.error(JSON.stringify(violations)); process.exit(1); }}
+    """
+    frontend_check = subprocess.run(
+        ["node", "--input-type=module", "--eval", frontend_script],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=ROOT / "frontend",
+    )
+    assert frontend_check.returncode == 0, frontend_check.stderr
+    for relative, contents in protected.items():
+        assert (tmp_path / relative).read_text(encoding="utf-8") == contents

--- a/backend/tests/test_module_scaffold.py
+++ b/backend/tests/test_module_scaffold.py
@@ -150,32 +150,7 @@ def test_generated_ids_are_consistent_and_python_module_imports(tmp_path: Path) 
     assert linted.returncode == 0, linted.stdout + linted.stderr
 
 
-def test_generated_frontend_satisfies_real_contract(tmp_path: Path) -> None:
-    prepare_repository(tmp_path)
-    assert run_scaffold(tmp_path, "hello-world").returncode == 0
-    discovery = (ROOT / "frontend/module-host/discovery.ts").as_uri()
-    script = f"""
-      import {{ resolveFrontendModules }} from {json.dumps(discovery)};
-      const modules = resolveFrontendModules({{
-        modulesDirectory: {json.dumps(str(tmp_path / 'frontend/frontend-modules'))},
-        appPagesDirectory: {json.dumps(str(tmp_path / 'frontend/app/pages'))},
-        enabledModules: 'hello-world',
-        backendModules: 'hello-world@1.0.0'
-      }});
-      if (modules.length !== 1 || modules[0].id !== 'hello-world') process.exit(1);
-    """
-
-    checked = subprocess.run(
-        ["node", "--input-type=module", "--eval", script],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=ROOT / "frontend",
-    )
-    assert checked.returncode == 0, checked.stderr
-
-
-def test_generated_module_passes_existing_architecture_checks_without_host_patches(
+def test_generated_module_passes_backend_architecture_checks_without_host_patches(
     tmp_path: Path,
 ) -> None:
     prepare_repository(tmp_path)
@@ -214,23 +189,5 @@ def test_generated_module_passes_existing_architecture_checks_without_host_patch
         text=True,
     )
     assert backend_check.returncode == 0, backend_check.stderr
-
-    frontend_scanner = (ROOT / "frontend/module-host/import-boundaries.ts").as_uri()
-    frontend_script = f"""
-      import {{ scanFrontendArchitecture }} from {json.dumps(frontend_scanner)};
-      const violations = scanFrontendArchitecture({{
-        repositoryRoot: {json.dumps(str(tmp_path))},
-        frontendRoot: {json.dumps(str(tmp_path / 'frontend'))}
-      }});
-      if (violations.length) {{ console.error(JSON.stringify(violations)); process.exit(1); }}
-    """
-    frontend_check = subprocess.run(
-        ["node", "--input-type=module", "--eval", frontend_script],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=ROOT / "frontend",
-    )
-    assert frontend_check.returncode == 0, frontend_check.stderr
     for relative, contents in protected.items():
         assert (tmp_path / relative).read_text(encoding="utf-8") == contents

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 
 ## Architektur und Frontend
 
+- [Module Getting Started und Scaffold](modules/getting-started.md)
 - [ADR: Modularer Host und Grenzen von Fachmodulen](architecture/adr-modular-host-and-module-boundaries.md)
 - [ADR: Frontend-Module als Build-Time Nuxt Layers](architecture/adr-frontend-build-time-modules.md)
 - [ADR: Frontend UI Extension Points](architecture/adr-frontend-ui-extension-points.md)

--- a/docs/modules/backend-module-runtime.md
+++ b/docs/modules/backend-module-runtime.md
@@ -51,10 +51,12 @@ Kompatibilitätsinventar bleibt auf ID und Version begrenzt.
 
 ## Discovery-Quellen
 
-`FirstPartyModuleDiscovery` verwendet einen fachneutralen Katalog aus passiven
-`ModuleDefinition`-Objekten oder verzögerten Definition-Loadern. Ein neues
-First-Party-Modul benötigt dadurch keine Änderung an `main.py` oder
-`app/api/router.py`.
+`FirstPartyModuleDiscovery` lädt ausschließlich explizit aktivierte Built-ins nach
+der Repository-Konvention `backend/app/modules/<python_name>/module.py` mit dem
+passiven Export `DEFINITION`. Die öffentliche Kebab-Case-ID wird dabei
+deterministisch in einen Python-Namen mit Unterstrichen übersetzt. Ein neues
+First-Party-Modul benötigt dadurch weder einen zentralen Entry-Point-Eintrag noch
+eine Änderung an `main.py` oder `app/api/router.py`.
 
 `EntryPointModuleDiscovery` berücksichtigt ausschließlich die Python-Entry-Point-
 Gruppe `open_city_planner.modules`. Der Entry-Point-Name ist die aktivierbare

--- a/docs/modules/getting-started.md
+++ b/docs/modules/getting-started.md
@@ -1,0 +1,190 @@
+# Open City Planner Module – Getting Started
+
+> The reference module is the canonical executable SDK example.
+
+Diese Anleitung führt zum kleinsten Built-in-Fullstack-Modul mit GET-API und
+Nuxt-Seite. Das Scaffold kopiert bewusst keine Fachlogik des Reference-Moduls.
+Persistence, Permissions, Events, Jobs und Map-Erweiterungen kommen erst bei Bedarf
+hinzu.
+
+## 1. Voraussetzungen
+
+Installiere die in `.python-version`, `.node-version`, `backend/pyproject.toml` und
+`frontend/package.json` festgelegten Versionen. Richte anschließend die gelockten
+Abhängigkeiten ein:
+
+```bash
+cd backend
+uv sync --frozen --extra dev
+cd ../frontend
+pnpm install --frozen-lockfile
+cd ..
+```
+
+## 2. Modul erzeugen
+
+Vom Repository-Root erzeugt dieser Befehl ein Built-in-Modul:
+
+```bash
+./scripts/create-module hello-world
+```
+
+Modul-IDs sind stabile lowercase-ASCII-IDs in Kebab Case, beginnen mit einem
+Buchstaben und sind höchstens 63 Zeichen lang. `hello-world` wird für Python zu
+`hello_world`; Config, Permissions, Capabilities und Contributions behalten die
+öffentliche ID `hello-world`. Existierende Ziele werden nie überschrieben.
+
+## 3. Modulstruktur verstehen
+
+Das Scaffold erzeugt ausschließlich modulbezogene Dateien:
+
+```text
+backend/app/modules/hello_world/
+├── api/
+├── module.py
+├── settings.py
+└── README.md
+backend/tests/modules/hello_world/
+frontend/frontend-modules/hello-world/
+├── module.json
+└── layer/
+frontend/tests/hello-world/
+```
+
+`module.py` exportiert die passive `ModuleDefinition`. `module.json` verwendet
+dieselbe ID und deklariert Route, Navigation und Backend-Kompatibilität. Der Host
+erkennt Built-in-Backends nach der Verzeichniskonvention
+`app.modules.<python_name>.module:DEFINITION`; zentrale Router, `app.main`,
+Navigation, AppShell und `MapCanvas.vue` bleiben unverändert.
+
+Der vollständige Datenweg und alle optionalen SDK-Primitives stehen im
+[`reference`-Modul](../../backend/app/modules/reference/README.md). Das vorhandene
+`example-module` ist nur eine kompakte interne Frontend-Contract-Fixture und keine
+zweite Modul-Autorenvorlage.
+
+## 4. Backend-API weiterentwickeln
+
+Die generierte Route `GET /api/v1/modules/hello-world/hello` liegt in
+`api/router.py`. Registriere weitere Router ausschließlich über
+`context.api.include_router()` und importiere Plattformverträge aus
+`app.platform.modules.sdk`.
+
+Details: [Backend Module SDK](backend-module-sdk.md),
+[Manifest V1](module-manifest-v1.md) und
+[Settings](configuration.md).
+
+## 5. Frontend-Seite beitragen
+
+Die generierte Seite ist unter `/modules/hello-world` deklariert. Neue Pages müssen
+im eigenen Nuxt-Layer liegen und in `module.json` unter
+`publicContributions.routes` aufgeführt sein. Navigation und UI-Slots werden
+ebenfalls deklarativ beigetragen; Host-Komponenten werden nicht gepatcht.
+
+Details: [Frontend-Host](frontend-host.md) und
+[Frontend UI Contributions](frontend-ui-contributions.md).
+
+## 6. Optional einen Map Layer beitragen
+
+Das Scaffold startet mit leeren `map.sources` und `map.layers`. Ergänze Source und
+Layer erst bei fachlichem Bedarf in `module.json`; Runtime-Interaktionen verwenden
+Typen aus `#frontend-module-sdk`. IDs beginnen mit `hello-world.`.
+
+Details und ein ausführbares Beispiel:
+[Map SDK](map-sdk.md) und das
+[`reference`-Frontend](../../frontend/frontend-modules/reference/README.md).
+
+## 7. Modul lokal aktivieren
+
+Das Backend entdeckt das Built-in-Modul ohne zentralen Entry-Point-Eintrag:
+
+```bash
+cd backend
+export ENABLED_MODULES=hello-world
+uv run uvicorn app.main:app --reload
+```
+
+Erzeuge in einem zweiten Terminal das reale Backend-Inventar und starte dann den
+Frontend-Host:
+
+```bash
+cd backend
+export ENABLED_MODULES=hello-world
+export OCP_BACKEND_MODULES="$(../scripts/backend-module-inventory --format env)"
+cd ../frontend
+export OCP_FRONTEND_MODULES=hello-world
+pnpm modules:check
+pnpm dev
+```
+
+`OCP_BACKEND_MODULES` ist ein generierter ID-/Versions-Transport, keine zusätzliche
+Aktivierungsentscheidung. Optionale Settings verwenden das Präfix
+`OCP_MODULE_HELLO_WORLD_`.
+
+## 8. Tests ausführen
+
+```bash
+cd backend
+uv run pytest tests/modules/hello_world
+
+cd ../frontend
+OCP_FRONTEND_MODULES=hello-world \
+OCP_BACKEND_MODULES=hello-world@1.0.0 \
+pnpm vitest run tests/hello-world
+pnpm typecheck
+```
+
+Die generierten Tests validieren das echte Backend-SDK und den realen Frontend-
+Module-Contract; sie sind keine vollständigen Datei-Snapshots.
+
+## 9. Contract Gate ausführen
+
+```bash
+cd ..
+scripts/module-contract-gate
+```
+
+Das Gate kombiniert Manifest-, Runtime-, Frontend-, Map- und Architekturprüfungen.
+Generierter Backend-Code darf keine Host-Interna importieren; Frontend-Code nutzt
+eigene relative Dateien, `#frontend-module-sdk` oder `#imports`.
+
+## 10. Nächste Schritte
+
+Erweitere nur die benötigten Verträge:
+
+- [Persistence und Migrationen](database-and-migrations.md)
+- [Permissions](permissions.md)
+- [Domain Events](domain-events.md)
+- [Background Jobs](background-jobs.md)
+- [Map Extensions](map-sdk.md)
+- [Settings und Secrets](configuration.md)
+- [Security und Community Review](community-module-review.md)
+- [Architecture Rules](architecture-rules.md)
+
+## Built-in und zukünftige Standalone-Module
+
+Built-in First-Party-Module liegen heute direkt im Host-Repository:
+
+```text
+backend/app/modules/foo
+frontend/frontend-modules/foo
+```
+
+Sie werden gemeinsam mit dem Host gebaut und benötigen keinen Installer. Das
+Scaffold aus #110 erzeugt ausschließlich dieses Layout.
+
+Ein zukünftig separat gepflegtes Modul soll dieselben inneren SDK-Verträge in einem
+eigenen Repository bündeln:
+
+```text
+ocp-module-example/
+├── module.yaml
+├── backend/
+├── frontend/
+├── tests/
+└── README.md
+```
+
+Dieses Layout ist noch kein implementiertes Paketformat. Installation und
+`modules.lock` folgen in #173, das gemeinsame `.ocp` Package Bundle in #174 und die
+Distribution über eine Package Registry in #175. #110 führt weder Installer,
+Bundler noch Registry ein.

--- a/docs/modules/map-sdk.md
+++ b/docs/modules/map-sdk.md
@@ -66,9 +66,9 @@ IDs beginnen immer mit der Modul-ID. Die Layerdefinition enthält weder `id` noc
 `source`; die Registry bindet beide kontrolliert. Kleinere Prioritäten liegen in
 derselben Gruppe weiter unten. Die Gruppenreihenfolge ist im ADR festgelegt.
 
-Das `example-module` enthält ein lauffähiges Beispiel. Mit
-`OCP_FRONTEND_MODULES=example-module` erscheint seine Definition im gemeinsamen
-Build-Snapshot; ohne Aktivierung ist sie vollständig abwesend.
+Das kanonische `reference`-Modul enthält ein ausführbares End-to-End-Beispiel mit
+Source, Layer, Feature Info und sauberem Cleanup. Das kleinere `example-module`
+bleibt eine interne Frontend-Contract-Fixture.
 
 ## Interaction und Cleanup
 

--- a/docs/modules/reference-module.md
+++ b/docs/modules/reference-module.md
@@ -1,9 +1,14 @@
 # End-to-End-Referenzmodul
 
-Das installierbare Modul `reference` ist die ausführbare Entwicklerdokumentation für
-die Backend- und Frontend-Module-SDKs. Es ergänzt das bewusst minimale
-`example-module`: Das Example bleibt ein schnelles Frontend-Contract-Fixture, während
-`reference` den vollständigen Datenweg demonstriert.
+Das Built-in-Modul `reference` ist die kanonische ausführbare
+Entwicklerdokumentation für die Backend- und Frontend-Module-SDKs:
+
+> The reference module is the canonical executable SDK example.
+
+Es ist kein produktives Fachmodul. Das vorhandene `example-module` bleibt lediglich
+eine schnelle interne Frontend-Contract-Fixture; neue Module beginnen mit dem
+[Getting-Started-Scaffold](getting-started.md), während `reference` den vollständigen
+Datenweg demonstriert.
 
 ```text
 reference.items
@@ -21,7 +26,7 @@ lokales Nuxt-Layer ── Seite / Navigation / UI-Slot / Map / Feature-Info
 Der Host kennt dabei ausschließlich Entry-Points und öffentliche Contracts. Es gibt
 keinen Reference-Import im zentralen Router, in der Navigation oder im `MapCanvas`.
 Die vollständige, mit dem Code synchron gehaltene Anleitung einschließlich
-Aktivierung, Entfernung und Copy Guide steht im
+Aktivierung und Entfernung steht im
 [README des Moduls](../../backend/app/modules/reference/README.md).
 
 Für die lokale Contract-Prüfung:

--- a/frontend/frontend-modules/reference/README.md
+++ b/frontend/frontend-modules/reference/README.md
@@ -2,5 +2,7 @@
 
 Dieses lokale Nuxt-Layer ist die Frontend-Hälfte der ausführbaren
 [Reference-Module-Dokumentation](../../../backend/app/modules/reference/README.md).
-Manifest, Aktivierung, Deaktivierung, Copy Guide und vollständige Tests sind dort
-gemeinsam für Backend und Frontend beschrieben.
+Manifest, Aktivierung, Deaktivierung und vollständige Tests sind dort gemeinsam für
+Backend und Frontend beschrieben. Neue Module beginnen mit dem
+[Getting-Started-Scaffold](../../../docs/modules/getting-started.md), statt dieses
+vollständige Reference-Modul zu kopieren.

--- a/frontend/tests/module-scaffold/module-scaffold.test.ts
+++ b/frontend/tests/module-scaffold/module-scaffold.test.ts
@@ -1,0 +1,79 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveFrontendModules } from '../../module-host/discovery'
+import { scanFrontendArchitecture } from '../../module-host/import-boundaries'
+
+const repositoryRoot = resolve(import.meta.dirname, '../../..')
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+function generateScaffold(moduleId = 'hello-world') {
+  const root = mkdtempSync(resolve(tmpdir(), 'ocp-module-scaffold-'))
+  temporaryDirectories.push(root)
+  for (const directory of [
+    'backend/app/modules',
+    'backend/tests/modules',
+    'frontend/frontend-modules',
+    'frontend/tests',
+    'frontend/app/pages'
+  ]) {
+    mkdirSync(resolve(root, directory), { recursive: true })
+  }
+
+  const result = spawnSync(
+    'python3',
+    [resolve(repositoryRoot, 'scripts/create-module'), moduleId, '--root', root],
+    { encoding: 'utf8' }
+  )
+  expect(result.error).toBeUndefined()
+  expect(result.status, result.stderr).toBe(0)
+
+  return {
+    root,
+    frontendRoot: resolve(root, 'frontend'),
+    modulesDirectory: resolve(root, 'frontend/frontend-modules'),
+    appPagesDirectory: resolve(root, 'frontend/app/pages')
+  }
+}
+
+describe('generated frontend module scaffold', () => {
+  it('satisfies real discovery, manifest and contribution contracts', () => {
+    const paths = generateScaffold()
+
+    const modules = resolveFrontendModules({
+      modulesDirectory: paths.modulesDirectory,
+      appPagesDirectory: paths.appPagesDirectory,
+      enabledModules: 'hello-world',
+      backendModules: 'hello-world@1.0.0'
+    })
+
+    expect(modules).toHaveLength(1)
+    expect(modules[0]).toMatchObject({
+      id: 'hello-world',
+      backendModuleId: 'hello-world',
+      publicContributions: {
+        routes: [{
+          path: '/modules/hello-world',
+          source: 'layer/app/pages/modules/hello-world.vue'
+        }]
+      }
+    })
+  })
+
+  it('passes the real frontend architecture scanner', () => {
+    const paths = generateScaffold()
+
+    expect(scanFrontendArchitecture({
+      repositoryRoot: paths.root,
+      frontendRoot: paths.frontendRoot
+    })).toEqual([])
+  })
+})

--- a/scripts/create-module
+++ b/scripts/create-module
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Create a minimal built-in Open City Planner module from maintained templates."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_ROOT = Path(__file__).resolve().parent / "templates/module"
+MODULE_ID_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+MAX_MODULE_ID_LENGTH = 63
+
+TEMPLATES = {
+    "backend/__init__.py.tmpl": "backend/app/modules/{python_name}/__init__.py",
+    "backend/README.md.tmpl": "backend/app/modules/{python_name}/README.md",
+    "backend/settings.py.tmpl": "backend/app/modules/{python_name}/settings.py",
+    "backend/module.py.tmpl": "backend/app/modules/{python_name}/module.py",
+    "backend/api/__init__.py.tmpl": "backend/app/modules/{python_name}/api/__init__.py",
+    "backend/api/router.py.tmpl": "backend/app/modules/{python_name}/api/router.py",
+    "backend-test/__init__.py.tmpl": "backend/tests/modules/{python_name}/__init__.py",
+    "backend-test/test_module.py.tmpl": "backend/tests/modules/{python_name}/test_module.py",
+    "frontend/module.json.tmpl": "frontend/frontend-modules/{module_id}/module.json",
+    "frontend/layer/nuxt.config.ts.tmpl": (
+        "frontend/frontend-modules/{module_id}/layer/nuxt.config.ts"
+    ),
+    "frontend/layer/app/pages/module.vue.tmpl": (
+        "frontend/frontend-modules/{module_id}/layer/app/pages/modules/{module_id}.vue"
+    ),
+    "frontend-test/module.test.ts.tmpl": "frontend/tests/{module_id}/module.test.ts",
+}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("module_id", help="Stable lowercase kebab-case module ID")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPOSITORY_ROOT,
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args(argv)
+
+
+def validate_module_id(module_id: str) -> None:
+    if len(module_id) > MAX_MODULE_ID_LENGTH or not MODULE_ID_PATTERN.fullmatch(module_id):
+        raise ValueError(
+            "Module IDs must be lowercase kebab-case, start with a letter, "
+            "and contain at most 63 characters."
+        )
+
+
+def template_values(module_id: str) -> dict[str, str]:
+    words = module_id.split("-")
+    python_name = module_id.replace("-", "_")
+    class_name = "".join(word[:1].upper() + word[1:] for word in words)
+    return {
+        "MODULE_ID": module_id,
+        "PYTHON_NAME": python_name,
+        "CLASS_NAME": class_name,
+        "DISPLAY_NAME": " ".join(word[:1].upper() + word[1:] for word in words),
+        "ENV_PREFIX": python_name.upper(),
+        "SCHEMA_NAME": python_name,
+    }
+
+
+def render(template: str, values: dict[str, str]) -> str:
+    rendered = template
+    for name, value in values.items():
+        rendered = rendered.replace(f"{{{{{name}}}}}", value)
+    if re.search(r"\{\{[A-Z_]+\}\}", rendered):
+        raise ValueError("The module template contains an unknown placeholder.")
+    return rendered
+
+
+def create_module(module_id: str, root: Path) -> tuple[Path, ...]:
+    validate_module_id(module_id)
+    root = root.resolve()
+    required_parents = (
+        root / "backend/app/modules",
+        root / "backend/tests/modules",
+        root / "frontend/frontend-modules",
+        root / "frontend/tests",
+    )
+    missing = [path for path in required_parents if not path.is_dir()]
+    if missing:
+        raise ValueError(f"Repository module directory does not exist: {missing[0]}")
+
+    values = template_values(module_id)
+    format_values = {
+        "module_id": module_id,
+        "python_name": values["PYTHON_NAME"],
+    }
+    targets = tuple(
+        root / destination.format(**format_values) for destination in TEMPLATES.values()
+    )
+    module_roots = (
+        root / f"backend/app/modules/{values['PYTHON_NAME']}",
+        root / f"backend/tests/modules/{values['PYTHON_NAME']}",
+        root / f"frontend/frontend-modules/{module_id}",
+        root / f"frontend/tests/{module_id}",
+    )
+    existing = [path for path in module_roots if path.exists()]
+    if existing:
+        raise FileExistsError(f"Refusing to overwrite existing module target: {existing[0]}")
+
+    rendered = tuple(
+        (
+            target,
+            render((TEMPLATE_ROOT / template).read_text(encoding="utf-8"), values),
+        )
+        for (template, _), target in zip(TEMPLATES.items(), targets, strict=True)
+    )
+    for target, contents in rendered:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
+    return targets
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw_args = list(sys.argv[1:] if argv is None else argv)
+    if raw_args and raw_args[0].startswith("-") and raw_args[0] not in {"-h", "--help"}:
+        print(
+            "create-module: Module IDs must be lowercase kebab-case, start with a letter, "
+            "and contain at most 63 characters.",
+            file=sys.stderr,
+        )
+        return 1
+    args = parse_args(raw_args)
+    try:
+        targets = create_module(args.module_id, args.root)
+    except (FileExistsError, OSError, ValueError) as error:
+        print(f"create-module: {error}", file=sys.stderr)
+        return 1
+    print(f'Created built-in module "{args.module_id}" ({len(targets)} files).')
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/module-contract-gate
+++ b/scripts/module-contract-gate
@@ -20,6 +20,7 @@ run_frontend() {
     tests/frontend-ui-contributions.test.ts \
     tests/map-runtime.test.ts \
     tests/map-sdk.test.ts \
+    tests/module-scaffold/module-scaffold.test.ts \
     tests/reference-module/reference-module.test.ts
   pnpm test:modules:ssr
 }

--- a/scripts/templates/module/backend-test/__init__.py.tmpl
+++ b/scripts/templates/module/backend-test/__init__.py.tmpl
@@ -1,0 +1,1 @@
+"""Tests for the {{MODULE_ID}} module."""

--- a/scripts/templates/module/backend-test/test_module.py.tmpl
+++ b/scripts/templates/module/backend-test/test_module.py.tmpl
@@ -1,0 +1,29 @@
+from app.modules.{{PYTHON_NAME}}.api import create_router
+from app.modules.{{PYTHON_NAME}}.module import (
+    CONFIG_NAMESPACE,
+    DEFINITION,
+    MANIFEST,
+    PERMISSION_NAMESPACE,
+    PERSISTENCE_SCHEMA,
+)
+from app.modules.{{PYTHON_NAME}}.settings import {{CLASS_NAME}}Settings
+
+from app.platform.modules.testing import ModuleTestHost
+
+
+def test_generated_namespaces_are_consistent() -> None:
+    assert MANIFEST.id == "{{MODULE_ID}}"
+    assert MANIFEST.config is not None
+    assert MANIFEST.config.namespace == CONFIG_NAMESPACE == "{{MODULE_ID}}"
+    assert PERMISSION_NAMESPACE == "{{MODULE_ID}}."
+    assert PERSISTENCE_SCHEMA == "{{SCHEMA_NAME}}"
+    assert all(item.startswith("{{MODULE_ID}}.") for item in MANIFEST.capabilities)
+    assert MANIFEST.permissions == []
+    assert DEFINITION.settings is not None
+    assert DEFINITION.settings.namespace == CONFIG_NAMESPACE
+
+
+def test_generated_module_registers_with_the_public_test_host() -> None:
+    ModuleTestHost(DEFINITION).register()
+    router = create_router({{CLASS_NAME}}Settings())
+    assert {route.path for route in router.routes} == {"/hello"}

--- a/scripts/templates/module/backend/README.md.tmpl
+++ b/scripts/templates/module/backend/README.md.tmpl
@@ -1,0 +1,16 @@
+# {{DISPLAY_NAME}} Module
+
+Dieses minimale Built-in-Modul wurde mit `scripts/create-module {{MODULE_ID}}`
+erzeugt. Es registriert eine kleine GET-API und besitzt ein passendes Frontend-Layer.
+
+Stabile Namespaces:
+
+- Modul und Config: `{{MODULE_ID}}`
+- Python-Paket und späteres Datenbankschema: `{{PYTHON_NAME}}`
+- Environment-Präfix: `OCP_MODULE_{{ENV_PREFIX}}_`
+- Permissions: `{{MODULE_ID}}.*`
+- Contributions und Capabilities: `{{MODULE_ID}}.*`
+
+Das Modul startet absichtlich ohne Persistence, Events, Jobs oder Kartenbeiträge.
+Erweiterungen folgen den öffentlichen Verträgen aus
+[`docs/modules/getting-started.md`](../../../../docs/modules/getting-started.md).

--- a/scripts/templates/module/backend/__init__.py.tmpl
+++ b/scripts/templates/module/backend/__init__.py.tmpl
@@ -1,0 +1,1 @@
+"""Built-in {{DISPLAY_NAME}} module."""

--- a/scripts/templates/module/backend/api/__init__.py.tmpl
+++ b/scripts/templates/module/backend/api/__init__.py.tmpl
@@ -1,0 +1,3 @@
+from .router import create_router
+
+__all__ = ["create_router"]

--- a/scripts/templates/module/backend/api/router.py.tmpl
+++ b/scripts/templates/module/backend/api/router.py.tmpl
@@ -1,0 +1,23 @@
+"""Public HTTP API for the {{MODULE_ID}} module."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel, ConfigDict
+
+from ..settings import {{CLASS_NAME}}Settings
+
+
+class {{CLASS_NAME}}Greeting(BaseModel):
+    module: str
+    message: str
+
+    model_config = ConfigDict(frozen=True)
+
+
+def create_router(settings: {{CLASS_NAME}}Settings) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/hello", response_model={{CLASS_NAME}}Greeting)
+    async def hello() -> {{CLASS_NAME}}Greeting:
+        return {{CLASS_NAME}}Greeting(module="{{MODULE_ID}}", message=settings.greeting)
+
+    return router

--- a/scripts/templates/module/backend/module.py.tmpl
+++ b/scripts/templates/module/backend/module.py.tmpl
@@ -1,0 +1,59 @@
+"""Composition root for the {{MODULE_ID}} module."""
+
+from app.platform.modules.sdk import (
+    ModuleContext,
+    ModuleDefinition,
+    ModuleSettingsContribution,
+    parse_manifest,
+)
+
+from .api import create_router
+from .settings import {{CLASS_NAME}}Settings
+
+CONFIG_NAMESPACE = "{{MODULE_ID}}"
+PERMISSION_NAMESPACE = "{{MODULE_ID}}."
+PERSISTENCE_SCHEMA = "{{SCHEMA_NAME}}"
+
+MANIFEST = parse_manifest(
+    {
+        "manifest_version": 1,
+        "id": "{{MODULE_ID}}",
+        "name": "{{DISPLAY_NAME}}",
+        "version": "1.0.0",
+        "requires": {"host": ">=0.2.0,<1.0.0", "sdk": ">=1.7.0,<2.0.0"},
+        "backend": {"package": "open-city-map-backend"},
+        "frontend": {"package": "{{MODULE_ID}}"},
+        "capabilities": ["{{MODULE_ID}}.api", "{{MODULE_ID}}.page"],
+        "permissions": [],
+        "config": {"namespace": CONFIG_NAMESPACE},
+    },
+    origin=__name__,
+)
+
+
+class {{CLASS_NAME}}Module:
+    manifest = MANIFEST
+
+    def register(self, context: ModuleContext) -> None:
+        configured = context.settings.get({{CLASS_NAME}}Settings) if context.settings else None
+        settings = (
+            configured if isinstance(configured, {{CLASS_NAME}}Settings) else {{CLASS_NAME}}Settings()
+        )
+        context.api.include_router(
+            create_router(settings),
+            prefix="/api/v1/modules/{{MODULE_ID}}",
+            tags=("{{DISPLAY_NAME}} module",),
+        )
+
+
+DEFINITION = ModuleDefinition(
+    manifest=MANIFEST,
+    loader={{CLASS_NAME}}Module,
+    origin=__name__,
+    declared_id=MANIFEST.id,
+    settings=ModuleSettingsContribution(
+        module_id=MANIFEST.id,
+        namespace=CONFIG_NAMESPACE,
+        model={{CLASS_NAME}}Settings,
+    ),
+)

--- a/scripts/templates/module/backend/settings.py.tmpl
+++ b/scripts/templates/module/backend/settings.py.tmpl
@@ -1,0 +1,14 @@
+"""Typed settings owned by the {{MODULE_ID}} module."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class {{CLASS_NAME}}Settings(BaseModel):
+    greeting: str = Field(
+        default="Hallo aus dem {{DISPLAY_NAME}}-Modul.",
+        min_length=1,
+        max_length=160,
+        json_schema_extra={"public": True},
+    )
+
+    model_config = ConfigDict(frozen=True)

--- a/scripts/templates/module/frontend-test/module.test.ts.tmpl
+++ b/scripts/templates/module/frontend-test/module.test.ts.tmpl
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveFrontendModules } from '../../module-host/discovery'
+
+const frontendRoot = fileURLToPath(new URL('../..', import.meta.url))
+
+describe('{{MODULE_ID}} frontend module', () => {
+  it('satisfies the real frontend module contract', () => {
+    const modules = resolveFrontendModules({
+      modulesDirectory: resolve(frontendRoot, 'frontend-modules'),
+      appPagesDirectory: resolve(frontendRoot, 'app/pages'),
+      enabledModules: '{{MODULE_ID}}',
+      backendModules: '{{MODULE_ID}}@1.0.0'
+    })
+
+    expect(modules.map(module => module.id)).toEqual(['{{MODULE_ID}}'])
+    expect(modules[0]?.publicContributions.ui[0]?.id)
+      .toBe('{{MODULE_ID}}.primary-navigation')
+  })
+})

--- a/scripts/templates/module/frontend/layer/app/pages/module.vue.tmpl
+++ b/scripts/templates/module/frontend/layer/app/pages/module.vue.tmpl
@@ -1,0 +1,22 @@
+<template>
+  <ContentPageShell
+    title="{{DISPLAY_NAME}}"
+    description="Minimaler Einstieg für das {{DISPLAY_NAME}}-Modul."
+    eyebrow="Built-in-Modul"
+    :breadcrumbs="[{ label: 'Startseite', to: '/' }, { label: '{{DISPLAY_NAME}}' }]"
+  >
+    <p class="text-sm text-slate-700 dark:text-slate-200">
+      Die Backend-API ist unter <code>/api/v1/modules/{{MODULE_ID}}/hello</code> erreichbar.
+    </p>
+  </ContentPageShell>
+</template>
+
+<script setup lang="ts">
+usePageSeo({
+  title: '{{DISPLAY_NAME}}',
+  description: 'Minimaler Einstieg für das {{DISPLAY_NAME}}-Modul.',
+  path: '/modules/{{MODULE_ID}}',
+  robots: 'noindex,nofollow',
+  structuredData: false
+})
+</script>

--- a/scripts/templates/module/frontend/layer/nuxt.config.ts.tmpl
+++ b/scripts/templates/module/frontend/layer/nuxt.config.ts.tmpl
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/scripts/templates/module/frontend/module.json.tmpl
+++ b/scripts/templates/module/frontend/module.json.tmpl
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "id": "{{MODULE_ID}}",
+  "version": "1.0.0",
+  "backendModuleId": "{{MODULE_ID}}",
+  "compatibility": {
+    "host": ">=1.0.0 <2.0.0",
+    "sdk": ">=1.2.0 <2.0.0",
+    "backend": ">=1.0.0 <2.0.0"
+  },
+  "layer": "layer",
+  "requires": { "modules": {} },
+  "publicContributions": {
+    "routes": [
+      {
+        "path": "/modules/{{MODULE_ID}}",
+        "source": "layer/app/pages/modules/{{MODULE_ID}}.vue"
+      }
+    ],
+    "ui": [
+      {
+        "id": "{{MODULE_ID}}.primary-navigation",
+        "slot": "navigation.primary",
+        "priority": 300,
+        "visibility": { "auth": "public", "module": "{{MODULE_ID}}" },
+        "label": "{{DISPLAY_NAME}}",
+        "to": "/modules/{{MODULE_ID}}",
+        "exact": true
+      }
+    ],
+    "map": { "sources": [], "layers": [] }
+  }
+}


### PR DESCRIPTION
## Problem

Neue Built-in-Module hatten bisher keinen kleinen, reproduzierbaren Einstieg. Das Reference-Modul zeigt bewusst den vollständigen SDK-Datenweg, ist als Kopiervorlage aber zu umfangreich. Außerdem benötigten Built-ins bislang zentrale Python-Entry-Point-Einträge.

## Lösung

- ergänzt den dünnen Generator `./scripts/create-module` mit gepflegten Backend-, Frontend- und Test-Templates
- validiert stabile Kebab-Case-IDs, leitet Python-/Namespace-Namen deterministisch ab und überschreibt keine vorhandenen Ziele
- erzeugt eine minimale GET-API, Nuxt-Seite und Tests gegen die öffentlichen SDK-/Host-Verträge
- vervollständigt die bestehende `FirstPartyModuleDiscovery` um konventionsbasierte Built-in-Erkennung
- verändert weder Main, Router, Navigation, AppShell noch MapCanvas
- behält die `EntryPointModuleDiscovery` für künftig installierte Standalone-Module bei
- dokumentiert den realen Inventory-/Environment-Aktivierungsweg
- erklärt `reference` ausdrücklich zum kanonischen ausführbaren SDK-Beispiel
- grenzt Installer/`modules.lock` (#173), `.ocp`-Bundle (#174) und Registry (#175) als Follow-ups ab

## Betroffene Bereiche

- Backend Module Discovery und Scaffold-Regressionstests
- Frontend-/Backend-Modultemplates
- Module Getting Started und Reference-Dokumentation

## Validierung

- Backend Ruff: erfolgreich
- Backend Pytest: 872 bestanden
- Backend App-Import: erfolgreich
- Frontend Vitest: 503 bestanden
- Frontend Typecheck: erfolgreich
- Frontend Production Build: erfolgreich
- Frontend Sprach-Audit: 552 Ressourcen, 0 Treffer
- Module Contract Gate: 260 Backend-, 43 Frontend- und 3 SSR-Tests bestanden
- Backend- und Frontend-Architekturprüfungen: erfolgreich
- Supply-Chain-Verifikation: erfolgreich
- `uv lock --check`: erfolgreich
- `git diff --check`: erfolgreich

## Migration, Konfiguration und Rollout

Keine Datenbankmigration und keine neue produktive Pflichtkonfiguration.

Neue Built-ins werden wie bestehende Module explizit über `ENABLED_MODULES` und `OCP_FRONTEND_MODULES` aktiviert. Ein Rollback ist durch Revert des fokussierten Commits möglich.

Closes #110
Part of #91
Coordinates #108

Follow-up: #173 #174 #175