### PR TITLE
feat(modules): expose operational runtime status

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -14,6 +14,7 @@ from app.cache.service import cache_service
 from app.core.config import get_settings
 from app.models.social_publication import SocialPublicationOutbox
 from app.models.user import User
+from app.platform.modules import ModuleOperationalStatusResponse, ModuleRuntime
 from app.schemas.admin import (
     AdminRoleRead,
     AdminUserListRead,
@@ -600,6 +601,25 @@ async def get_cache_stats(
 ) -> dict:
     private_no_store(response)
     return await cache_service.stats()
+
+
+@router.get(
+    "/modules/status",
+    response_model=ModuleOperationalStatusResponse,
+    summary="Operationalen Modulstatus anzeigen",
+)
+async def get_module_operational_status(
+    request: Request,
+    response: Response,
+    _actor: Annotated[User, Depends(require_superuser)],
+) -> ModuleOperationalStatusResponse:
+    """Return safe runtime facts without exposing settings or internal origins."""
+
+    private_no_store(response)
+    runtime = getattr(request.app.state, "module_runtime", None)
+    if not isinstance(runtime, ModuleRuntime):
+        raise HTTPException(status_code=503, detail="Module runtime is unavailable.")
+    return runtime.operational_status
 
 
 @router.post("/cache/invalidate")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -181,6 +181,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 app.state.permission_engine = permission_engine
+app.state.module_runtime = module_runtime
 
 app.add_middleware(GZipMiddleware, minimum_size=1_000, compresslevel=5)
 app.add_middleware(RequestBodyLimitMiddleware)

--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -73,6 +73,11 @@ from app.platform.modules.manifest import (
     validate_manifest,
     validate_manifests,
 )
+from app.platform.modules.operations import (
+    ModuleOperationalDependencyStatus,
+    ModuleOperationalStatus,
+    ModuleOperationalStatusResponse,
+)
 from app.platform.modules.permissions import (
     LegacyRolePermissionResolver,
     PermissionEngine,
@@ -140,6 +145,9 @@ __all__ = [
     "ModuleManifestError",
     "ModuleManifestV1",
     "ModuleMigrationSource",
+    "ModuleOperationalDependencyStatus",
+    "ModuleOperationalStatus",
+    "ModuleOperationalStatusResponse",
     "ModuleOptionalRequirements",
     "ModulePersistence",
     "ModulePersistenceContribution",

--- a/backend/app/platform/modules/operations.py
+++ b/backend/app/platform/modules/operations.py
@@ -1,0 +1,71 @@
+"""Read-only operational projection of the active backend module runtime."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.platform.modules.manifest import (
+    ModuleId,
+    NamespacedId,
+    SemanticVersion,
+    SemanticVersionRange,
+)
+
+type ModuleRuntimeStatus = Literal["loaded", "registered", "running"]
+type SafeModuleOrigin = Literal["built-in", "entry-point", "unknown"]
+
+
+class OperationalStatusModel(BaseModel):
+    """Strict immutable base for host-owned operational response models."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class ModuleOperationalDependencyStatus(OperationalStatusModel):
+    """One already validated dependency resolved in the active runtime."""
+
+    id: ModuleId
+    requirement: SemanticVersionRange
+    resolved: SemanticVersion
+    optional: bool
+    compatible: Literal[True] = True
+
+
+class ModuleOperationalStatus(OperationalStatusModel):
+    """Small, safe projection of one active module record."""
+
+    id: ModuleId
+    version: SemanticVersion
+    status: ModuleRuntimeStatus
+    enabled: Literal[True] = True
+    registered: bool
+    capabilities: tuple[NamespacedId, ...]
+    dependencies: tuple[ModuleOperationalDependencyStatus, ...]
+    origin: SafeModuleOrigin
+    job_count: int = Field(ge=0)
+
+
+class ModuleOperationalStatusResponse(OperationalStatusModel):
+    """Administrative operational snapshot for all active runtime records."""
+
+    modules: tuple[ModuleOperationalStatus, ...]
+
+
+def safe_module_origin(origin: str) -> SafeModuleOrigin:
+    """Reduce internal import/entry-point details to a bounded public category."""
+
+    if origin.startswith("app.modules."):
+        return "built-in"
+    if origin.startswith("entry-point:"):
+        return "entry-point"
+    return "unknown"
+
+
+__all__ = [
+    "ModuleOperationalDependencyStatus",
+    "ModuleOperationalStatus",
+    "ModuleOperationalStatusResponse",
+    "ModuleRuntimeStatus",
+    "SafeModuleOrigin",
+    "safe_module_origin",
+]

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -24,6 +24,12 @@ from app.platform.modules.errors import (
 )
 from app.platform.modules.jobs import JobRegistry
 from app.platform.modules.manifest import ModuleManifestV1, parse_manifest, validate_manifests
+from app.platform.modules.operations import (
+    ModuleOperationalDependencyStatus,
+    ModuleOperationalStatus,
+    ModuleOperationalStatusResponse,
+    safe_module_origin,
+)
 from app.platform.modules.permissions import PermissionRegistry
 from app.platform.modules.sdk import BackendModule, ModuleContext, ModuleDefinition
 from app.platform.modules.services import ServiceRegistry
@@ -108,6 +114,54 @@ class ModuleRuntime:
     def job_registry(self) -> JobRegistry | None:
         return self._job_registry
 
+    @property
+    def operational_status(self) -> ModuleOperationalStatusResponse:
+        """Project current runtime facts without storing a second lifecycle state."""
+
+        versions = {
+            record.manifest.id: record.manifest.version for record in self.registry.records
+        }
+        job_counts: dict[str, int] = {}
+        if self._job_registry is not None:
+            for descriptor in self._job_registry.jobs:
+                job_counts[descriptor.module_id] = job_counts.get(descriptor.module_id, 0) + 1
+
+        modules = []
+        for record in self.registry.records:
+            status = "running" if self._running else "registered" if record.registered else "loaded"
+            dependencies = [
+                ModuleOperationalDependencyStatus(
+                    id=module_id,
+                    requirement=requirement,
+                    resolved=versions[module_id],
+                    optional=False,
+                )
+                for module_id, requirement in sorted(record.manifest.requires.modules.items())
+            ]
+            dependencies.extend(
+                ModuleOperationalDependencyStatus(
+                    id=module_id,
+                    requirement=requirement,
+                    resolved=versions[module_id],
+                    optional=True,
+                )
+                for module_id, requirement in sorted(record.manifest.optional.modules.items())
+                if module_id in versions
+            )
+            modules.append(
+                ModuleOperationalStatus(
+                    id=record.manifest.id,
+                    version=record.manifest.version,
+                    status=status,
+                    registered=record.registered,
+                    capabilities=tuple(record.manifest.capabilities),
+                    dependencies=tuple(dependencies),
+                    origin=safe_module_origin(record.origin),
+                    job_count=job_counts.get(record.manifest.id, 0),
+                )
+            )
+        return ModuleOperationalStatusResponse(modules=tuple(modules))
+
     def register(self, app: FastAPI) -> None:
         """Deklariere Beiträge einmalig und binde Router kontrolliert an den Host."""
 
@@ -122,6 +176,7 @@ class ModuleRuntime:
                 record.registration.close()
             except Exception as exc:
                 record.registration.close()
+                logger.exception("Module registration failed", extra=fields)
                 raise ModuleRegistrationError(
                     "The module register() hook failed.",
                     module_id=record.manifest.id,
@@ -161,16 +216,20 @@ class ModuleRuntime:
             raise ModuleStartupError("The module runtime has already been started.")
 
         for record in self.registry.records:
+            fields = _log_fields(record, "startup")
+            logger.info("Module startup started", extra=fields)
             for contribution in record.registration.lifecycle:
                 try:
                     if contribution.startup is not None:
                         await contribution.startup()
                     self._started.append((record, contribution))
                 except Exception as exc:
+                    logger.exception("Module startup failed", extra=fields)
                     await self._cleanup_after_startup_failure()
                     raise ModuleStartupError(
                         "A module startup hook failed.", module_id=record.manifest.id
                     ) from exc
+            logger.info("Module startup completed", extra=fields)
         self._running = True
 
     async def shutdown(self) -> None:

--- a/backend/tests/test_health_endpoints.py
+++ b/backend/tests/test_health_endpoints.py
@@ -19,6 +19,19 @@ async def test_health_live_is_liveness_only() -> None:
 
 
 @pytest.mark.asyncio
+async def test_public_health_info_does_not_expose_module_operations() -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=main_module.app),
+        base_url="https://api.stadtplaner.oklabflensburg.de",
+    ) as client:
+        response = await client.get("/health/info")
+
+    assert response.status_code == 200
+    assert set(response.json()) == {"version", "release_sha", "environment"}
+    assert "modules" not in response.text
+
+
+@pytest.mark.asyncio
 async def test_health_ready_reports_database_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_database_health() -> str:
         return "down"

--- a/backend/tests/test_module_operations.py
+++ b/backend/tests/test_module_operations.py
@@ -1,0 +1,194 @@
+import logging
+from dataclasses import replace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.api.admin import router as admin_router
+from app.auth.dependencies import require_superuser
+from app.platform.modules import (
+    FirstPartyModuleDiscovery,
+    JobDefinition,
+    ModuleContext,
+    ModuleDefinition,
+    create_module_runtime,
+    parse_manifest,
+)
+from app.platform.modules.operations import safe_module_origin
+from tests.test_module_runtime import definition, manifest_data, runtime_for
+
+
+def test_real_enabled_analysis_areas_module_is_visible_with_manifest_capabilities() -> None:
+    runtime = create_module_runtime(
+        enabled_module_ids=("analysis-areas",),
+        discovery_providers=(FirstPartyModuleDiscovery(),),
+        host_version="0.2.0",
+    )
+
+    module = runtime.operational_status.modules[0]
+    assert module.id == "analysis-areas"
+    assert module.version == "1.0.0"
+    assert module.origin == "built-in"
+    assert module.capabilities == (
+        "analysis-areas.public-api",
+        "analysis-areas.lookup",
+        "analysis-areas.geojson",
+    )
+
+
+def test_status_projects_only_enabled_records_and_validated_dependencies() -> None:
+    runtime = runtime_for(
+        [
+            definition("base-module", capabilities=["base-module.read"]),
+            definition(
+                "consumer",
+                required={"base-module": ">=1.0.0,<2.0.0"},
+                optional={"disabled-module": ">=1.0.0,<2.0.0"},
+                capabilities=["consumer.read"],
+            ),
+            definition("disabled-module"),
+        ],
+        enabled=("consumer", "base-module"),
+    )
+
+    payload = runtime.operational_status.model_dump(mode="json")
+
+    assert [module["id"] for module in payload["modules"]] == ["base-module", "consumer"]
+    assert payload["modules"][0] == {
+        "id": "base-module",
+        "version": "1.0.0",
+        "status": "loaded",
+        "enabled": True,
+        "registered": False,
+        "capabilities": ["base-module.read"],
+        "dependencies": [],
+        "origin": "unknown",
+        "job_count": 0,
+    }
+    assert payload["modules"][1]["dependencies"] == [
+        {
+            "id": "base-module",
+            "requirement": ">=1.0.0,<2.0.0",
+            "resolved": "1.0.0",
+            "optional": False,
+            "compatible": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_status_is_derived_from_registration_and_running_flags() -> None:
+    runtime = runtime_for([definition("example-module")])
+    assert runtime.operational_status.modules[0].status == "loaded"
+
+    runtime.register(FastAPI())
+    registered = runtime.operational_status.modules[0]
+    assert registered.status == "registered"
+    assert registered.registered is True
+
+    await runtime.startup()
+    assert runtime.operational_status.modules[0].status == "running"
+
+    await runtime.shutdown()
+    assert runtime.operational_status.modules[0].status == "registered"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_logs_keep_bounded_module_fields(caplog: pytest.LogCaptureFixture) -> None:
+    runtime = runtime_for([definition("example-module")])
+
+    with caplog.at_level(logging.INFO, logger="app.platform.modules.runtime"):
+        runtime.register(FastAPI())
+        await runtime.startup()
+
+    lifecycle = [
+        record
+        for record in caplog.records
+        if getattr(record, "module_id", None) == "example-module"
+    ]
+    assert [record.getMessage() for record in lifecycle] == [
+        "Module registration started",
+        "Module registration completed",
+        "Module startup started",
+        "Module startup completed",
+    ]
+    assert {record.module_version for record in lifecycle} == {"1.0.0"}
+    assert {record.module_phase for record in lifecycle} == {"registration", "startup"}
+
+
+def test_status_counts_only_jobs_registered_for_each_module() -> None:
+    manifest = parse_manifest(manifest_data("job-module"))
+
+    class JobModule:
+        def __init__(self) -> None:
+            self.manifest = manifest
+
+        def register(self, context: ModuleContext) -> None:
+            assert context.scheduler is not None
+
+            async def refresh(_context: ModuleContext) -> None:
+                return None
+
+            context.scheduler.register(JobDefinition(job_id="refresh", handler=refresh))
+
+    runtime = runtime_for(
+        [ModuleDefinition(manifest, JobModule, "app.modules.job_module.module", "job-module")]
+    )
+    runtime.register(FastAPI())
+
+    module = runtime.operational_status.modules[0]
+    assert module.job_count == 1
+    assert module.origin == "built-in"
+
+
+@pytest.mark.parametrize(
+    ("origin", "safe"),
+    [
+        ("app.modules.reference.module", "built-in"),
+        ("entry-point:reference=package:definition", "entry-point"),
+        ("/home/operator/project/module.py", "unknown"),
+    ],
+)
+def test_origin_is_reduced_to_a_safe_bounded_category(origin: str, safe: str) -> None:
+    assert safe_module_origin(origin) == safe
+
+
+@pytest.mark.asyncio
+async def test_operational_endpoint_requires_admin_and_never_exposes_secrets() -> None:
+    unsafe_definition = replace(
+        definition("safe-module", capabilities=["safe-module.read"]),
+        origin="entry-point:safe-module=/home/alice/token=top-secret",
+    )
+    runtime = runtime_for([unsafe_definition])
+    runtime.registry.records[0].module.password = "module-password"  # type: ignore[attr-defined]
+    runtime.register(FastAPI())
+
+    app = FastAPI()
+    app.state.module_runtime = runtime
+    app.include_router(admin_router, prefix="/api/v1")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        unauthenticated = await client.get("/api/v1/admin/modules/status")
+
+    assert unauthenticated.status_code == 401
+
+    async def allow_superuser() -> object:
+        return object()
+
+    app.dependency_overrides[require_superuser] = allow_superuser
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/v1/admin/modules/status")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.json()["modules"][0]["origin"] == "entry-point"
+    serialized = response.text
+    for secret in ("/home/alice", "top-secret", "module-password", "password"):
+        assert secret not in serialized

--- a/backend/tests/test_module_runtime.py
+++ b/backend/tests/test_module_runtime.py
@@ -234,6 +234,8 @@ def test_incompatible_runtime_version_is_fail_fast(
 
     assert isinstance(error.value.__cause__, ModuleCompatibilityError)
     assert error.value.__cause__.target == target
+    assert error.value.module_id == definition_value.declared_id
+    assert error.value.origin == f"test:{definition_value.declared_id}"
 
 
 def test_required_dependency_and_optional_dependency_define_load_order() -> None:
@@ -312,6 +314,8 @@ def test_registration_failure_is_fail_fast_and_registration_is_single_use() -> N
     )
     with pytest.raises(ModuleRegistrationError, match="module_id=broken-module"):
         broken.register(FastAPI())
+    assert broken.operational_status.modules[0].status == "loaded"
+    assert broken.operational_status.modules[0].registered is False
 
     runtime = runtime_for([])
     app = FastAPI()
@@ -388,6 +392,7 @@ async def test_startup_failure_cleans_up_already_started_modules() -> None:
 
     assert error.value.module_id == "module-b"
     assert events == ["start:module-a", "start:module-b", "stop:module-a"]
+    assert {module.status for module in runtime.operational_status.modules} == {"registered"}
     await runtime.shutdown()
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 - [ADR: Datenbank- und Migrations-Ownership von Modulen](architecture/adr-module-database-and-migration-ownership.md)
 - [Module Manifest Schema V1](modules/module-manifest-v1.md)
 - [Backend-Module-Runtime](modules/backend-module-runtime.md)
+- [Operationaler Modulstatus und Diagnose](modules/operations.md)
 - [Öffentliches Backend-Module-SDK](modules/backend-module-sdk.md)
 - [Domain Events und transaktionale Outbox](modules/domain-events.md)
 - [Modulare Background Jobs](modules/background-jobs.md)

--- a/docs/modules/backend-module-runtime.md
+++ b/docs/modules/backend-module-runtime.md
@@ -49,6 +49,10 @@ Dependency-/Load-Reihenfolge.
 Trust und Capabilities werden bewusst nicht in diesen Build-Contract gemischt. Das
 Kompatibilitätsinventar bleibt auf ID und Version begrenzt.
 
+Runtime-, Dependency- und Jobdiagnose bleibt davon getrennt und wird ausschließlich
+als geschützter, read-only [operationaler Modulstatus](operations.md) aus der
+laufenden Runtime projiziert.
+
 ## Discovery-Quellen
 
 `FirstPartyModuleDiscovery` lädt ausschließlich explizit aktivierte Built-ins nach

--- a/docs/modules/operations.md
+++ b/docs/modules/operations.md
@@ -1,0 +1,152 @@
+# Operationaler Modulstatus
+
+Der operationale Modulstatus ist eine read-only Projektion der bereits aktiven
+Backend-Runtime. Er ist kein Installationsinventar und keine persistente
+Lifecycle-State-Machine.
+
+## Zwei getrennte Verträge
+
+Das generierte Backend-Inventar bleibt der Build- und Compatibility-Contract für
+den Frontend-Host:
+
+```json
+{"modules":[{"id":"analysis-areas","version":"1.0.0"}]}
+```
+
+Es enthält weiterhin ausschließlich ID und Version. Runtime-, Health-, Job- und
+Origin-Daten werden dort nicht ergänzt.
+
+Der operationale Status steht separat unter:
+
+```text
+GET /api/v1/admin/modules/status
+```
+
+Der Endpoint verwendet die bestehende Superuser-Authentifizierung, antwortet mit
+`Cache-Control: private, no-store` und ist nicht Teil der öffentlichen Health-API.
+Ein Snapshot sieht beispielsweise so aus:
+
+```json
+{
+  "modules": [
+    {
+      "id": "analysis-areas",
+      "version": "1.0.0",
+      "status": "running",
+      "enabled": true,
+      "registered": true,
+      "capabilities": [
+        "analysis-areas.public-api",
+        "analysis-areas.lookup",
+        "analysis-areas.geojson"
+      ],
+      "dependencies": [],
+      "origin": "built-in",
+      "job_count": 0
+    }
+  ]
+}
+```
+
+`loaded`, `registered` und `running` werden unmittelbar aus `ModuleRecord` und
+`ModuleRuntime` abgeleitet. Es gibt keinen separat gespeicherten Status. Da nur
+aktivierte, erfolgreich validierte Runtime-Records projiziert werden, ist
+`enabled` immer `true`. Nicht aktivierte Built-ins werden nicht gesucht und nicht
+als vermeintlich installierte Module ausgegeben.
+
+Dependencies stammen aus den bereits validierten Manifesten und den aufgelösten
+Runtime-Records. Erforderliche sowie tatsächlich vorhandene optionale Dependencies
+enthalten Requirement, aufgelöste Version und `compatible: true`. Die Statuslogik
+führt keine zweite SemVer- oder Graphauflösung aus. Inkompatible Manifeste brechen
+weiterhin vor Erzeugung der Runtime mit `ModuleValidationError` ab.
+
+Origins werden ausschließlich als `built-in`, `entry-point` oder `unknown`
+ausgegeben. Python-Importpfade, Entry-Point-Werte, lokale Dateipfade,
+Distribution-Interna, Settings, Secrets und Exception-Texte sind kein Bestandteil
+des Response-Contracts. Die JobRegistry wird nur als Anzahl stabil registrierter
+Jobs pro Modul projiziert; Jobhistorie und Scheduler-Dashboard existieren nicht.
+
+## Health und Fail-fast
+
+Die öffentlichen Endpunkte `/health/live`, `/health/ready`, `/health` und
+`/health/info` bleiben unverändert. Moduldetails beeinflussen ihre Antwort nicht.
+Die heutige Bootstrap-Policy bleibt dennoch fail-fast: Discovery-, Manifest-,
+Compatibility-, Dependency- und Load-Fehler verhindern den Aufbau einer
+halbgültigen Runtime. Registration- und Startup-Fehler bleiben strukturierte
+`ModuleRuntimeError`-Unterklassen; bereits gestartete Lifecycle-Beiträge werden
+beim Startup-Fehler weiterhin aufgeräumt.
+
+Runtime-Logs verwenden `module_id`, `module_version` und `module_phase`. Job-Logs
+und -Metriken behalten die dokumentierten begrenzten `module_id`, `job_id`,
+`job_phase` und `result`-Dimensionen. Fehlertexte, URLs und nutzerbezogene Werte
+werden nicht als Metriklabels eingeführt.
+
+## Diagnoseablauf
+
+1. Aktivierung in der lokalen oder deployten Environment prüfen, ohne Secret-Werte
+   auszugeben:
+
+   ```bash
+   cd backend
+   rg '^ENABLED_MODULES=' .env
+   ```
+
+2. Discovery, Manifest und Compatibility über den bestehenden Build-Contract
+   prüfen:
+
+   ```bash
+   cd ..
+   scripts/backend-module-inventory --format json
+   ```
+
+3. Den geschützten Runtime-Snapshot mit einer bestehenden Superuser-Sitzung
+   abrufen. Eine lokale Cookie-Datei darf nicht committed oder protokolliert werden:
+
+   ```bash
+   curl --fail --cookie ./admin-cookie.jar \
+     http://127.0.0.1:8000/api/v1/admin/modules/status
+   ```
+
+4. Registration und Startup über strukturierte Logs prüfen:
+
+   ```bash
+   sudo journalctl -u stadtplaner-api -o cat \
+     | jq 'select(.module_id != null)'
+   ```
+
+5. Host-Liveness und -Readiness unabhängig prüfen:
+
+   ```bash
+   curl --fail http://127.0.0.1:8000/health/live
+   curl --fail http://127.0.0.1:8000/health/ready
+   ```
+
+6. Den Migrationsgraph der aktivierten Module prüfen:
+
+   ```bash
+   cd backend
+   uv run python -m app.cli.module_migrations preflight
+   ```
+
+7. `job_count` im Status mit den stabilen Job-IDs und der Telemetrie aus
+   [Modulare Background Jobs](background-jobs.md) abgleichen. Es wird keine
+   Jobhistorie im Status gespeichert.
+
+8. Den bestehenden Contract- und Architektur-Gate ausführen:
+
+   ```bash
+   cd ..
+   scripts/module-contract-gate
+   ```
+
+9. Bei Fehlern die `phase`, `module_id` und sichere Origin-Kategorie mit dem
+   ursprünglichen `ModuleValidationError`, `ModuleRegistrationError` oder
+   `ModuleStartupError` im Prozesslog korrelieren. Interne Exception-Texte werden
+   bewusst nicht über den Admin-Endpoint gespiegelt.
+
+## Scope
+
+Dieser Status führt weder `installed`, Upgrade-/Rollback-Zustände, Enable-/Disable-
+Befehle noch eine persistente Lifecycle-Datenbank ein. Installer und `modules.lock`
+bleiben #173 vorbehalten, `.ocp`-Bundles #174 und eine Package Registry #175. Die
+weitergehende Lifecycle-Policy folgt in #112.


### PR DESCRIPTION
## Problem

Das bestehende Backend-Modul-Inventar ist bewusst ein schlanker Build-/Frontend-Compatibility-Contract aus ID und Version. Für Betrieb und Diagnose fehlte bislang ein separater, geschützter Snapshot der tatsächlich aktiven Runtime.

## Lösung

- ergänzt einen strikt getrennten host-owned Operational-Statusvertrag
- projiziert `loaded`, `registered` und `running` direkt aus `ModuleRuntime` und `ModuleRecord`
- zeigt validierte Capabilities und bereits aufgelöste aktive Dependencies
- reduziert interne Origins auf `built-in`, `entry-point` oder `unknown`
- projiziert aus der bestehenden `JobRegistry` ausschließlich `job_count`
- stellt `GET /api/v1/admin/modules/status` über die bestehende Superuser-Authentifizierung bereit
- setzt `Cache-Control: private, no-store`
- exponiert keine Settings, Secrets, Exception-Texte, Importpfade oder lokalen Dateipfade
- behält `/health/live`, `/health/ready`, `/health` und `/health/info` unverändert
- ergänzt strukturierte Registration-/Startup-Logs mit den bestehenden Modulfeldern
- dokumentiert den realen Diagnoseablauf in `docs/modules/operations.md`

## Getrennte Contracts

Das Build-Inventar bleibt unverändert auf ID und Version begrenzt. Operational Status ist eine reine read-only Runtime-Projektion und kein Installationsinventar.

Nicht aktivierte Built-ins werden nicht gescannt oder als disabled ausgegeben. Inkompatible Module scheitern weiterhin fail-fast mit `ModuleValidationError`, bevor eine Runtime entsteht.

## Tests

- reales `analysis-areas`-Modul mit ID, Version und Capabilities
- `loaded`/`registered`/`running` aus vorhandenen Runtime-Flags
- aktivierte und deaktivierte Module
- validierte Dependency-Projektion
- Jobanzahl aus der `JobRegistry`
- sichere Origin-Kategorien
- Superuser-Schutz und `Cache-Control`
- Ausschluss von Secrets, Pfaden und internen Origins
- inkompatible Module und sichere Fehlerkontexte
- Registration- und Startup-Fehler einschließlich Cleanup
- öffentliche Health-Info ohne Moduldetails
- strukturierte Lifecycle-Logs mit begrenzten Feldern

## Validierung

- `uv sync --frozen --extra dev --no-editable`: erfolgreich
- Ruff: erfolgreich
- Pytest: 881 bestanden
- Module Migration Preflight: erfolgreich, `host: 20260825_0034`
- Module Contract Gate: 268 Backend-, 45 Frontend- und 3 SSR-Tests bestanden
- Backend- und Frontend-Architekturprüfungen: erfolgreich
- Backend Build Inventory unverändert: ID und Version
- `git diff --check`: erfolgreich

Frontend-Produktcode wurde nicht verändert. Die Frontend-Contract- und SSR-Anteile des gemeinsamen Module Contract Gates wurden ausgeführt.

## Migration, Konfiguration und Rollout

Keine Datenbankmigration, keine neue Environment-Variable und keine Deploymentänderung. Rollback erfolgt durch Revert des fokussierten Commits.

Keine Lifecycle-State-Machine, kein Installer, keine `modules.lock`-Datei, kein `.ocp`-Bundler und keine Registry wurden eingeführt.

Closes #111
Part of #91
Coordinates #108
Next: #112