### PR TITLE
feat(modules): define lifecycle policy

### DIFF
--- a/backend/app/cli/module_migrations.py
+++ b/backend/app/cli/module_migrations.py
@@ -8,7 +8,10 @@ from alembic.config import Config
 from app.core.config import BACKEND_ENV_FILE, get_settings
 from app.platform.modules import EntryPointModuleDiscovery, FirstPartyModuleDiscovery
 from app.platform.modules.migrations import MigrationCoordinator
-from app.platform.modules.persistence import build_persistence_registry
+from app.platform.modules.persistence import (
+    build_persistence_registry,
+    resolve_available_persistence_definitions,
+)
 from app.platform.modules.runtime import resolve_module_definitions
 from app.platform.modules.settings import (
     ModuleSettingsRegistry,
@@ -21,25 +24,27 @@ BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
 def coordinator() -> MigrationCoordinator:
     settings = get_settings()
-    resolved = resolve_module_definitions(
+    discovery_providers = (FirstPartyModuleDiscovery(), EntryPointModuleDiscovery())
+    enabled = resolve_module_definitions(
         enabled_module_ids=settings.enabled_module_list,
-        discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
+        discovery_providers=discovery_providers,
         host_version=settings.api_version,
     )
     build_module_settings_registry(
-        resolved,
+        enabled,
         registry=ModuleSettingsRegistry(
             read_module_environment(env_file=BACKEND_ENV_FILE)
         ),
     )
     config = Config(str(BACKEND_ROOT / "alembic.ini"))
     config.attributes["database_url"] = settings.database_url
-    return MigrationCoordinator(config, build_persistence_registry(resolved))
+    available = resolve_available_persistence_definitions(discovery_providers)
+    return MigrationCoordinator(config, build_persistence_registry(available))
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Validate or migrate the enabled host/module revision graph."
+        description="Validate or migrate the locally available host/module revision graph."
     )
     parser.add_argument("action", choices=("preflight", "upgrade", "downgrade"))
     parser.add_argument("revision", nargs="?", help="Explicit target for downgrade.")

--- a/backend/app/cli/module_migrations.py
+++ b/backend/app/cli/module_migrations.py
@@ -5,11 +5,16 @@ from pathlib import Path
 
 from alembic.config import Config
 
-from app.core.config import get_settings
+from app.core.config import BACKEND_ENV_FILE, get_settings
 from app.platform.modules import EntryPointModuleDiscovery, FirstPartyModuleDiscovery
 from app.platform.modules.migrations import MigrationCoordinator
 from app.platform.modules.persistence import build_persistence_registry
 from app.platform.modules.runtime import resolve_module_definitions
+from app.platform.modules.settings import (
+    ModuleSettingsRegistry,
+    build_module_settings_registry,
+    read_module_environment,
+)
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
@@ -20,6 +25,12 @@ def coordinator() -> MigrationCoordinator:
         enabled_module_ids=settings.enabled_module_list,
         discovery_providers=(FirstPartyModuleDiscovery(), EntryPointModuleDiscovery()),
         host_version=settings.api_version,
+    )
+    build_module_settings_registry(
+        resolved,
+        registry=ModuleSettingsRegistry(
+            read_module_environment(env_file=BACKEND_ENV_FILE)
+        ),
     )
     config = Config(str(BACKEND_ROOT / "alembic.ini"))
     config.attributes["database_url"] = settings.database_url

--- a/backend/app/platform/modules/__init__.py
+++ b/backend/app/platform/modules/__init__.py
@@ -1,6 +1,7 @@
 """Öffentliche Contracts der Backend-Module-Plattform."""
 
 from app.platform.modules.contracts import (
+    AvailableModuleDiscoveryProvider,
     ModuleDefinition,
     ModuleDiscoveryProvider,
     ModuleLifecycleHook,
@@ -106,6 +107,7 @@ from app.platform.modules.services import ServiceRegistry
 __all__ = [
     "ENTRY_POINT_GROUP",
     "MODULE_SDK_VERSION",
+    "AvailableModuleDiscoveryProvider",
     "BackendModule",
     "BackendModuleInventory",
     "BackendModuleInventoryEntry",

--- a/backend/app/platform/modules/contracts.py
+++ b/backend/app/platform/modules/contracts.py
@@ -81,7 +81,14 @@ class ModuleDiscoveryProvider(Protocol):
     def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]: ...
 
 
+class AvailableModuleDiscoveryProvider(ModuleDiscoveryProvider, Protocol):
+    """Liefert passive Definitionen aller lokal verfügbaren Module für Migrationen."""
+
+    def discover_available(self) -> Sequence[ModuleDefinition]: ...
+
+
 __all__ = [
+    "AvailableModuleDiscoveryProvider",
     "BackendModule",
     "LifecycleContribution",
     "ModuleDefinition",

--- a/backend/app/platform/modules/discovery.py
+++ b/backend/app/platform/modules/discovery.py
@@ -108,7 +108,7 @@ class EntryPointModuleDiscovery:
         return self._discover(enabled_module_ids)
 
     def discover_available(self) -> Sequence[ModuleDefinition]:
-        """Lade passive Definitionen aller lokal installierten Modul-Entry-Points."""
+        """Passive Definitionen aller lokal installierten Modul-Entry-Points ermitteln."""
 
         return self._discover(None)
 

--- a/backend/app/platform/modules/discovery.py
+++ b/backend/app/platform/modules/discovery.py
@@ -20,13 +20,24 @@ class FirstPartyModuleDiscovery:
         self._catalog = catalog
 
     def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
-        definitions: list[ModuleDefinition] = []
+        return self._discover(enabled_module_ids)
+
+    def discover_available(self) -> Sequence[ModuleDefinition]:
+        """Entdecke alle lokal vorhandenen Built-ins ohne sie runtime-seitig zu aktivieren."""
+
         module_ids = (
-            enabled_module_ids
+            frozenset(_available_builtin_module_ids())
             if self._catalog is None
-            else enabled_module_ids.intersection(self._catalog)
+            else frozenset(self._catalog)
         )
-        for module_id in sorted(module_ids):
+        return self._discover(module_ids)
+
+    def _discover(self, module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        definitions: list[ModuleDefinition] = []
+        selected_ids = (
+            module_ids if self._catalog is None else module_ids.intersection(self._catalog)
+        )
+        for module_id in sorted(selected_ids):
             try:
                 definition = (
                     _load_builtin_definition(module_id)
@@ -70,6 +81,22 @@ def _load_builtin_definition(module_id: str) -> ModuleDefinition | None:
     return module.DEFINITION
 
 
+def _available_builtin_module_ids() -> tuple[str, ...]:
+    """Leite Built-in-IDs generisch aus lokalen Python-Modulpaketen ab."""
+
+    if not BUILTIN_MODULES_DIRECTORY.is_dir():
+        return ()
+    return tuple(
+        sorted(
+            path.name.replace("_", "-")
+            for path in BUILTIN_MODULES_DIRECTORY.iterdir()
+            if path.is_dir()
+            and path.name.isidentifier()
+            and (path / "module.py").is_file()
+        )
+    )
+
+
 def _resolve_source(source: DefinitionSource) -> ModuleDefinition:
     return source() if callable(source) else source
 
@@ -78,23 +105,36 @@ class EntryPointModuleDiscovery:
     """Discovery vertrauenswürdiger installierter Python-Distributionen."""
 
     def discover(self, enabled_module_ids: frozenset[str]) -> Sequence[ModuleDefinition]:
+        return self._discover(enabled_module_ids)
+
+    def discover_available(self) -> Sequence[ModuleDefinition]:
+        """Lade passive Definitionen aller lokal installierten Modul-Entry-Points."""
+
+        return self._discover(None)
+
+    def _discover(
+        self, enabled_module_ids: frozenset[str] | None
+    ) -> Sequence[ModuleDefinition]:
         definitions: list[ModuleDefinition] = []
         entry_points = metadata.entry_points().select(group=ENTRY_POINT_GROUP)
         for entry_point in sorted(entry_points, key=lambda candidate: candidate.name):
-            if entry_point.name not in enabled_module_ids:
+            if (
+                enabled_module_ids is not None
+                and entry_point.name not in enabled_module_ids
+            ):
                 continue
             origin = f"entry-point:{entry_point.name}={entry_point.value}"
             try:
                 definition = entry_point.load()
             except Exception as exc:
                 raise ModuleDiscoveryError(
-                    "The enabled Python entry point could not be loaded.",
+                    "The installed Python entry point definition could not be loaded.",
                     module_id=entry_point.name,
                     origin=origin,
                 ) from exc
             if not isinstance(definition, ModuleDefinition):
                 raise ModuleDiscoveryError(
-                    "The Python entry point does not expose a ModuleDefinition.",
+                    "The installed Python entry point does not expose a ModuleDefinition.",
                     module_id=entry_point.name,
                     origin=origin,
                 )

--- a/backend/app/platform/modules/persistence.py
+++ b/backend/app/platform/modules/persistence.py
@@ -12,8 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.db.base import Base
 from app.db.session import AsyncSessionLocal
+from app.platform.modules.contracts import AvailableModuleDiscoveryProvider
+from app.platform.modules.dependency_graph import resolve_module_order
 from app.platform.modules.errors import ModulePersistenceError
-from app.platform.modules.manifest import ModuleManifestV1
+from app.platform.modules.manifest import ModuleManifestV1, parse_manifest
 from app.platform.modules.sdk import (
     ModuleDefinition,
     ModuleMigrationSource,
@@ -246,6 +248,35 @@ def build_persistence_registry(
     return registry
 
 
+def resolve_available_persistence_definitions(
+    discovery_providers: Sequence[AvailableModuleDiscoveryProvider],
+) -> tuple[tuple[ModuleDefinition, ModuleManifestV1], ...]:
+    """Löse passive installierte Persistence-Beiträge ohne Runtime-Compatibility auf."""
+
+    definitions = tuple(
+        definition
+        for provider in discovery_providers
+        for definition in provider.discover_available()
+    )
+    parsed: list[tuple[ModuleDefinition, ModuleManifestV1]] = []
+    for definition in definitions:
+        manifest = (
+            definition.manifest
+            if isinstance(definition.manifest, ModuleManifestV1)
+            else parse_manifest(definition.manifest, origin=definition.origin)
+        )
+        if definition.declared_id != manifest.id:
+            raise ModulePersistenceError(
+                "The available migration definition ID does not match its manifest.",
+                module_id=definition.declared_id,
+            )
+        parsed.append((definition, manifest))
+
+    ordered = resolve_module_order(tuple(manifest for _, manifest in parsed))
+    definitions_by_id = {manifest.id: definition for definition, manifest in parsed}
+    return tuple((definitions_by_id[manifest.id], manifest) for manifest in ordered)
+
+
 def resolve_migration_source(source: ModuleMigrationSource, *, module_id: str) -> Path:
     """Löse ausschließlich Ressourcen bereits installierter Python-Pakete auf."""
 
@@ -304,6 +335,7 @@ __all__ = [
     "build_persistence_registry",
     "include_autogenerate_object",
     "migration_log_fields",
+    "resolve_available_persistence_definitions",
     "resolve_migration_source",
     "revision_namespace_for",
 ]

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -9,6 +9,7 @@ import pytest_asyncio
 from alembic.autogenerate import compare_metadata
 from alembic.config import Config
 from alembic.migration import MigrationContext
+from fastapi import FastAPI
 from geoalchemy2 import Geometry
 from sqlalchemy import Column, Integer, MetaData, String, Table, func, insert, select, text, true
 from sqlalchemy.engine import URL, make_url
@@ -29,6 +30,7 @@ from app.platform.modules import (
     ModuleMigrationSource,
     ModulePersistenceContribution,
     ModulePersistenceError,
+    ModuleStartupError,
     parse_manifest,
     resolve_module_definitions,
     validate_manifests,
@@ -44,7 +46,7 @@ from app.platform.modules.persistence import (
 )
 from tests.fixtures.example_backend_module import DEFINITION as EXAMPLE_DEFINITION
 from tests.fixtures.example_persistence_module import DEFINITION as DEPENDENT_DEFINITION
-from tests.test_module_runtime import FakeDiscovery
+from tests.test_module_runtime import FakeDiscovery, definition, runtime_for
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 
@@ -519,6 +521,96 @@ async def test_reference_module_migration_up_down_and_seed_data(
         revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
     assert revision == "mod_reference_20260826_0001"
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reference_module_reenable_reuses_existing_revision_and_data(
+    fresh_database_url: str,
+) -> None:
+    enabled = resolve_module_definitions(
+        enabled_module_ids=("reference",),
+        discovery_providers=(FakeDiscovery((REFERENCE_DEFINITION,)),),
+        host_version="0.2.0",
+    )
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    config.attributes["database_url"] = fresh_database_url
+    coordinator = MigrationCoordinator(config, build_persistence_registry(enabled))
+    await asyncio.to_thread(coordinator.upgrade)
+
+    engine = create_async_engine(fresh_database_url)
+    async with engine.connect() as connection:
+        before_disable = await connection.scalar(text("SELECT count(*) FROM reference.items"))
+
+    disabled = resolve_module_definitions(
+        enabled_module_ids=(),
+        discovery_providers=(FakeDiscovery((REFERENCE_DEFINITION,)),),
+        host_version="0.2.0",
+    )
+    assert build_persistence_registry(disabled, include_legacy=False).contributions == ()
+    async with engine.connect() as connection:
+        while_disabled = await connection.scalar(text("SELECT count(*) FROM reference.items"))
+
+    reenabled = resolve_module_definitions(
+        enabled_module_ids=("reference",),
+        discovery_providers=(FakeDiscovery((REFERENCE_DEFINITION,)),),
+        host_version="0.2.0",
+    )
+    reenable_config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    reenable_config.attributes["database_url"] = fresh_database_url
+    await asyncio.to_thread(
+        MigrationCoordinator(
+            reenable_config, build_persistence_registry(reenabled)
+        ).upgrade
+    )
+    async with engine.connect() as connection:
+        after_reenable = await connection.scalar(text("SELECT count(*) FROM reference.items"))
+
+    assert (before_disable, while_disabled, after_reenable) == (2, 2, 2)
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_successful_migration_then_startup_failure_does_not_downgrade(
+    fresh_database_url: str,
+) -> None:
+    resolved = resolve_module_definitions(
+        enabled_module_ids=("reference",),
+        discovery_providers=(FakeDiscovery((REFERENCE_DEFINITION,)),),
+        host_version="0.2.0",
+    )
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    config.attributes["database_url"] = fresh_database_url
+    await asyncio.to_thread(
+        MigrationCoordinator(config, build_persistence_registry(resolved)).upgrade
+    )
+
+    runtime = runtime_for(
+        [
+            definition(
+                "failing-module",
+                events=[],
+                startup_error=RuntimeError("startup failed"),
+            )
+        ]
+    )
+    runtime.register(FastAPI())
+    with pytest.raises(ModuleStartupError, match="startup"):
+        await runtime.startup()
+
+    engine = create_async_engine(fresh_database_url)
+    async with engine.connect() as connection:
+        revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
+        count = await connection.scalar(text("SELECT count(*) FROM reference.items"))
+    assert revision == "mod_reference_20260826_0001"
+    assert count == 2
+    await engine.dispose()
+
+
+def test_downgrade_requires_an_explicit_target_before_preflight() -> None:
+    coordinator = migration_coordinator("postgresql+asyncpg://unused:unused@localhost/unused")
+
+    with pytest.raises(ValueError, match="explicit downgrade target"):
+        coordinator.downgrade("")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -1,7 +1,7 @@
 import asyncio
 import uuid
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import pytest
@@ -21,7 +21,8 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-from app.core.config import get_settings
+from app.cli import module_migrations as migration_cli
+from app.core.config import Settings, get_settings
 from app.db.base import Base
 from app.modules.reference.module import DEFINITION as REFERENCE_DEFINITION
 from app.platform.modules import (
@@ -41,6 +42,7 @@ from app.platform.modules.persistence import (
     PersistenceRegistry,
     build_persistence_registry,
     include_autogenerate_object,
+    resolve_available_persistence_definitions,
     resolve_migration_source,
     revision_namespace_for,
 )
@@ -49,6 +51,12 @@ from tests.fixtures.example_persistence_module import DEFINITION as DEPENDENT_DE
 from tests.test_module_runtime import FakeDiscovery, definition, runtime_for
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass
+class FakeAvailableDiscovery(FakeDiscovery):
+    def discover_available(self):
+        return self.definitions
 
 
 def module_manifest(
@@ -184,6 +192,24 @@ def test_independent_module_persistence_is_ordered_lexicographically() -> None:
     registry = build_persistence_registry(resolved, include_legacy=False)
 
     assert [item.module_id for item in registry.contributions] == ["example-a", "example-b"]
+
+
+def test_available_migration_resolution_ignores_disabled_runtime_compatibility() -> None:
+    manifest_data = REFERENCE_DEFINITION.manifest.model_dump(by_alias=True)
+    manifest_data["requires"] = {
+        **manifest_data["requires"],
+        "host": ">=99.0.0,<100.0.0",
+        "sdk": ">=99.0.0,<100.0.0",
+    }
+    incompatible = replace(REFERENCE_DEFINITION, manifest=manifest_data)
+
+    resolved = resolve_available_persistence_definitions(
+        (FakeAvailableDiscovery((incompatible,)),)
+    )
+
+    assert [(definition.declared_id, manifest.id) for definition, manifest in resolved] == [
+        ("reference", "reference")
+    ]
 
 
 def test_duplicate_module_registration_is_rejected() -> None:
@@ -524,8 +550,9 @@ async def test_reference_module_migration_up_down_and_seed_data(
 
 
 @pytest.mark.asyncio
-async def test_reference_module_reenable_reuses_existing_revision_and_data(
+async def test_reference_module_disable_and_reenable_keep_graph_revision_and_data(
     fresh_database_url: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     enabled = resolve_module_definitions(
         enabled_module_ids=("reference",),
@@ -540,31 +567,41 @@ async def test_reference_module_reenable_reuses_existing_revision_and_data(
     engine = create_async_engine(fresh_database_url)
     async with engine.connect() as connection:
         before_disable = await connection.scalar(text("SELECT count(*) FROM reference.items"))
+        enabled_revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
 
-    disabled = resolve_module_definitions(
-        enabled_module_ids=(),
-        discovery_providers=(FakeDiscovery((REFERENCE_DEFINITION,)),),
-        host_version="0.2.0",
+    monkeypatch.setattr(
+        migration_cli,
+        "get_settings",
+        lambda: Settings(enabled_modules="", database_url=fresh_database_url),
     )
-    assert build_persistence_registry(disabled, include_legacy=False).contributions == ()
+    monkeypatch.setattr(
+        "app.platform.modules.migrations.command.downgrade",
+        lambda *_args, **_kwargs: pytest.fail("Disable must never invoke downgrade"),
+    )
+    disabled_coordinator = migration_cli.coordinator()
+    disabled_plan = await asyncio.to_thread(disabled_coordinator.preflight)
+    await asyncio.to_thread(disabled_coordinator.upgrade)
     async with engine.connect() as connection:
         while_disabled = await connection.scalar(text("SELECT count(*) FROM reference.items"))
+        disabled_revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
 
-    reenabled = resolve_module_definitions(
-        enabled_module_ids=("reference",),
-        discovery_providers=(FakeDiscovery((REFERENCE_DEFINITION,)),),
-        host_version="0.2.0",
+    monkeypatch.setattr(
+        migration_cli,
+        "get_settings",
+        lambda: Settings(
+            enabled_modules="reference", database_url=fresh_database_url
+        ),
     )
-    reenable_config = Config(str(BACKEND_ROOT / "alembic.ini"))
-    reenable_config.attributes["database_url"] = fresh_database_url
-    await asyncio.to_thread(
-        MigrationCoordinator(
-            reenable_config, build_persistence_registry(reenabled)
-        ).upgrade
-    )
+    await asyncio.to_thread(migration_cli.coordinator().upgrade)
     async with engine.connect() as connection:
         after_reenable = await connection.scalar(text("SELECT count(*) FROM reference.items"))
+        reenabled_revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
 
+    assert (disabled_plan[-1].module_id, disabled_plan[-1].revision) == (
+        "reference",
+        "mod_reference_20260826_0001",
+    )
+    assert enabled_revision == disabled_revision == reenabled_revision
     assert (before_disable, while_disabled, after_reenable) == (2, 2, 2)
     await engine.dispose()
 

--- a/backend/tests/test_module_runtime.py
+++ b/backend/tests/test_module_runtime.py
@@ -179,6 +179,23 @@ def test_first_party_discovery_loads_only_enabled_definitions() -> None:
     assert loaded == ["module-b"]
 
 
+def test_first_party_available_discovery_is_generic_and_does_not_enable_runtime() -> None:
+    provider = FirstPartyModuleDiscovery()
+
+    available = provider.discover_available()
+    runtime = create_module_runtime(
+        enabled_module_ids=(),
+        discovery_providers=(provider,),
+        host_version="0.2.0",
+    )
+
+    assert {definition.declared_id for definition in available} >= {
+        "analysis-areas",
+        "reference",
+    }
+    assert runtime.module_ids == ()
+
+
 def test_runtime_ignores_disabled_definition_returned_by_provider() -> None:
     disabled = ModuleDefinition(
         manifest={"manifest_version": 1, "id": "INVALID"},
@@ -559,6 +576,27 @@ def test_entry_point_discovery_loads_only_enabled_group_member(
     assert runtime.module_ids == ("test-example-module",)
     assert enabled.load_count == 1
     assert disabled.load_count == 0
+
+
+def test_entry_point_available_discovery_loads_passive_installed_definitions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installed = FakeEntryPoint(
+        "test-example-module", "package:definition", EXAMPLE_DEFINITION
+    )
+    monkeypatch.setattr(
+        discovery_module.metadata, "entry_points", lambda: FakeEntryPoints([installed])
+    )
+
+    available = EntryPointModuleDiscovery().discover_available()
+
+    assert [definition.declared_id for definition in available] == [
+        "test-example-module"
+    ]
+    assert available[0].origin == (
+        "entry-point:test-example-module=package:definition"
+    )
+    assert installed.load_count == 1
 
 
 def test_broken_enabled_entry_point_has_discovery_context(

--- a/backend/tests/test_module_runtime.py
+++ b/backend/tests/test_module_runtime.py
@@ -7,12 +7,14 @@ import pytest
 from fastapi import FastAPI
 
 from app.api.router import api_router
+from app.platform.events import InProcessEventBus
 from app.platform.modules import (
     DuplicateModuleIdError,
     EntryPointModuleDiscovery,
     FirstPartyModuleDiscovery,
     MissingModuleDependencyError,
     ModuleCompatibilityError,
+    ModuleContext,
     ModuleDefinition,
     ModuleDependencyCycleError,
     ModuleDiscoveryError,
@@ -27,6 +29,7 @@ from app.platform.modules import (
     parse_manifest,
 )
 from app.platform.modules import discovery as discovery_module
+from app.platform.modules.context import ModuleContextFactory
 from app.platform.modules.contracts import ModuleDiscoveryProvider
 from app.platform.modules.discovery import ENTRY_POINT_GROUP
 from tests.fixtures.example_backend_module import DEFINITION as EXAMPLE_DEFINITION
@@ -261,6 +264,18 @@ def test_required_dependency_on_disabled_module_fails() -> None:
     assert isinstance(error.value.__cause__, MissingModuleDependencyError)
 
 
+def test_optional_dependency_on_disabled_module_still_allows_registration() -> None:
+    consumer = definition(
+        "consumer", optional={"disabled-base": ">=1.0.0,<2.0.0"}
+    )
+    runtime = runtime_for([consumer], enabled=("consumer",))
+
+    runtime.register(FastAPI())
+
+    assert runtime.module_ids == ("consumer",)
+    assert runtime.operational_status.modules[0].registered is True
+
+
 def test_dependency_cycle_is_reported_by_manifest_graph() -> None:
     module_a = definition("module-a", required={"module-b": ">=1.0.0,<2.0.0"})
     module_b = definition("module-b", required={"module-a": ">=1.0.0,<2.0.0"})
@@ -325,6 +340,35 @@ def test_registration_failure_is_fail_fast_and_registration_is_single_use() -> N
 
 
 @pytest.mark.asyncio
+async def test_partial_registration_failure_does_not_attach_collected_routers() -> None:
+    runtime = runtime_for(
+        [
+            EXAMPLE_DEFINITION,
+            definition(
+                "z-broken-module",
+                registration_error=RuntimeError("register failed"),
+            ),
+        ]
+    )
+    app = FastAPI()
+
+    with pytest.raises(ModuleRegistrationError) as error:
+        runtime.register(app)
+
+    assert error.value.module_id == "z-broken-module"
+    assert error.value.origin == "test:z-broken-module"
+    assert [module.registered for module in runtime.operational_status.modules] == [
+        True,
+        False,
+    ]
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/v1/module-test/ping")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_router_registration_coexists_with_legacy_router() -> None:
     runtime = runtime_for([EXAMPLE_DEFINITION])
     app = FastAPI()
@@ -353,6 +397,53 @@ async def test_disabled_fixture_module_has_no_route() -> None:
     ) as client:
         response = await client.get("/api/v1/module-test/ping")
     assert response.status_code == 404
+
+
+def test_disabled_module_registers_no_event_subscriber_or_lifecycle_hook() -> None:
+    manifest = parse_manifest(manifest_data("subscriber-module"))
+    event_bus = InProcessEventBus()
+    loaded: list[str] = []
+
+    class SubscriberModule:
+        def __init__(self) -> None:
+            self.manifest = manifest
+            loaded.append("loaded")
+
+        def register(self, context: ModuleContext) -> None:
+            assert context.events is not None
+
+            async def handle(_event) -> None:
+                return None
+
+            context.events.subscribe(
+                "publisher.changed",
+                handler_id="subscriber-module.handle-change",
+                versions=frozenset({1}),
+                handler=handle,
+            )
+
+            async def startup() -> None:
+                return None
+
+            context.lifecycle.add_lifecycle(startup=startup)
+
+    disabled = ModuleDefinition(
+        manifest,
+        SubscriberModule,
+        "test:subscriber-module",
+        "subscriber-module",
+    )
+    runtime = create_module_runtime(
+        enabled_module_ids=(),
+        discovery_providers=(FakeDiscovery((disabled,)),),
+        host_version="0.2.0",
+        context_factory=ModuleContextFactory(event_bus=event_bus),
+    )
+    runtime.register(FastAPI())
+
+    assert runtime.module_ids == ()
+    assert loaded == []
+    assert event_bus.subscriptions == ()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_module_settings.py
+++ b/backend/tests/test_module_settings.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError
 
+from app.cli import module_migrations as migration_cli
 from app.core.config import Settings
 from app.platform.modules.context import ModuleContextFactory
 from app.platform.modules.discovery import FirstPartyModuleDiscovery
@@ -15,6 +16,7 @@ from app.platform.modules.errors import (
     ModuleSettingsError,
     ModuleSettingsNamespaceError,
     ModuleSettingsValidationError,
+    ModuleValidationError,
 )
 from app.platform.modules.import_boundaries import find_host_settings_import_violations
 from app.platform.modules.runtime import create_module_runtime
@@ -140,6 +142,67 @@ def test_disabled_module_does_not_validate_required_secret() -> None:
     )
     runtime.register(FastAPI())
     assert runtime.module_ids == ()
+
+
+def test_migration_cli_validates_active_module_settings_before_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(enabled_modules="settings-fixture")
+    monkeypatch.setattr(migration_cli, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        migration_cli,
+        "resolve_module_definitions",
+        lambda **_kwargs: ((DEFINITION, MANIFEST),),
+    )
+    monkeypatch.setattr(
+        migration_cli,
+        "read_module_environment",
+        lambda **_kwargs: {
+            "OCP_MODULE_SETTINGS_FIXTURE_ENDPOINT_URL": "https://example.org/api"
+        },
+    )
+    monkeypatch.setattr(
+        migration_cli,
+        "MigrationCoordinator",
+        lambda *_args, **_kwargs: pytest.fail(
+            "MigrationCoordinator must not be created for invalid module settings"
+        ),
+    )
+
+    with pytest.raises(ModuleSettingsValidationError) as error:
+        migration_cli.coordinator()
+
+    assert error.value.module_id == "settings-fixture"
+    assert error.value.environment_key == "OCP_MODULE_SETTINGS_FIXTURE_API_TOKEN"
+
+
+def test_migration_cli_stops_incompatible_manifest_before_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(enabled_modules="future-module")
+    monkeypatch.setattr(migration_cli, "get_settings", lambda: settings)
+
+    def reject_incompatible(**_kwargs):
+        raise ModuleValidationError(
+            "Module requires an incompatible host version.",
+            module_id="future-module",
+        )
+
+    monkeypatch.setattr(
+        migration_cli, "resolve_module_definitions", reject_incompatible
+    )
+    monkeypatch.setattr(
+        migration_cli,
+        "MigrationCoordinator",
+        lambda *_args, **_kwargs: pytest.fail(
+            "MigrationCoordinator must not be created for incompatible modules"
+        ),
+    )
+
+    with pytest.raises(ModuleValidationError) as error:
+        migration_cli.coordinator()
+
+    assert error.value.module_id == "future-module"
 
 
 def test_runtime_binds_validated_settings_before_module_registration() -> None:

--- a/backend/tests/test_module_settings.py
+++ b/backend/tests/test_module_settings.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,8 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError
 
 from app.cli import module_migrations as migration_cli
 from app.core.config import Settings
+from app.modules.reference.module import DEFINITION as REFERENCE_DEFINITION
+from app.modules.reference.module import MANIFEST as REFERENCE_MANIFEST
 from app.platform.modules.context import ModuleContextFactory
 from app.platform.modules.discovery import FirstPartyModuleDiscovery
 from app.platform.modules.errors import (
@@ -203,6 +206,51 @@ def test_migration_cli_stops_incompatible_manifest_before_coordinator(
         migration_cli.coordinator()
 
     assert error.value.module_id == "future-module"
+
+
+def test_disabled_available_migration_does_not_validate_required_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DisabledReferenceSettings(BaseModel):
+        api_token: SecretStr
+
+        model_config = ConfigDict(frozen=True)
+
+    available_definition = replace(
+        REFERENCE_DEFINITION,
+        settings=ModuleSettingsContribution(
+            module_id="reference",
+            namespace="reference",
+            model=DisabledReferenceSettings,
+        ),
+    )
+    monkeypatch.setattr(
+        migration_cli,
+        "get_settings",
+        lambda: Settings(enabled_modules=""),
+    )
+    monkeypatch.setattr(
+        migration_cli,
+        "resolve_module_definitions",
+        lambda **_kwargs: (),
+    )
+    monkeypatch.setattr(
+        migration_cli,
+        "resolve_available_persistence_definitions",
+        lambda _providers: ((available_definition, REFERENCE_MANIFEST),),
+    )
+    monkeypatch.setattr(
+        migration_cli,
+        "read_module_environment",
+        lambda **_kwargs: {},
+    )
+
+    plan = migration_cli.coordinator().preflight()
+
+    assert (plan[-1].module_id, plan[-1].revision) == (
+        "reference",
+        "mod_reference_20260826_0001",
+    )
 
 
 def test_runtime_binds_validated_settings_before_module_registration() -> None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Dieses Verzeichnis enthält die Entwickler-, Architektur- und Betriebsdokumentat
 - [ADR: Datenbank- und Migrations-Ownership von Modulen](architecture/adr-module-database-and-migration-ownership.md)
 - [Module Manifest Schema V1](modules/module-manifest-v1.md)
 - [Backend-Module-Runtime](modules/backend-module-runtime.md)
+- [Modul-Lifecycle-Policy und Runbook](modules/lifecycle.md)
 - [Operationaler Modulstatus und Diagnose](modules/operations.md)
 - [Öffentliches Backend-Module-SDK](modules/backend-module-sdk.md)
 - [Domain Events und transaktionale Outbox](modules/domain-events.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,13 +79,17 @@ uv run python -m app.cli.module_migrations upgrade
 
 Die Alembic-Befehle bleiben für die veröffentlichte Host-/Legacy-Historie maßgeblich.
 Der anschließende generische Modul-CLI löst die in `ENABLED_MODULES` konfigurierten,
-installierten Migrationsquellen auf, prüft den gemeinsamen linearen Graph und führt
-ausstehende Modulrevisionen vor der Aktivierung aus. Installierte Module mit eigenen
-Migrationen folgen damit dem in
+installierten Migrationsquellen auf und führt zuerst die vorhandene Settings Registry
+für alle aktiven Module aus. Fehlende oder ungültige Modulsettings stoppen damit vor
+dem Migrations-Preflight. Anschließend prüft er den gemeinsamen linearen Graphen und
+führt ausstehende Modulrevisionen vor der Aktivierung aus. Installierte Module mit
+eigenen Migrationen werden damit durch den in
 [ADR #97](architecture/adr-module-database-and-migration-ownership.md)
 beschriebenen Persistence-Preflight geprüft. Bereits angewandte Migrationsquellen
 müssen auch bei deaktiviertem Modul installiert und im Migrationsinventar auflösbar
 bleiben; Deaktivierung führt nie automatisch einen Downgrade aus.
+Die vollständige Enable-, Disable- und Fehler-Recovery-Policy steht im
+[Modul-Lifecycle-Runbook](modules/lifecycle.md).
 
 Die produktive Installation verwendet keine Development-Extras. CI und lokale
 Vorabprüfungen ergänzen dagegen `--extra dev` für Pytest und Ruff. Beide Pfade

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,11 +79,14 @@ uv run python -m app.cli.module_migrations upgrade
 
 Die Alembic-Befehle bleiben für die veröffentlichte Host-/Legacy-Historie maßgeblich.
 Der anschließende generische Modul-CLI löst die in `ENABLED_MODULES` konfigurierten,
-installierten Migrationsquellen auf und führt zuerst die vorhandene Settings Registry
-für alle aktiven Module aus. Fehlende oder ungültige Modulsettings stoppen damit vor
-dem Migrations-Preflight. Anschließend prüft er den gemeinsamen linearen Graphen und
-führt ausstehende Modulrevisionen vor der Aktivierung aus. Installierte Module mit
-eigenen Migrationen werden damit durch den in
+aktiven Module für Compatibility, Dependencies und Settings auf. Fehlende oder
+ungültige Settings eines aktiven Moduls stoppen damit vor dem Migrations-Preflight.
+Für den gemeinsamen linearen Alembic-Graphen entdeckt der CLI davon getrennt alle
+lokal verfügbaren Built-in- und installierten Entry-Point-Migrationsquellen. Ein
+deaktiviertes Modul bleibt so im bekannten Revisionsgraphen, ohne Runtime-Beiträge
+zu aktivieren oder seine Settings zu verlangen. Anschließend führt der CLI
+ausstehende Revisionen vor der Aktivierung aus. Installierte Module mit eigenen
+Migrationen werden damit durch den in
 [ADR #97](architecture/adr-module-database-and-migration-ownership.md)
 beschriebenen Persistence-Preflight geprüft. Bereits angewandte Migrationsquellen
 müssen auch bei deaktiviertem Modul installiert und im Migrationsinventar auflösbar

--- a/docs/modules/backend-module-runtime.md
+++ b/docs/modules/backend-module-runtime.md
@@ -52,6 +52,8 @@ Kompatibilitätsinventar bleibt auf ID und Version begrenzt.
 Runtime-, Dependency- und Jobdiagnose bleibt davon getrennt und wird ausschließlich
 als geschützter, read-only [operationaler Modulstatus](operations.md) aus der
 laufenden Runtime projiziert.
+Enable, Disable, Re-Enable und Fehler-Recovery sind in der zentralen
+[Lifecycle-Policy](lifecycle.md) verbindlich beschrieben.
 
 ## Discovery-Quellen
 

--- a/docs/modules/database-and-migrations.md
+++ b/docs/modules/database-and-migrations.md
@@ -113,6 +113,12 @@ ENABLED_MODULES=reference uv run python -m app.cli.module_migrations preflight
 ENABLED_MODULES=reference uv run python -m app.cli.module_migrations upgrade
 ```
 
+Vor Erzeugung des Coordinators validiert der CLI-Einstieg die Settings Contributions
+aller aktiven Module über dieselbe `ModuleSettingsRegistry` wie die Runtime. Eine
+fehlende oder ungültige Modulkonfiguration stoppt damit vor Preflight und Upgrade.
+Die vollständige Reihenfolge und Recovery-Policy steht unter
+[Modul-Lifecycle](lifecycle.md).
+
 Ein Downgrade akzeptiert absichtlich nur ein explizites Ziel, zum Beispiel
 `python -m app.cli.module_migrations downgrade <revision>`.
 

--- a/docs/modules/database-and-migrations.md
+++ b/docs/modules/database-and-migrations.md
@@ -119,6 +119,20 @@ fehlende oder ungültige Modulkonfiguration stoppt damit vor Preflight und Upgra
 Die vollständige Reihenfolge und Recovery-Policy steht unter
 [Modul-Lifecycle](lifecycle.md).
 
+Die Persistence Registry des Coordinators wird bewusst aus einer zweiten,
+enablement-unabhängigen Menge aufgebaut. Sie entdeckt passive Definitionen aller
+lokalen Built-ins unter `app/modules/*/module.py` und aller installierten Entry
+Points aus `open_city_planner.modules`. Damit bleiben Migrationsquellen deaktivierter
+Module im Alembic-Graph, obwohl diese Module nicht geladen, registriert oder gestartet
+werden. Der Modul-Loader wird bei dieser Discovery nicht aufgerufen.
+
+Manifeststruktur, Persistence-Ownership und die lesbare Dependency-Reihenfolge
+bleiben für den Graph erforderlich. Host-/SDK-Compatibility und Modulsettings eines
+deaktivierten Moduls sind dagegen kein Runtime-Gate. Fehlende Secrets eines
+deaktivierten Moduls blockieren den Preflight daher nicht. Diese lokale passive
+Discovery ist noch kein `modules.lock` oder persistentes Installationsinventar; diese
+Package-Lifecycle-Grenze bleibt #173 vorbehalten.
+
 Ein Downgrade akzeptiert absichtlich nur ein explizites Ziel, zum Beispiel
 `python -m app.cli.module_migrations downgrade <revision>`.
 

--- a/docs/modules/frontend-host.md
+++ b/docs/modules/frontend-host.md
@@ -148,6 +148,8 @@ weil sie nur ein technischer Architekturbeweis ist.
 6. bei einem Fullstack-Modul das Backend-Inventar im Deployment konsistent setzen.
 
 Der Host wird dafür nicht um fachliche Imports oder eine ID-Liste erweitert.
+Enable, Disable und Fullstack-Recovery sind ergänzend in der
+[Modul-Lifecycle-Policy](lifecycle.md) beschrieben.
 
 ## Bewusste Grenzen von V1
 

--- a/docs/modules/lifecycle.md
+++ b/docs/modules/lifecycle.md
@@ -38,6 +38,14 @@ dabei nicht geladen. `MigrationCoordinator.upgrade()` wiederholt den statischen
 Graph-Preflight, prüft anschließend den aktuellen DB-Head gegen den installierten
 Graphen und führt erst dann Revisionen aus.
 
+Runtime-Enablement und Verfügbarkeit der Migrationshistorie sind dabei zwei getrennte
+Mengen. Compatibility, Required/Optional Dependencies und Settings werden nur für
+die IDs aus `ENABLED_MODULES` als Runtime-Vertrag validiert. Der Alembic-Graph erhält
+dagegen die passiven Persistence Contributions aller lokal verfügbaren Built-ins und
+installierten Modul-Entry-Points. Dadurch bleibt eine Revision lesbar, wenn ihr Modul
+deaktiviert ist oder nicht mehr zur aktuellen Host-/SDK-Version passt. Das lädt
+weder den `ModuleDefinition.loader` noch Router, Jobs oder andere Runtime-Beiträge.
+
 Die Runtime registriert Contributions in Dependency-/Load-Reihenfolge, startet
 Lifecycle-Hooks in derselben Reihenfolge und beendet sie umgekehrt. Einen
 Registration-Fehler behandelt der Host fail-fast; der betreffende Prozess wird
@@ -80,9 +88,12 @@ Router, Jobs, Event-Subscriber, Permissions und Lifecycle-Hooks. Im Frontend feh
 Nuxt-Layer, Pages, Navigation, UI-Slots sowie Map Sources und Layers.
 
 Disable löscht weder Tabellen noch Daten und startet keinen Downgrade. Bereits
-angewandte Revisionen und ihre Migrationsquellen bleiben Teil des installierten
-Release-Graphen. Package-Entfernung und explizites Daten-Cleanup gehören zum
-späteren Installer-Lifecycle.
+angewandte Revisionen und ihre lokal verfügbaren Migrationsquellen bleiben Teil des
+installierten Release-Graphen. Built-ins werden dafür generisch aus
+`backend/app/modules/*/module.py` abgeleitet; installierte Third-Party-Module aus der
+bestehenden Entry-Point-Gruppe `open_city_planner.modules`. Diese passive Discovery
+ist kein persistentes Package Inventory. Package-Entfernung und explizites
+Daten-Cleanup gehören zum späteren Installer-Lifecycle.
 
 Beim Re-Enable wird die ID wieder konfiguriert und der vollständige Preflight
 wiederholt. Bereits angewandte Revisionen werden erkannt; vorhandene Daten werden
@@ -98,10 +109,16 @@ fail-fast.
 
 ## Migration, Downgrade und Recovery
 
-Eine statisch inkompatible Modulversion darf keine Migration auslösen. Der Preflight
-prüft einen globalen Alembic-Head, auflösbare Migrationsquellen, Schema-Ownership,
-Revision-Namespaces und die Dependency-Reihenfolge. Ein ungültiger aktueller
-DB-Head stoppt `upgrade()` vor der ersten neuen Revision.
+Eine zur Aktivierung ausgewählte, statisch inkompatible Modulversion darf keine
+Migration auslösen. Der Preflight prüft einen globalen Alembic-Head, auflösbare
+Migrationsquellen, Schema-Ownership, Revision-Namespaces und die
+Dependency-Reihenfolge. Ein ungültiger aktueller DB-Head stoppt `upgrade()` vor der
+ersten neuen Revision.
+
+Diese Compatibility-Regel gilt für die neu aktivierte Version. Eine deaktivierte,
+lokal noch verfügbare Version wird nur strukturell als passive Migrationsquelle
+gelesen und erzwingt keine Runtime-Kompatibilität oder Settings. So kann der Graph
+einen bereits angewandten alten Head weiterhin erkennen.
 
 Downgrade ist kein Disable- oder Rollback-Nebeneffekt. Er benötigt immer eine
 explizite Zielrevision, ein aktuelles Backup sowie eine geprüfte Datenverlust- und
@@ -154,8 +171,10 @@ Disable:
 
 1. ID aus beiden Enable-Variablen entfernen.
 2. Frontend neu bauen und Backend neu starten.
-3. Status, Routen und Contributions auf Abwesenheit prüfen.
-4. DB-Revision und erwartete Moduldaten unverändert bestätigen.
+3. Migrations-Preflight und idempotentes Upgrade gegen den weiterhin vollständigen
+   lokalen Graphen ausführen.
+4. Status, Routen und Contributions auf Abwesenheit prüfen.
+5. DB-Revision und erwartete Moduldaten unverändert bestätigen.
 
 Re-Enable:
 

--- a/docs/modules/lifecycle.md
+++ b/docs/modules/lifecycle.md
@@ -1,0 +1,172 @@
+# Modul-Lifecycle-Policy und Runbook
+
+Diese Policy beschreibt den vorhandenen deploy-time Lifecycle. Sie führt weder eine
+persistente State Machine noch einen Installer ein. Maßgeblich bleiben die
+bestehende [Backend-Runtime](backend-module-runtime.md), der
+[Frontend-Host](frontend-host.md), der
+[MigrationCoordinator](database-and-migrations.md) und der read-only
+[operationale Status](operations.md).
+
+## Zustände und Reihenfolge
+
+Ein Modul ist in V1 nur für den konkreten Release konfiguriert oder nicht
+konfiguriert. `installed but disabled` ist noch kein persistierter Plattformzustand.
+Die beobachtbaren Runtime-Fakten bleiben `loaded`, `registered` und `running`.
+
+Der Backend-Ablauf ist verbindlich:
+
+```text
+configured/enabled
+→ discovery
+→ manifest parsing
+→ host/sdk compatibility
+→ dependency resolution
+→ settings validation
+→ migration preflight
+→ migration upgrade
+→ module loading
+→ registration
+→ startup
+→ running
+→ shutdown
+```
+
+Manifest-, Compatibility-, Dependency- und Settingsfehler stoppen den Release vor
+Migration und Startup. Der Migrations-CLI verwendet dafür dieselbe passive
+Discovery, Manifestauflösung und Settings Registry wie die Runtime; Runtimecode wird
+dabei nicht geladen. `MigrationCoordinator.upgrade()` wiederholt den statischen
+Graph-Preflight, prüft anschließend den aktuellen DB-Head gegen den installierten
+Graphen und führt erst dann Revisionen aus.
+
+Die Runtime registriert Contributions in Dependency-/Load-Reihenfolge, startet
+Lifecycle-Hooks in derselben Reihenfolge und beendet sie umgekehrt. Einen
+Registration-Fehler behandelt der Host fail-fast; der betreffende Prozess wird
+nicht in Betrieb genommen. Bei einem Startup-Fehler werden bereits gestartete Hooks
+umgekehrt aufgeräumt. Ein Cleanup-Fehler verdeckt den ursprünglichen Startup-Fehler
+nicht.
+
+## Enable
+
+Enable ist ein neuer Build beziehungsweise ein Deployment, kein Hot-Reload.
+
+Backend:
+
+1. Modul-ID zu `ENABLED_MODULES` hinzufügen.
+2. Backend-Inventar erzeugen und Manifest, Host-/SDK-Kompatibilität sowie Required
+   und vorhandene Optional Dependencies prüfen.
+3. Modulsettings über die vorhandene Settings Registry validieren.
+4. Datenbankbackup entsprechend dem Migrationsrisiko erstellen.
+5. `python -m app.cli.module_migrations preflight` und danach `upgrade` ausführen.
+6. Release starten; Registration, Startup und operationalen Status prüfen.
+
+Frontend:
+
+1. dieselbe Fullstack-ID zu `OCP_FRONTEND_MODULES` hinzufügen;
+2. `OCP_BACKEND_MODULES` aus dem Backend-Inventar erzeugen;
+3. Frontend-Manifest, Compatibility, Dependencies, Routen und Contributions mit
+   `pnpm modules:check` prüfen;
+4. Nuxt-Layer bauen und das zusammengehörige Release deployen.
+
+Ein aktiviertes Frontend ohne erforderliches Backend schlägt im Preflight fehl. Ein
+Backend darf ohne Frontend laufen, sofern sein eigener Vertrag kein Frontend
+voraussetzt.
+
+## Disable und Re-Enable
+
+Disable bedeutet, die ID aus `ENABLED_MODULES` und – falls vorhanden – aus
+`OCP_FRONTEND_MODULES` zu entfernen und Backend beziehungsweise Frontend neu zu
+starten oder zu bauen. Das Backend entdeckt oder lädt das Modul nicht. Damit fehlen
+Router, Jobs, Event-Subscriber, Permissions und Lifecycle-Hooks. Im Frontend fehlen
+Nuxt-Layer, Pages, Navigation, UI-Slots sowie Map Sources und Layers.
+
+Disable löscht weder Tabellen noch Daten und startet keinen Downgrade. Bereits
+angewandte Revisionen und ihre Migrationsquellen bleiben Teil des installierten
+Release-Graphen. Package-Entfernung und explizites Daten-Cleanup gehören zum
+späteren Installer-Lifecycle.
+
+Beim Re-Enable wird die ID wieder konfiguriert und der vollständige Preflight
+wiederholt. Bereits angewandte Revisionen werden erkannt; vorhandene Daten werden
+weiterverwendet und nicht neu initialisiert.
+
+## Dependencies
+
+Eine deaktivierte Required Dependency ist ein Validierungsfehler vor Registration.
+Eine fehlende Optional Dependency ist zulässig; ist sie vorhanden, wird ihre
+Version geprüft und sie wird vor dem Consumer geordnet. Der Frontend-Vertrag besitzt
+derzeit ausschließlich Required Module Dependencies und verhält sich entsprechend
+fail-fast.
+
+## Migration, Downgrade und Recovery
+
+Eine statisch inkompatible Modulversion darf keine Migration auslösen. Der Preflight
+prüft einen globalen Alembic-Head, auflösbare Migrationsquellen, Schema-Ownership,
+Revision-Namespaces und die Dependency-Reihenfolge. Ein ungültiger aktueller
+DB-Head stoppt `upgrade()` vor der ersten neuen Revision.
+
+Downgrade ist kein Disable- oder Rollback-Nebeneffekt. Er benötigt immer eine
+explizite Zielrevision, ein aktuelles Backup sowie eine geprüfte Datenverlust- und
+Kompatibilitätsbewertung. Weder Disable noch Startup-Fehler, Prozessstart oder
+Code-Rollback führen automatisch `MigrationCoordinator.downgrade(target_revision)`
+aus.
+
+Wenn eine Migration erfolgreich war, Registration oder Startup danach aber
+fehlschlägt, gilt das Deployment als fehlgeschlagen. Runtime-Cleanup beendet nur
+bereits gestartete Lifecycle-Contributions; der Datenbankstand bleibt auf der neuen
+Revision. Vorgehen:
+
+1. Fehlerphase, `module_id`, Origin-Kategorie und ursprüngliche Exception in den
+   strukturierten Logs bestimmen.
+2. `python -m app.cli.module_migrations preflight` sowie den aktuellen
+   `alembic_version`-Stand prüfen.
+3. Falls der Prozess weit genug gestartet ist, den geschützten operationalen Status
+   prüfen; andernfalls sind die Bootstrap-Logs maßgeblich.
+4. Einen Forward-Fix bevorzugen.
+5. Code nur zurückrollen, wenn die vorherige Version nachweislich mit dem neuen
+   Schema kompatibel ist.
+6. Die Datenbank nur explizit auf eine geprüfte Zielrevision downgraden.
+
+Schlägt eine Migration selbst fehl, startet die Runtime nicht. Der Coordinator
+meldet Modul, Schema und Phase; der Operator prüft den teilweise erreichten
+Revisionsstand und entscheidet anhand Backup und Migrationsreview über Forward-Fix
+oder explizite Recovery.
+
+## Runbook
+
+Enable:
+
+```bash
+cd backend
+export ENABLED_MODULES=reference
+uv run python -m app.cli.module_inventory --format json
+uv run python -m app.cli.module_migrations preflight
+uv run python -m app.cli.module_migrations upgrade
+export OCP_BACKEND_MODULES="$(../scripts/backend-module-inventory --format env)"
+cd ../frontend
+export OCP_FRONTEND_MODULES=reference
+pnpm modules:check
+pnpm build
+```
+
+Nach Deploy `GET /api/v1/admin/modules/status`, relevante Routen, Jobs und Logs
+prüfen.
+
+Disable:
+
+1. ID aus beiden Enable-Variablen entfernen.
+2. Frontend neu bauen und Backend neu starten.
+3. Status, Routen und Contributions auf Abwesenheit prüfen.
+4. DB-Revision und erwartete Moduldaten unverändert bestätigen.
+
+Re-Enable:
+
+1. ID wieder hinzufügen.
+2. Inventar, Settings, Compatibility und Migration-Preflight erneut prüfen.
+3. `upgrade` idempotent ausführen und Release deployen.
+4. Status sowie vorhandene Daten prüfen.
+
+## Scope
+
+Installer, `modules.lock`, `.ocp`-Bundles, Registry, Marketplace, Uninstall und ein
+persistenter `installed but disabled`-Zustand folgen frühestens in #173 bis #175.
+Diese Policy ergänzt keine Lifecycle-Datenbank, automatische DB-Rollbacks,
+Package-Downloads, Admin-UI oder Runtime-Hot-Reload.

--- a/docs/modules/operations.md
+++ b/docs/modules/operations.md
@@ -149,4 +149,6 @@ werden nicht als Metriklabels eingeführt.
 Dieser Status führt weder `installed`, Upgrade-/Rollback-Zustände, Enable-/Disable-
 Befehle noch eine persistente Lifecycle-Datenbank ein. Installer und `modules.lock`
 bleiben #173 vorbehalten, `.ocp`-Bundles #174 und eine Package Registry #175. Die
-weitergehende Lifecycle-Policy folgt in #112.
+verbindliche Enable-/Disable-Semantik sowie Upgrade- und Recovery-Abläufe stehen in
+der [Modul-Lifecycle-Policy](lifecycle.md). Dieser Status bleibt dabei unverändert
+eine Projektion von `loaded`, `registered` und `running`.

--- a/frontend/tests/frontend-module-host.test.ts
+++ b/frontend/tests/frontend-module-host.test.ts
@@ -8,6 +8,8 @@ import {
   resolveFrontendModules
 } from '../module-host/discovery'
 import { FRONTEND_MODULE_SDK_VERSION } from '../module-host/contract'
+import { createMapExtensionDefinitionRegistry } from '../module-host/map-definition-registry'
+import { createFrontendContributionRegistry } from '../module-host/ui-registry'
 
 const temporaryDirectories: string[] = []
 
@@ -57,6 +59,47 @@ describe('frontend build-time module host', () => {
     expect(discoverFrontendModules(paths.modulesDirectory).map(module => module.id)).toEqual(['alpha', 'zeta'])
     expect(resolveFrontendModules({ ...paths, enabledModules: 'zeta,alpha' }).map(module => module.id)).toEqual(['alpha', 'zeta'])
     expect(resolveFrontendModules({ ...paths, enabledModules: '' })).toEqual([])
+  })
+
+  it('omits every route, UI and map contribution when a module is disabled', () => {
+    const paths = fixture()
+    addModule(paths.modulesDirectory, 'full-stack', {
+      backendModuleId: 'full-stack',
+      publicContributions: {
+        routes: [{ path: '/full-stack', source: 'layer/app/pages/full-stack.vue' }],
+        ui: [{
+          id: 'full-stack.navigation',
+          slot: 'navigation.primary',
+          label: 'Full Stack',
+          to: '/full-stack'
+        }],
+        map: {
+          sources: [{
+            id: 'full-stack.items',
+            source: { type: 'geojson', data: { type: 'FeatureCollection', features: [] } }
+          }],
+          layers: [{
+            id: 'full-stack.items',
+            sourceId: 'full-stack.items',
+            layer: { type: 'circle', paint: { 'circle-radius': 4, 'circle-color': '#154d73' } },
+            group: 'overlay'
+          }]
+        }
+      }
+    })
+
+    const resolved = resolveFrontendModules({
+      ...paths,
+      enabledModules: '',
+      backendModules: 'full-stack@1.0.0'
+    })
+    const ui = createFrontendContributionRegistry(resolved, [])
+    const map = createMapExtensionDefinitionRegistry(resolved).snapshot()
+
+    expect(resolved).toEqual([])
+    expect(ui.all()).toEqual([])
+    expect(map.sources).toEqual([])
+    expect(map.layers).toEqual([])
   })
 
   it('fails for missing enabled modules', () => {


### PR DESCRIPTION
## Ausgangslage

Der modulare Host besitzt bereits deploy-time Enablement, Runtime-Lifecycle, den `MigrationCoordinator` und den operationalen Status aus #111.

Eine verbindliche Enable-/Disable-/Recovery-Semantik sowie einige wichtige Regressionstests fehlten jedoch noch.

## Umsetzung

- bestehende Lifecycle-Reihenfolge von Discovery bis Reverse Shutdown dokumentiert
- Enable, Disable und Re-Enable verbindlich als Build-/Deployment-Vorgänge definiert
- Upgrade-Preflight, expliziten Downgrade und Recovery nach fehlgeschlagenem Startup dokumentiert
- aktive Modulsettings im bestehenden Migrations-CLI vor Preflight und Upgrade validiert
- vorhandene `ModuleSettingsRegistry` wiederverwendet
- Disable-Verhalten für Router, Jobs, Subscriber, Permissions und Lifecycle-Hooks abgesichert
- Disable-Verhalten für Frontend-Routen, Navigation, UI-Slots und Map-Contributions abgesichert
- Required und Optional Dependencies abgesichert
- partielle Registration- und Startup-Fehler getestet
- operationalen Status aus #111 unverändert weiterverwendet
- mit der echten Reference-Modulmigration geprüft, dass Daten bei Disable und Re-Enable erhalten bleiben
- geprüft, dass ein Startup-Fehler nach erfolgreicher Migration keinen automatischen DB-Downgrade auslöst

## Lifecycle-Reihenfolge

```text
configured/enabled
→ discovery
→ manifest parsing
→ host/sdk compatibility
→ dependency resolution
→ settings validation
→ migration preflight
→ migration upgrade
→ module loading
→ registration
→ startup
→ running
→ shutdown
```

## Enable

Enable ist ein neuer Build beziehungsweise ein Deployment und kein Hot Enable.

Backend:

1. Modul-ID zu `ENABLED_MODULES` hinzufügen.
2. Discovery und Manifestvalidierung ausführen.
3. Host-, SDK- und Dependency-Kompatibilität prüfen.
4. Modulsettings validieren.
5. Migration-Preflight ausführen.
6. Migrationen anwenden.
7. Runtime registrieren und starten.
8. Operationalen Status prüfen.

Frontend:

1. Modul-ID zu `OCP_FRONTEND_MODULES` hinzufügen.
2. Backend-Inventar erzeugen.
3. Frontend-Manifest und Compatibility prüfen.
4. Nuxt-Layer und Contributions auflösen.
5. Frontend bauen und deployen.

## Disable

Disable bedeutet:

- Modul-ID aus der Enable-Konfiguration entfernen
- Backend neu starten
- Frontend neu bauen
- Modul nicht mehr entdecken, laden oder registrieren

Danach fehlen im Backend:

- Router
- Jobs
- Event-Subscriber
- Permissions
- Lifecycle-Hooks

Im Frontend fehlen:

- Nuxt-Layer
- Seiten und Routen
- Navigation Contributions
- UI-Slot Contributions
- Map Sources und Layers

Disable führt ausdrücklich nicht zu:

- Datenlöschung
- Tabellenlöschung
- automatischem Downgrade
- implizitem Uninstall

## Re-Enable und Datenhaltung

Der Re-Enable-Vertrag wurde mit dem echten Reference-Modul geprüft:

1. Reference-Migration anwenden.
2. Bestehende Testdaten prüfen.
3. Modul deaktivieren.
4. Migration und Daten bleiben erhalten.
5. Modul erneut aktivieren.
6. Upgrade erneut idempotent ausführen.
7. Vorhandene Daten werden weiterverwendet.

Es findet keine künstliche Neuinitialisierung der Moduldaten statt.

## Dependencies

- eine deaktivierte Required Dependency stoppt fail-fast vor Registration
- eine fehlende Optional Dependency ist zulässig
- vorhandene optionale Dependencies werden weiterhin auf Version und Reihenfolge geprüft
- ein aktiviertes Fullstack-Frontend ohne erforderliches Backend schlägt im Frontend-Preflight fehl
- ein Backend darf ohne Frontend laufen, sofern sein Vertrag kein Frontend voraussetzt

## Migration und Recovery

Vor einer Modulmigration werden geprüft:

- Manifest
- Host-Kompatibilität
- SDK-Kompatibilität
- Module Dependencies
- Modulsettings
- Migrationsquellen
- Revision-Namespaces
- Dependency-Reihenfolge
- globaler Alembic-Head

Eine bereits statisch inkompatible Modulversion erreicht den `MigrationCoordinator` nicht.

Wenn eine Migration erfolgreich war und Registration oder Startup anschließend fehlschlagen:

- gilt das Deployment als fehlgeschlagen
- werden bereits gestartete Lifecycle-Contributions aufgeräumt
- bleibt die Datenbank auf der neuen Revision
- erfolgt kein automatischer DB-Downgrade
- wird ein Forward-Fix bevorzugt
- darf Code nur bei nachgewiesener DB-Kompatibilität zurückgerollt werden
- benötigt ein DB-Downgrade weiterhin eine explizite und geprüfte Zielrevision

## Dokumentation

Neu:

- `docs/modules/lifecycle.md`

Ergänzt und verknüpft:

- `docs/README.md`
- `docs/deployment.md`
- `docs/modules/backend-module-runtime.md`
- `docs/modules/database-and-migrations.md`
- `docs/modules/frontend-host.md`
- `docs/modules/operations.md`

## Validierung

Backend:

- `uv sync --frozen --extra dev --no-editable` – erfolgreich
- `uv run ruff check .` – erfolgreich
- `uv run pytest` – 889 Tests bestanden
- `uv run python -m app.cli.module_migrations preflight` – erfolgreich
- geprüfter Host-Head: `20260825_0034`

Frontend:

- `pnpm install --frozen-lockfile` – erfolgreich
- `pnpm test` – 506 Tests bestanden
- `pnpm typecheck` – erfolgreich
- `pnpm build` – erfolgreich

Module Contract Gate:

- Backend-Architekturprüfung – erfolgreich
- 276 Backend-Contract-Tests – erfolgreich
- Frontend-Architekturprüfung – erfolgreich
- Frontend-Modul-Preflight – erfolgreich
- 46 Frontend-Contract-Tests – erfolgreich
- 3 SSR-Modultests – erfolgreich

Zusätzlich:

- Enable-Matrix für `analysis-areas` – erfolgreich
- Backend-Inventar – erfolgreich
- Frontend-Preflight – erfolgreich
- `git diff --check` – erfolgreich

## Scope

Nicht eingeführt wurden:

- persistente Lifecycle-State-Machine
- Installer oder `modules.lock`
- `.ocp`-Bundle-Verarbeitung
- Package Registry oder Marketplace
- Runtime Hot Enable
- automatischer DB-Rollback
- zusätzlicher Lifecycle-CI-Workflow
- zweite operationale Statusprojektion

Closes #112  
Part of #91  
Coordinates #108 #111  
Next: #173