### PR TITLE
feat(modules): add versioned ocp package bundles

### DIFF
--- a/backend/app/cli/modules.py
+++ b/backend/app/cli/modules.py
@@ -11,13 +11,22 @@ from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from app.cli import module_migrations
 from app.core.config import BACKEND_ENV_FILE, get_settings
+from app.platform.modules.bundle import (
+    build_ocp_bundle,
+    load_bundle_manifest,
+    staged_ocp_bundle,
+)
 from app.platform.modules.installer import (
     DEFAULT_INSTALL_ROOT,
     EnablementEnvironment,
     ModuleInstaller,
     ModuleInstallerError,
+    ModuleProvenance,
+    ModuleSource,
 )
 from app.platform.modules.settings import read_module_environment
 
@@ -146,6 +155,15 @@ def _render_table(installer: ModuleInstaller) -> str:
     return "\n".join(rows)
 
 
+@contextmanager
+def _installer_package_input(path: Path):
+    if path.suffix == ".ocp":
+        with staged_ocp_bundle(path) as (package_root, _package):
+            yield package_root
+        return
+    yield path
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -168,15 +186,57 @@ def main(argv: Sequence[str] | None = None) -> int:
         "env", help="Render deterministic deploy-time enablement from modules.lock."
     )
     environment.add_argument("--format", choices=("json", "shell"), default="shell")
+    bundle = commands.add_parser("bundle", help="Build deterministic passive OCP bundles.")
+    bundle_commands = bundle.add_subparsers(dest="bundle_command", required=True)
+    bundle_build = bundle_commands.add_parser("build", help="Build one OCP v1 bundle.")
+    bundle_build.add_argument("--manifest", type=Path, required=True)
+    bundle_build.add_argument("--backend", type=Path)
+    bundle_build.add_argument("--frontend", type=Path)
+    bundle_build.add_argument("--publisher", required=True)
+    bundle_build.add_argument("--source-reference", required=True)
+    bundle_build.add_argument("--source-repository", required=True)
+    bundle_build.add_argument("--source-commit", required=True)
+    bundle_build.add_argument("--source-tag")
+    bundle_build.add_argument("--build-workflow", required=True)
+    bundle_build.add_argument("--license", required=True)
+    bundle_build.add_argument("--sbom-reference")
+    bundle_build.add_argument("--attestation-reference")
+    bundle_build.add_argument("--output", type=Path, required=True)
 
     args = parser.parse_args(argv)
-    installer = _installer(_install_root(args.root))
     try:
+        if args.command == "bundle":
+            digest = build_ocp_bundle(
+                args.output,
+                manifest=load_bundle_manifest(args.manifest),
+                publisher=args.publisher,
+                source=ModuleSource(
+                    type="local",
+                    reference=args.source_reference,
+                ),
+                provenance=ModuleProvenance(
+                    source_repository=args.source_repository,
+                    source_commit=args.source_commit,
+                    source_tag=args.source_tag,
+                    build_workflow=args.build_workflow,
+                    license=args.license,
+                    sbom_reference=args.sbom_reference,
+                    attestation_reference=args.attestation_reference,
+                ),
+                backend_artifact=args.backend,
+                frontend_artifact=args.frontend,
+            )
+            print(json.dumps({"bundle": str(args.output), "sha256": digest}, sort_keys=True))
+            return 0
+
+        installer = _installer(_install_root(args.root))
         if args.command == "verify":
-            package = installer.verify_installable(args.package)
+            with _installer_package_input(args.package) as package_root:
+                package = installer.verify_installable(package_root)
             print(package.model_dump_json(exclude={"manifest"}))
         elif args.command == "install":
-            entry = installer.install(args.package)
+            with _installer_package_input(args.package) as package_root:
+                entry = installer.install(package_root)
             print(entry.model_dump_json())
             print("Module installed as disabled; enable and deploy it explicitly.")
         elif args.command == "enable":
@@ -193,14 +253,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if args.format == "json"
                 else _render_table(installer)
             )
-        else:
+        elif args.command == "env":
             values = _environment_values(installer.enablement_environment())
             if args.format == "json":
                 print(json.dumps(values, sort_keys=True, separators=(",", ":")))
             else:
                 for key in sorted(values):
                     print(f"export {key}={shlex.quote(values[key])}")
-    except (ModuleInstallerError, subprocess.CalledProcessError) as exc:
+    except (ModuleInstallerError, ValidationError, subprocess.CalledProcessError) as exc:
         parser.exit(1, f"modules: {exc}\n")
     return 0
 

--- a/backend/app/platform/modules/bundle.py
+++ b/backend/app/platform/modules/bundle.py
@@ -203,7 +203,9 @@ def build_ocp_bundle(
     _validate_declared_bundle(metadata, checksums, members)
     output.parent.mkdir(parents=True, exist_ok=True)
     descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+        ".tmp",
+        f".{output.name}.",
+        output.parent,
     )
     os.close(descriptor)
     temporary = Path(temporary_name)

--- a/backend/app/platform/modules/bundle.py
+++ b/backend/app/platform/modules/bundle.py
@@ -1,0 +1,571 @@
+"""Versioned, passive and deterministic OCP module release bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import tempfile
+import zipfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from tempfile import TemporaryDirectory
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from app.platform.modules.errors import ModuleManifestError
+from app.platform.modules.installer import (
+    LOCAL_PACKAGE_INPUT_FILENAME,
+    Digest,
+    LockedArtifact,
+    ModuleId,
+    ModulePackageError,
+    ModuleProvenance,
+    ModuleSource,
+    PackageComponentInput,
+    VerifiedModulePackage,
+    calculate_package_digest,
+)
+from app.platform.modules.manifest import SemanticVersion, parse_manifest
+
+BUNDLE_FORMAT_VERSION = 1
+BUNDLE_METADATA_PATH = "module.yaml"
+BUNDLE_CHECKSUMS_PATH = "checksums.json"
+MAX_BUNDLE_FILES = 32
+MAX_BUNDLE_FILE_SIZE = 256 * 1024 * 1024
+MAX_BUNDLE_UNCOMPRESSED_SIZE = 512 * 1024 * 1024
+MAX_BUNDLE_ARCHIVE_SIZE = 512 * 1024 * 1024
+MAX_BUNDLE_COMPRESSION_RATIO = 200
+_ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+_ALLOWED_DIRECTORIES = frozenset({"backend", "frontend"})
+
+
+class ModuleBundleError(ModulePackageError):
+    """Base error for an invalid local OCP bundle."""
+
+
+class ModuleBundleFormatError(ModuleBundleError):
+    """The bundle structure or metadata schema is unsupported."""
+
+
+class ModuleBundleIntegrityError(ModuleBundleError):
+    """The bundle payload does not match its integrity metadata."""
+
+
+class _StrictBundleModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class BundleComponent(_StrictBundleModel):
+    artifact: str = Field(min_length=1, max_length=512)
+
+
+class ModuleBundleMetadata(_StrictBundleModel):
+    bundle_format_version: Literal[BUNDLE_FORMAT_VERSION]
+    module_id: ModuleId
+    version: SemanticVersion
+    publisher: str = Field(min_length=1, max_length=255)
+    source: ModuleSource
+    provenance: ModuleProvenance
+    manifest: dict[str, object]
+    backend: BundleComponent | None = None
+    frontend: BundleComponent | None = None
+
+    @model_validator(mode="after")
+    def has_payload(self) -> ModuleBundleMetadata:
+        if self.backend is None and self.frontend is None:
+            raise ValueError("an OCP bundle requires a backend or frontend artifact")
+        return self
+
+
+class BundleChecksums(_StrictBundleModel):
+    algorithm: Literal["sha256"]
+    files: dict[str, Digest]
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeySafeLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> dict[object, object]:
+    result: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in result
+        except TypeError as exc:
+            raise ModuleBundleFormatError("YAML mapping keys must be scalar values.") from exc
+        if duplicate:
+            raise ModuleBundleFormatError(f'Duplicate YAML key "{key}" is forbidden.')
+        result[key] = loader.construct_object(value_node, deep=deep)
+    return result
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def bundle_sha256(path: Path) -> str:
+    return _sha256_file(path)
+
+
+def load_bundle_manifest(path: Path) -> dict[str, object]:
+    """Safely decode a JSON or YAML module manifest for the bundle builder."""
+
+    try:
+        decoded = yaml.load(path.read_text(encoding="utf-8"), Loader=_UniqueKeySafeLoader)
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+        raise ModuleBundleFormatError(f"The module manifest input is invalid: {exc}") from exc
+    if not isinstance(decoded, dict) or not all(isinstance(key, str) for key in decoded):
+        raise ModuleBundleFormatError("The module manifest input must be a string-keyed mapping.")
+    return decoded
+
+
+def build_ocp_bundle(
+    output: Path,
+    *,
+    manifest: Mapping[str, object],
+    publisher: str,
+    source: ModuleSource,
+    provenance: ModuleProvenance,
+    backend_artifact: Path | None = None,
+    frontend_artifact: Path | None = None,
+) -> str:
+    """Build one deterministic OCP v1 ZIP and return its immutable file digest."""
+
+    if output.suffix != ".ocp":
+        raise ModuleBundleFormatError('Bundle output must use the ".ocp" extension.')
+    try:
+        parsed_manifest = parse_manifest(manifest, origin=str(output))
+    except ModuleManifestError as exc:
+        raise ModuleBundleFormatError(str(exc)) from exc
+    if (backend_artifact is None) != (parsed_manifest.backend is None):
+        raise ModuleBundleFormatError(
+            "Backend artifact presence must match the transported module manifest."
+        )
+    if (frontend_artifact is None) != (parsed_manifest.frontend is None):
+        raise ModuleBundleFormatError(
+            "Frontend artifact presence must match the transported module manifest."
+        )
+
+    payloads: dict[str, bytes] = {}
+    if backend_artifact is not None:
+        if backend_artifact.suffix != ".whl":
+            raise ModuleBundleFormatError("Backend bundle artifacts must be wheels.")
+        payloads[f"backend/{backend_artifact.name}"] = _read_local_artifact(
+            backend_artifact
+        )
+    if frontend_artifact is not None:
+        if not frontend_artifact.name.endswith(".tgz"):
+            raise ModuleBundleFormatError('Frontend bundle artifacts must use ".tgz".')
+        payloads[f"frontend/{frontend_artifact.name}"] = _read_local_artifact(
+            frontend_artifact
+        )
+
+    metadata = ModuleBundleMetadata(
+        bundle_format_version=BUNDLE_FORMAT_VERSION,
+        module_id=parsed_manifest.id,
+        version=parsed_manifest.version,
+        publisher=publisher,
+        source=source,
+        provenance=provenance,
+        manifest=parsed_manifest.model_dump(mode="json", by_alias=True),
+        backend=(
+            None
+            if backend_artifact is None
+            else BundleComponent(artifact=f"backend/{backend_artifact.name}")
+        ),
+        frontend=(
+            None
+            if frontend_artifact is None
+            else BundleComponent(artifact=f"frontend/{frontend_artifact.name}")
+        ),
+    )
+    checksums = BundleChecksums(
+        algorithm="sha256",
+        files={name: _sha256_bytes(payload) for name, payload in sorted(payloads.items())},
+    )
+    members = {
+        BUNDLE_METADATA_PATH: _serialize_bundle_metadata(metadata),
+        **payloads,
+        BUNDLE_CHECKSUMS_PATH: _serialize_checksums(checksums),
+    }
+    _validate_declared_bundle(metadata, checksums, members)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        with zipfile.ZipFile(
+            temporary,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
+            strict_timestamps=True,
+        ) as archive:
+            for name in _ordered_member_names(members):
+                info = zipfile.ZipInfo(name, date_time=_ZIP_TIMESTAMP)
+                info.create_system = 3
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = (stat.S_IFREG | 0o644) << 16
+                archive.writestr(info, members[name], compress_type=zipfile.ZIP_DEFLATED)
+        temporary.replace(output)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    return bundle_sha256(output)
+
+
+def read_ocp_bundle(bundle_path: Path, staging_directory: Path) -> VerifiedModulePackage:
+    """Validate and stage one local OCP bundle as the existing installer handoff."""
+
+    path = bundle_path.resolve()
+    if path.suffix != ".ocp" or path.is_symlink() or not path.is_file():
+        raise ModuleBundleFormatError("Bundle input must be a regular local .ocp file.")
+    try:
+        if path.stat().st_size > MAX_BUNDLE_ARCHIVE_SIZE:
+            raise ModuleBundleFormatError("OCP bundle exceeds the compressed size limit.")
+    except OSError as exc:
+        raise ModuleBundleFormatError(f"OCP bundle metadata could not be read: {exc}") from exc
+
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = _inspect_archive(archive)
+            metadata_bytes = _read_member(archive, members[BUNDLE_METADATA_PATH])
+            checksums_bytes = _read_member(archive, members[BUNDLE_CHECKSUMS_PATH])
+            metadata = _parse_bundle_metadata(metadata_bytes)
+            checksums = _parse_checksums(checksums_bytes)
+            payload_paths = _declared_payload_paths(metadata)
+            _validate_member_set(members, payload_paths)
+            _validate_checksums(checksums, payload_paths)
+
+            payloads: dict[str, bytes] = {}
+            for payload_path in payload_paths:
+                payload = _read_member(archive, members[payload_path])
+                if _sha256_bytes(payload) != checksums.files[payload_path]:
+                    raise ModuleBundleIntegrityError(
+                        f'Bundle payload SHA-256 mismatch for "{payload_path}".'
+                    )
+                payloads[payload_path] = payload
+    except ModuleBundleError:
+        raise
+    except (OSError, zipfile.BadZipFile, KeyError) as exc:
+        raise ModuleBundleFormatError(f"The OCP bundle is not a valid ZIP archive: {exc}") from exc
+
+    try:
+        manifest = parse_manifest(
+            metadata.manifest,
+            origin=f"{path}:{BUNDLE_METADATA_PATH}",
+        )
+    except ModuleManifestError as exc:
+        raise ModuleBundleFormatError(str(exc)) from exc
+    if metadata.module_id != manifest.id:
+        raise ModuleBundleFormatError("Bundle module_id does not match the transported manifest ID.")
+    if metadata.version != manifest.version:
+        raise ModuleBundleFormatError("Bundle version does not match the transported manifest version.")
+    if (metadata.backend is None) != (manifest.backend is None):
+        raise ModuleBundleFormatError(
+            "Backend artifact presence does not match the transported manifest."
+        )
+    if (metadata.frontend is None) != (manifest.frontend is None):
+        raise ModuleBundleFormatError(
+            "Frontend artifact presence does not match the transported manifest."
+        )
+
+    staging_root = staging_directory.resolve()
+    staging_root.mkdir(parents=True, exist_ok=True)
+    components: dict[str, PackageComponentInput | None] = {
+        "backend": None,
+        "frontend": None,
+    }
+    for component_name, component in (
+        ("backend", metadata.backend),
+        ("frontend", metadata.frontend),
+    ):
+        if component is None:
+            continue
+        payload = payloads[component.artifact]
+        target = staging_root.joinpath(*PurePosixPath(component.artifact).parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+        components[component_name] = PackageComponentInput(
+            path=component.artifact,
+            artifact=PurePosixPath(component.artifact).name,
+            sha256=checksums.files[component.artifact],
+        )
+
+    backend = components["backend"]
+    frontend = components["frontend"]
+    package = VerifiedModulePackage(
+        module_id=metadata.module_id,
+        version=metadata.version,
+        publisher=metadata.publisher,
+        source=metadata.source,
+        provenance=metadata.provenance,
+        artifact=LockedArtifact(
+            identifier=path.name,
+            sha256=calculate_package_digest(
+                None
+                if backend is None
+                else (backend.artifact, payloads[backend.path]),
+                None
+                if frontend is None
+                else (frontend.artifact, payloads[frontend.path]),
+            ),
+        ),
+        bundle_sha256=bundle_sha256(path),
+        manifest=manifest.model_dump(mode="json", by_alias=True),
+        backend=backend,
+        frontend=frontend,
+    )
+    (staging_root / LOCAL_PACKAGE_INPUT_FILENAME).write_text(
+        package.model_dump_json(),
+        encoding="utf-8",
+    )
+    return package
+
+
+@contextmanager
+def staged_ocp_bundle(bundle_path: Path) -> Iterator[tuple[Path, VerifiedModulePackage]]:
+    """Keep staged payloads alive only while the authoritative installer consumes them."""
+
+    with TemporaryDirectory(prefix="ocp-bundle-") as temporary:
+        root = Path(temporary)
+        package = read_ocp_bundle(bundle_path, root)
+        yield root, package
+
+
+def _inspect_archive(archive: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
+    infos = archive.infolist()
+    if len(infos) > MAX_BUNDLE_FILES:
+        raise ModuleBundleFormatError("OCP bundle contains too many archive members.")
+    members: dict[str, zipfile.ZipInfo] = {}
+    total_size = 0
+    for info in infos:
+        name = info.filename.rstrip("/")
+        if not name:
+            raise ModuleBundleFormatError("OCP bundle contains an empty archive path.")
+        normalized = _validate_bundle_path(name).as_posix()
+        if normalized in members:
+            raise ModuleBundleFormatError(
+                f'Duplicate OCP bundle path "{normalized}" is forbidden.'
+            )
+        mode = info.external_attr >> 16
+        if info.is_dir():
+            if normalized not in _ALLOWED_DIRECTORIES:
+                raise ModuleBundleFormatError(
+                    f'Unknown OCP bundle directory "{normalized}".'
+                )
+        else:
+            file_type = stat.S_IFMT(mode)
+            if file_type not in {0, stat.S_IFREG}:
+                raise ModuleBundleFormatError("OCP bundles may contain only regular files.")
+            if info.flag_bits & 0x1:
+                raise ModuleBundleFormatError("Encrypted OCP bundle members are forbidden.")
+            if info.file_size > MAX_BUNDLE_FILE_SIZE:
+                raise ModuleBundleFormatError(
+                    f'OCP bundle member "{normalized}" exceeds the file size limit.'
+                )
+            total_size += info.file_size
+            if total_size > MAX_BUNDLE_UNCOMPRESSED_SIZE:
+                raise ModuleBundleFormatError(
+                    "OCP bundle exceeds the total uncompressed size limit."
+                )
+            if (
+                info.file_size > 1024 * 1024
+                and (
+                    info.compress_size == 0
+                    or info.file_size / info.compress_size > MAX_BUNDLE_COMPRESSION_RATIO
+                )
+            ):
+                raise ModuleBundleFormatError(
+                    f'OCP bundle member "{normalized}" exceeds the compression ratio limit.'
+                )
+        members[normalized] = info
+    return members
+
+
+def _validate_bundle_path(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or "\\" in value
+        or "\x00" in value
+        or path.is_absolute()
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or value != path.as_posix()
+    ):
+        raise ModuleBundleFormatError(
+            "OCP bundle paths must be normalized relative POSIX paths."
+        )
+    root = path.parts[0]
+    if len(path.parts) == 1:
+        if root not in {BUNDLE_METADATA_PATH, BUNDLE_CHECKSUMS_PATH, *_ALLOWED_DIRECTORIES}:
+            raise ModuleBundleFormatError(f'Unknown OCP bundle root "{root}".')
+    elif root not in _ALLOWED_DIRECTORIES or len(path.parts) != 2:
+        raise ModuleBundleFormatError(f'Unknown OCP bundle payload path "{value}".')
+    return path
+
+
+def _read_member(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> bytes:
+    with archive.open(info) as stream:
+        payload = stream.read(MAX_BUNDLE_FILE_SIZE + 1)
+    if len(payload) > MAX_BUNDLE_FILE_SIZE:
+        raise ModuleBundleFormatError(
+            f'OCP bundle member "{info.filename}" exceeds the file size limit.'
+        )
+    return payload
+
+
+def _parse_bundle_metadata(payload: bytes) -> ModuleBundleMetadata:
+    try:
+        decoded = yaml.load(payload.decode("utf-8"), Loader=_UniqueKeySafeLoader)
+        return ModuleBundleMetadata.model_validate(decoded)
+    except ModuleBundleError:
+        raise
+    except (UnicodeDecodeError, yaml.YAMLError, ValidationError) as exc:
+        raise ModuleBundleFormatError(f"Invalid module.yaml: {exc}") from exc
+
+
+def _parse_checksums(payload: bytes) -> BundleChecksums:
+    def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ModuleBundleFormatError(
+                    f'Duplicate checksums.json key "{key}" is forbidden.'
+                )
+            result[key] = value
+        return result
+
+    try:
+        decoded = json.loads(payload, object_pairs_hook=unique_object)
+        return BundleChecksums.model_validate(decoded)
+    except ModuleBundleError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+        raise ModuleBundleFormatError(f"Invalid checksums.json: {exc}") from exc
+
+
+def _declared_payload_paths(metadata: ModuleBundleMetadata) -> tuple[str, ...]:
+    paths = tuple(
+        component.artifact
+        for component in (metadata.backend, metadata.frontend)
+        if component is not None
+    )
+    for path in paths:
+        normalized = _validate_bundle_path(path)
+        if normalized.parts[0] == "backend" and not path.endswith(".whl"):
+            raise ModuleBundleFormatError("Backend bundle artifacts must be wheels.")
+        if normalized.parts[0] == "frontend" and not path.endswith(".tgz"):
+            raise ModuleBundleFormatError('Frontend bundle artifacts must use ".tgz".')
+    if len(paths) != len(set(paths)):
+        raise ModuleBundleFormatError("Bundle components must use distinct artifact paths.")
+    return tuple(sorted(paths))
+
+
+def _validate_member_set(
+    members: Mapping[str, zipfile.ZipInfo],
+    payload_paths: tuple[str, ...],
+) -> None:
+    files = {name for name, info in members.items() if not info.is_dir()}
+    expected = {BUNDLE_METADATA_PATH, BUNDLE_CHECKSUMS_PATH, *payload_paths}
+    missing = sorted(expected.difference(files))
+    if missing:
+        raise ModuleBundleFormatError(f'Missing OCP bundle member "{missing[0]}".')
+    unknown = sorted(files.difference(expected))
+    if unknown:
+        raise ModuleBundleFormatError(f'Undeclared OCP bundle member "{unknown[0]}".')
+
+
+def _validate_checksums(
+    checksums: BundleChecksums,
+    payload_paths: tuple[str, ...],
+) -> None:
+    for path in checksums.files:
+        _validate_bundle_path(path)
+    declared = set(payload_paths)
+    actual = set(checksums.files)
+    if actual != declared:
+        missing = sorted(declared.difference(actual))
+        unknown = sorted(actual.difference(declared))
+        detail = missing[0] if missing else unknown[0]
+        raise ModuleBundleIntegrityError(
+            f'Checksums must cover exactly the declared payloads; mismatch at "{detail}".'
+        )
+
+
+def _validate_declared_bundle(
+    metadata: ModuleBundleMetadata,
+    checksums: BundleChecksums,
+    members: Mapping[str, bytes],
+) -> None:
+    payload_paths = _declared_payload_paths(metadata)
+    if set(checksums.files) != set(payload_paths):
+        raise ModuleBundleIntegrityError("Builder checksums do not match bundle payloads.")
+    if set(members) != {BUNDLE_METADATA_PATH, BUNDLE_CHECKSUMS_PATH, *payload_paths}:
+        raise ModuleBundleFormatError("Builder member set does not match bundle metadata.")
+
+
+def _ordered_member_names(members: Mapping[str, bytes]) -> tuple[str, ...]:
+    payloads = sorted(
+        name
+        for name in members
+        if name not in {BUNDLE_METADATA_PATH, BUNDLE_CHECKSUMS_PATH}
+    )
+    return (BUNDLE_METADATA_PATH, *payloads, BUNDLE_CHECKSUMS_PATH)
+
+
+def _serialize_bundle_metadata(metadata: ModuleBundleMetadata) -> bytes:
+    return yaml.safe_dump(
+        metadata.model_dump(mode="json"),
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=1_000_000,
+    ).encode("utf-8")
+
+
+def _serialize_checksums(checksums: BundleChecksums) -> bytes:
+    return (
+        json.dumps(
+            checksums.model_dump(mode="json"),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _read_local_artifact(path: Path) -> bytes:
+    resolved = path.resolve()
+    if path.is_symlink() or not resolved.is_file():
+        raise ModuleBundleFormatError("Bundle artifacts must be regular local files.")
+    if resolved.stat().st_size > MAX_BUNDLE_FILE_SIZE:
+        raise ModuleBundleFormatError("Bundle artifact exceeds the file size limit.")
+    return resolved.read_bytes()
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/backend/app/platform/modules/installer.py
+++ b/backend/app/platform/modules/installer.py
@@ -211,6 +211,7 @@ class VerifiedModulePackage(_StrictModel):
     source: ModuleSource
     provenance: ModuleProvenance
     artifact: LockedArtifact
+    bundle_sha256: Digest | None = None
     manifest: dict[str, object]
     backend: PackageComponentInput | None = None
     frontend: PackageComponentInput | None = None
@@ -787,7 +788,9 @@ def _lock_entry(package: VerifiedModulePackage, *, enabled: bool) -> ModuleLockE
         publisher=package.publisher,
         source=package.source,
         provenance=package.provenance,
-        artifact=package.artifact,
+        artifact=package.artifact.model_copy(
+            update={"sha256": package.bundle_sha256 or package.artifact.sha256}
+        ),
         backend=LockedComponent(
             present=package.backend is not None,
             artifact=None if package.backend is None else package.backend.artifact,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "pyjwt>=2.10.1",
   "pyotp>=2.9.0",
   "python-multipart>=0.0.20",
+  "pyyaml==6.0.3",
   "redis>=5.2,<9",
   "semantic-version>=2.10.0,<3",
   "shapely>=2.1.1",
@@ -50,8 +51,7 @@ dev = [
   "ruff>=0.12.8"
 ]
 security = [
-  "pip-audit==2.10.1",
-  "pyyaml==6.0.3"
+  "pip-audit==2.10.1"
 ]
 
 [tool.ruff]

--- a/backend/tests/test_module_bundle.py
+++ b/backend/tests/test_module_bundle.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.cli import modules as modules_cli
+from app.platform.modules.bundle import (
+    BUNDLE_CHECKSUMS_PATH,
+    BUNDLE_METADATA_PATH,
+    MAX_BUNDLE_FILE_SIZE,
+    ModuleBundleFormatError,
+    ModuleBundleIntegrityError,
+    build_ocp_bundle,
+    bundle_sha256,
+    read_ocp_bundle,
+    staged_ocp_bundle,
+)
+from app.platform.modules.installer import (
+    ModuleProvenance,
+    ModuleSource,
+    installed_backend_distribution_paths,
+    read_modules_lock,
+)
+from tests.test_module_installer import (
+    _frontend_archive,
+    _installer,
+    _manifest,
+    _wheel,
+)
+
+
+def _source(module_id: str) -> ModuleSource:
+    return ModuleSource(type="local", reference=f"releases/{module_id}")
+
+
+def _provenance(version: str = "1.0.0") -> ModuleProvenance:
+    return ModuleProvenance(
+        source_repository="https://github.com/example/ocp-module",
+        source_commit="a" * 40,
+        source_tag=f"v{version}",
+        build_workflow="github-actions/module-release",
+        license="AGPL-3.0-only",
+    )
+
+
+def _bundle(
+    root: Path,
+    module_id: str,
+    *,
+    backend: bool = True,
+    frontend: bool = True,
+    output_name: str | None = None,
+) -> tuple[Path, dict[str, object]]:
+    manifest = _manifest(
+        module_id,
+        backend=backend,
+        frontend=frontend,
+    )
+    artifacts = root / f"artifacts-{module_id}"
+    backend_path = _wheel(artifacts, module_id, manifest) if backend else None
+    frontend_path = (
+        _frontend_archive(artifacts, module_id, "1.0.0", backend=backend)
+        if frontend
+        else None
+    )
+    output = root / (output_name or f"{module_id}-1.0.0.ocp")
+    build_ocp_bundle(
+        output,
+        manifest=manifest,
+        publisher="fixture-publisher",
+        source=_source(module_id),
+        provenance=_provenance(),
+        backend_artifact=backend_path,
+        frontend_artifact=frontend_path,
+    )
+    return output, manifest
+
+
+def _members(path: Path) -> dict[str, bytes]:
+    with zipfile.ZipFile(path) as archive:
+        return {
+            info.filename: archive.read(info)
+            for info in archive.infolist()
+            if not info.is_dir()
+        }
+
+
+def _write_zip(path: Path, members: list[tuple[zipfile.ZipInfo | str, bytes]]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for member, payload in members:
+            archive.writestr(member, payload)
+
+
+def _replace_members(path: Path, members: dict[str, bytes]) -> None:
+    _write_zip(path, list(members.items()))
+
+
+def test_fullstack_bundle_maps_to_existing_installer_and_lifecycle(tmp_path: Path) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, "bundle-fullstack")
+    installer = _installer(tmp_path / "state")
+
+    with staged_ocp_bundle(bundle) as (package_root, package):
+        assert package.module_id == "bundle-fullstack"
+        assert package.bundle_sha256 == hashlib.sha256(bundle.read_bytes()).hexdigest()
+        verified = installer.verify_installable(package_root)
+        assert verified.bundle_sha256 == package.bundle_sha256
+        assert not installer.lock_path.exists()
+
+    with staged_ocp_bundle(bundle) as (package_root, _package):
+        installed = installer.install(package_root)
+    assert installed.enabled is False
+    assert installed.artifact.sha256 == bundle_sha256(bundle)
+    assert read_modules_lock(installer.lock_path).modules == (installed,)
+
+    assert installer.enable("bundle-fullstack").enabled is True
+    assert "bundle-fullstack" in installer.enablement_environment().runtime_backend_paths
+    assert installer.disable("bundle-fullstack").enabled is False
+    assert installer.enablement_environment().runtime_backend_paths == ""
+    assert "bundle-fullstack/1.0.0/backend/site-packages" in str(
+        installed_backend_distribution_paths(installer.root)[0]
+    )
+    assert (installer.root / "installed/bundle-fullstack/1.0.0").is_dir()
+    assert installer.enable("bundle-fullstack").enabled is True
+
+
+@pytest.mark.parametrize(
+    ("module_id", "backend", "frontend"),
+    (
+        ("backend-bundle", True, False),
+        ("frontend-bundle", False, True),
+    ),
+)
+def test_backend_only_and_frontend_only_bundles_install(
+    tmp_path: Path,
+    module_id: str,
+    backend: bool,
+    frontend: bool,
+) -> None:
+    bundle, _manifest_data = _bundle(
+        tmp_path,
+        module_id,
+        backend=backend,
+        frontend=frontend,
+    )
+    installer = _installer(tmp_path / f"state-{module_id}")
+
+    with staged_ocp_bundle(bundle) as (package_root, _package):
+        entry = installer.install(package_root)
+
+    assert entry.backend.present is backend
+    assert entry.frontend.present is frontend
+    assert entry.enabled is False
+    assert installer.enable(module_id).enabled is True
+
+
+def test_bundle_build_is_deterministic(tmp_path: Path) -> None:
+    first, manifest = _bundle(tmp_path, "deterministic", output_name="first.ocp")
+    artifacts = tmp_path / "artifacts-deterministic"
+    second = tmp_path / "second.ocp"
+
+    build_ocp_bundle(
+        second,
+        manifest=manifest,
+        publisher="fixture-publisher",
+        source=_source("deterministic"),
+        provenance=_provenance(),
+        backend_artifact=next((artifacts / "backend").glob("*.whl")),
+        frontend_artifact=next((artifacts / "frontend").glob("*.tgz")),
+    )
+
+    assert first.read_bytes() == second.read_bytes()
+    assert bundle_sha256(first) == bundle_sha256(second)
+
+
+@pytest.mark.parametrize("field", ("module_id", "version"))
+def test_bundle_identity_mismatch_fails_before_install(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, f"mismatch-{field.replace('_', '-')}")
+    members = _members(bundle)
+    metadata = yaml.safe_load(members[BUNDLE_METADATA_PATH])
+    metadata[field] = "different-id" if field == "module_id" else "2.0.0"
+    members[BUNDLE_METADATA_PATH] = yaml.safe_dump(metadata, sort_keys=False).encode()
+    _replace_members(bundle, members)
+
+    with pytest.raises(ModuleBundleFormatError, match="does not match"):
+        read_ocp_bundle(bundle, tmp_path / "staging")
+    assert not (tmp_path / "state/modules.lock").exists()
+
+
+def test_unknown_bundle_version_and_unknown_metadata_key_fail(tmp_path: Path) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, "strict-metadata")
+    original_members = _members(bundle)
+    for key, value, expected in (
+        ("bundle_format_version", 99, "bundle_format_version"),
+        ("trusted", True, "trusted"),
+    ):
+        members = dict(original_members)
+        metadata = yaml.safe_load(members[BUNDLE_METADATA_PATH])
+        metadata[key] = value
+        members[BUNDLE_METADATA_PATH] = yaml.safe_dump(metadata, sort_keys=False).encode()
+        _replace_members(bundle, members)
+        with pytest.raises(ModuleBundleFormatError, match=expected):
+            read_ocp_bundle(bundle, tmp_path / f"staging-{key}")
+
+
+@pytest.mark.parametrize("missing", (BUNDLE_METADATA_PATH, BUNDLE_CHECKSUMS_PATH))
+def test_required_bundle_members_are_enforced(tmp_path: Path, missing: str) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, f"missing-{missing.split('.')[0]}")
+    members = _members(bundle)
+    members.pop(missing)
+    _replace_members(bundle, members)
+
+    with pytest.raises(ModuleBundleFormatError, match="module.yaml|checksums.json|valid ZIP"):
+        read_ocp_bundle(bundle, tmp_path / "staging")
+
+
+def test_payload_checksum_mismatch_is_atomic(tmp_path: Path) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, "checksum-mismatch")
+    installer = _installer(tmp_path / "state")
+    members = _members(bundle)
+    payload_path = next(name for name in members if name.startswith("backend/"))
+    members[payload_path] += b"modified"
+    _replace_members(bundle, members)
+
+    with (
+        pytest.raises(ModuleBundleIntegrityError, match="SHA-256 mismatch"),
+        staged_ocp_bundle(bundle) as (package_root, _package),
+    ):
+        installer.install(package_root)
+    assert not installer.lock_path.exists()
+    assert not installer.root.exists()
+
+
+@pytest.mark.parametrize("change", ("missing", "unknown"))
+def test_checksum_coverage_must_exactly_match_payloads(
+    tmp_path: Path,
+    change: str,
+) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, f"checksum-{change}")
+    members = _members(bundle)
+    checksums = json.loads(members[BUNDLE_CHECKSUMS_PATH])
+    if change == "missing":
+        checksums["files"].pop(next(iter(checksums["files"])))
+    else:
+        checksums["files"]["frontend/unknown.tgz"] = "0" * 64
+    members[BUNDLE_CHECKSUMS_PATH] = json.dumps(checksums).encode()
+    _replace_members(bundle, members)
+
+    with pytest.raises(ModuleBundleIntegrityError, match="exactly the declared"):
+        read_ocp_bundle(bundle, tmp_path / "staging")
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "evil.txt",
+        "scripts/install.sh",
+        "../escape.whl",
+        "/absolute.whl",
+        "backend\\escape.whl",
+    ),
+)
+def test_unknown_and_unsafe_bundle_paths_are_rejected(tmp_path: Path, name: str) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, "unsafe-roots")
+    members = list(_members(bundle).items())
+    members.append((name, b"unsafe"))
+    _write_zip(bundle, members)
+
+    with pytest.raises(ModuleBundleFormatError, match="path|root|payload"):
+        read_ocp_bundle(bundle, tmp_path / "staging")
+
+
+def test_duplicate_bundle_paths_are_rejected(tmp_path: Path) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, "duplicate-path")
+    members = list(_members(bundle).items())
+    members.append((BUNDLE_METADATA_PATH, b"duplicate"))
+    _write_zip(bundle, members)
+
+    with pytest.raises(ModuleBundleFormatError, match="Duplicate OCP bundle path"):
+        read_ocp_bundle(bundle, tmp_path / "staging")
+
+
+@pytest.mark.parametrize("file_type", (stat.S_IFLNK, stat.S_IFIFO))
+def test_links_and_special_files_are_rejected(tmp_path: Path, file_type: int) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, "special-file")
+    members: list[tuple[zipfile.ZipInfo | str, bytes]] = list(_members(bundle).items())
+    special = zipfile.ZipInfo("backend/special.whl")
+    special.create_system = 3
+    special.external_attr = (file_type | 0o777) << 16
+    members.append((special, b"target"))
+    _write_zip(bundle, members)
+
+    with pytest.raises(ModuleBundleFormatError, match="regular files"):
+        read_ocp_bundle(bundle, tmp_path / "staging")
+
+
+def test_archive_size_limit_is_checked_before_reading_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, "size-limit")
+    monkeypatch.setattr(
+        "app.platform.modules.bundle.MAX_BUNDLE_FILE_SIZE",
+        16,
+    )
+
+    with pytest.raises(ModuleBundleFormatError, match="file size limit"):
+        read_ocp_bundle(bundle, tmp_path / "staging")
+    assert MAX_BUNDLE_FILE_SIZE > 16
+
+
+def test_extreme_compression_ratio_is_rejected(tmp_path: Path) -> None:
+    bundle = tmp_path / "compression-bomb.ocp"
+    _write_zip(bundle, [(BUNDLE_METADATA_PATH, b"x" * (1024 * 1024 + 1))])
+
+    with pytest.raises(ModuleBundleFormatError, match="compression ratio limit"):
+        read_ocp_bundle(bundle, tmp_path / "staging")
+
+
+def test_cli_verify_and_install_accept_ocp_without_second_installer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle, _manifest_data = _bundle(
+        tmp_path,
+        "cli-bundle",
+        backend=True,
+        frontend=False,
+    )
+    installer = _installer(tmp_path / "state")
+    monkeypatch.setattr(modules_cli, "_installer", lambda _root: installer)
+
+    assert modules_cli.main(["verify", str(bundle)]) == 0
+    verify_output = capsys.readouterr().out
+    assert '"module_id":"cli-bundle"' in verify_output
+    assert not installer.lock_path.exists()
+
+    assert modules_cli.main(["install", str(bundle)]) == 0
+    install_output = capsys.readouterr().out
+    assert '"enabled":false' in install_output
+    assert read_modules_lock(installer.lock_path).modules[0].id == "cli-bundle"
+
+
+def test_bundle_reader_cleanup_removes_private_staging(tmp_path: Path) -> None:
+    bundle, _manifest_data = _bundle(tmp_path, "cleanup")
+    with staged_ocp_bundle(bundle) as (package_root, _package):
+        assert package_root.is_dir()
+        staged_path = package_root
+    assert not staged_path.exists()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -656,6 +656,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pyotp" },
     { name = "python-multipart" },
+    { name = "pyyaml" },
     { name = "redis" },
     { name = "semantic-version" },
     { name = "shapely" },
@@ -672,7 +673,6 @@ dev = [
 ]
 security = [
     { name = "pip-audit" },
-    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -704,7 +704,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
-    { name = "pyyaml", marker = "extra == 'security'", specifier = "==6.0.3" },
+    { name = "pyyaml", specifier = "==6.0.3" },
     { name = "redis", specifier = ">=5.2,<9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.8" },
     { name = "semantic-version", specifier = ">=2.10.0,<3" },

--- a/docs/modules/distribution.md
+++ b/docs/modules/distribution.md
@@ -8,10 +8,9 @@ dem bestehenden [Manifest V1](module-manifest-v1.md), der
 [Trust-Modell](../architecture/adr-module-trust-model.md) auf. Diese bestehenden
 Verträge bleiben maßgeblich.
 
-Die Policy ist der fachliche Input für den Installer und `modules.lock` aus #173,
-das `.ocp`-Bundle aus #174 und die Registry aus #175. Der darauf aufbauende
-[Installer](installer.md) bleibt ein separater technischer Layer; diese Policy legt
-weiterhin kein maschinenlesbares Bundle-Schema fest.
+Die Policy ist der fachliche Input für den [Installer und `modules.lock`](installer.md),
+das konkrete [`.ocp` Package Bundle v1](package-bundle.md) und die Registry aus
+#175. Der Installer bleibt ein separater technischer Layer.
 
 ## Kanonische Identität und Namen
 
@@ -91,11 +90,12 @@ Backend- beziehungsweise Frontend-Modulmanifest bleibt die maßgebliche Quelle f
 - Config-Namespace und Persistence-Metadaten;
 - Frontend-Routen sowie UI- und Map-Contributions.
 
-Ein zukünftiges `module.yaml` im `.ocp`-Bundle darf diesen Contract nur
-transportieren oder eindeutig spiegeln. Gespiegelte ID, Version und
+Das `module.yaml` im `.ocp`-Bundle transportiert diesen Contract und ergänzt ihn
+nur um Distribution-Metadaten. Gespiegelte ID, Version und
 Compatibility-Metadaten müssen mit dem eingebetteten bestehenden Manifest
 übereinstimmen; zwei unabhängig pflegbare Versions- oder Dependency-Modelle sind
-unzulässig. Das konkrete Transportformat und dessen Validierung gehören zu #174.
+unzulässig. Das konkrete Transportformat ist in [Package Bundle v1](package-bundle.md)
+festgelegt.
 Publisher-, Provenance-, Lizenz- und Digest-Angaben sind Metadaten der
 Distribution, keine vom Modul selbst festgelegte Runtime-Trustklasse.
 
@@ -148,9 +148,9 @@ entpackt es vor dem Nuxt-Build in die kontrollierte, versionierte Ablage aus
 [#173](installer.md). Das öffentliche Archivlayout und die weitergehende
 Dependency-Integration werden erst in #174 festgelegt.
 
-## Beziehung zum zukünftigen OCP-Bundle
+## Beziehung zum OCP-Bundle v1
 
-Ein mögliches Release `energy-analysis-1.4.0.ocp` fasst die überprüfbaren
+Ein Release `energy-analysis-1.4.0.ocp` fasst die überprüfbaren
 Artefaktklassen einer Modulversion zusammen. Konzeptionell kann es enthalten:
 
 ```text
@@ -164,8 +164,8 @@ Ein Fullstack-Bundle enthält Backend und Frontend mit derselben ID und Version.
 Backend-only- oder Frontend-only-Bundle lässt die nicht benötigte Artefaktklasse
 aus. `module.yaml` transportiert oder spiegelt den vorhandenen Manifest-Contract;
 `checksums.json` bindet die enthaltenen Bytes an ihre Digests. Dateinamen,
-Pflichtfelder, Kanonisierung, Parser und Writer werden in #174 entschieden. Diese
-Policy macht die Skizze nicht zu einem finalen Format.
+Pflichtfelder, Checksums, Sicherheitsgrenzen, Parser und Writer beschreibt
+[Package Bundle v1](package-bundle.md).
 
 ## Integrität, Provenance und Lizenz
 
@@ -302,7 +302,7 @@ npm-Paket gebaut.
   Publisher/Source, Backend-/Frontend-Artefakte und bestehende
   Compatibility-Metadaten; definiert Installation, Ablage und persistente
   Auflösung.
-- **#174 OCP-Bundle:** definiert das endgültige Archiv- und Metadatenschema,
+- **[OCP-Bundle v1](package-bundle.md):** definiert das Archiv- und Metadatenschema,
   transportiert den bestehenden Manifest-Contract und bindet alle Artefakte per
   Digest zu einer Releaseeinheit.
 - **#175 Registry:** indexiert mindestens ID, Version, Publisher, Lizenz,

--- a/docs/modules/getting-started.md
+++ b/docs/modules/getting-started.md
@@ -160,7 +160,7 @@ Erweitere nur die benötigten Verträge:
 - [Security und Community Review](community-module-review.md)
 - [Architecture Rules](architecture-rules.md)
 
-## Built-in und zukünftige Standalone-Module
+## Built-in und Standalone-Module
 
 Built-in First-Party-Module liegen heute direkt im Host-Repository:
 
@@ -172,7 +172,7 @@ frontend/frontend-modules/foo
 Sie werden gemeinsam mit dem Host gebaut und benötigen keinen Installer. Das
 Scaffold aus #110 erzeugt ausschließlich dieses Layout.
 
-Ein zukünftig separat gepflegtes Modul soll dieselben inneren SDK-Verträge in einem
+Ein separat gepflegtes Modul bündelt dieselben inneren SDK-Verträge in einem
 eigenen Repository bündeln:
 
 ```text
@@ -184,11 +184,13 @@ ocp-module-example/
 └── README.md
 ```
 
-Dieses Layout ist noch kein implementiertes Paketformat. Der
-[Installer und `modules.lock`](installer.md) aus #173 konsumieren einen schmalen
-verifizierten lokalen Package-Input; das gemeinsame `.ocp` Package Bundle folgt in
-#174 und die Distribution über eine Package Registry in #175. Das Built-in-
-Scaffold aus #110 benötigt keinen dieser Installationspfade.
+Aus validiertem Manifest, optionalem Backend-Wheel und optionalem Frontend-`.tgz`
+erzeugt `python -m app.cli.modules bundle build` das öffentliche `.ocp`-Release.
+Danach führen `verify`, `install` und `enable` über den bestehenden
+[Installer und `modules.lock`](installer.md). Der vollständige Ablauf steht in
+[Package Bundle v1](package-bundle.md). Eine Registry folgt separat in #175; lokale
+und private Bundles benötigen sie nicht. Das Built-in-Scaffold aus #110 benötigt
+keinen dieser Installationspfade.
 
 Die verbindlichen Namen, Releaseversionen, Artefaktklassen und
 Supply-Chain-Metadaten für ein späteres Standalone-Modul stehen in der

--- a/docs/modules/installer.md
+++ b/docs/modules/installer.md
@@ -10,7 +10,8 @@ den reproduzierbaren Installationszustand. Der
 Runtime.
 
 ```text
-verified local package input
+lokale .ocp-Datei
+  -> Bundle-Reader / VerifiedModulePackage
   -> installer
   -> modules.lock
   -> versionierte Backend-/Frontend-Artefakte
@@ -125,11 +126,11 @@ Lizenz sowie optionale Tag-, SBOM- und Attestation-Referenzen. Hinzu kommen
 Backend-/Frontend-Artefaktbeschreibungen und der bestehende Manifestinhalt. Der
 Vertrag ist kein neues fachliches Manifest.
 
-Der heute unterstützte `LocalPackageSource` erwartet für CLI- und Testzwecke ein
-Verzeichnis mit `verified-package-input.json` und den referenzierten lokalen
-Artefakten. Dieses Handoff-Format ist ausdrücklich kein öffentliches `.ocp`-Format.
-#174 darf es durch einen Bundle-Reader ersetzen, der nach erfolgreicher Prüfung
-denselben `VerifiedModulePackage` erzeugt.
+Der öffentliche Nutzerpfad ist das [`.ocp` Package Bundle v1](package-bundle.md).
+Der sichere Bundle-Reader erzeugt nach Struktur-, Manifest- und Digestprüfung genau
+denselben `VerifiedModulePackage`, den der bestehende Installer konsumiert. Das
+Verzeichnis mit `verified-package-input.json` und referenzierten lokalen Artefakten
+bleibt ein privater Handoff und eine interne Test-Fixture.
 
 Der Release-Digest bindet deterministisch Identifier und SHA-256 der vorhandenen
 Backend-/Frontend-Artefakte. Jeder Komponenten-Digest wird zusätzlich gegen die
@@ -167,10 +168,10 @@ Die CLI folgt den bestehenden Python-Modulbefehlen:
 cd backend
 
 uv run python -m app.cli.modules --root /var/lib/stadtplaner/modules \
-  verify /srv/reviewed/energy-analysis
+  verify /srv/reviewed/energy-analysis-1.4.0.ocp
 
 uv run python -m app.cli.modules --root /var/lib/stadtplaner/modules \
-  install /srv/reviewed/energy-analysis
+  install /srv/reviewed/energy-analysis-1.4.0.ocp
 
 uv run python -m app.cli.modules --root /var/lib/stadtplaner/modules \
   enable energy-analysis
@@ -267,7 +268,7 @@ bleibt eine separate, explizite und backupgestützte Operation.
 
 Uninstall und Upgrade bleiben zunächst außerhalb von #173, weil angewandte
 Migrationshistorie und DB-Kompatibilität keine sichere automatische Entfernung oder
-Rücksetzung erlauben. Ebenfalls nicht enthalten sind finales `.ocp`-Schema oder
-Parser (#174), Registry/HTTP-Client (#175), Marketplace, Web-UI, Hot Update,
+Rücksetzung erlauben. Ebenfalls nicht enthalten sind Registry/HTTP-Client (#175),
+Marketplace, Web-UI, Hot Update,
 Signatur-PKI, Trust State Machine, Dependency Resolver und automatischer
 DB-Downgrade.

--- a/docs/modules/package-bundle.md
+++ b/docs/modules/package-bundle.md
@@ -1,0 +1,139 @@
+# OCP Package Bundle v1
+
+Das `.ocp`-Bundle ist das öffentliche, passive Release- und Transportformat für
+genau ein separat verteiltes Modulrelease. Es ist weder Installer noch Runtime:
+
+```text
+lokale .ocp-Datei
+  -> sicherer Bundle-Reader
+  -> VerifiedModulePackage
+  -> bestehender ModuleInstaller
+  -> modules.lock
+```
+
+## Format und Struktur
+
+Version 1 verwendet ZIP mit der Dateiendung `.ocp`. Der empfohlene Dateiname ist
+`<module-id>-<version>.ocp`; die Identität wird jedoch ausschließlich aus dem
+validierten Inhalt abgeleitet.
+
+```text
+energy-analysis-1.4.0.ocp
+├── module.yaml
+├── backend/
+│   └── ocp_module_energy_analysis-1.4.0-py3-none-any.whl
+├── frontend/
+│   └── energy-analysis-1.4.0.tgz
+└── checksums.json
+```
+
+Backend-only und Frontend-only lassen den jeweils anderen Ordner weg. Mindestens
+eine Komponente ist Pflicht. Andere Roots, mehrere Artefakte einer Komponente und
+nicht deklarierte Dateien sind unzulässig.
+
+## `module.yaml`
+
+`module.yaml` ist ein strikt validierter Distribution-Wrapper:
+
+```yaml
+bundle_format_version: 1
+module_id: energy-analysis
+version: 1.4.0
+publisher: oklabflensburg
+source:
+  type: local
+  reference: releases/energy-analysis-1.4.0
+provenance:
+  source_repository: https://github.com/oklabflensburg/ocp-module-energy-analysis
+  source_commit: 0123456789abcdef0123456789abcdef01234567
+  source_tag: v1.4.0
+  build_workflow: github-actions/module-release
+  license: AGPL-3.0-only
+  sbom_reference: null
+  attestation_reference: null
+manifest:
+  manifest_version: 1
+  id: energy-analysis
+  version: 1.4.0
+  # übriger bestehender Manifest-V1-Contract
+backend:
+  artifact: backend/ocp_module_energy_analysis-1.4.0-py3-none-any.whl
+frontend:
+  artifact: frontend/energy-analysis-1.4.0.tgz
+```
+
+Das eingebettete bestehende Manifest bleibt Source of Truth für Compatibility,
+Dependencies, Capabilities, Permissions, Config und Persistence. Die gespiegelten
+Felder `module_id` und `version` müssen exakt übereinstimmen. Unbekannte
+Bundle-Versionen und Felder sowie doppelte YAML-Keys werden abgelehnt. Das sichere
+YAML-Laden erlaubt keine Python-Tags oder Objektkonstruktion. Publisher ist reine
+Provenance, kein Trust-Grant.
+
+## Checksums und Release-Digest
+
+`checksums.json` enthält ausschließlich lowercase SHA-256-Digests und muss exakt
+jede deklarierte Payload abdecken:
+
+```json
+{"algorithm":"sha256","files":{"backend/foo.whl":"<64 lowercase hex>"}}
+```
+
+`module.yaml` und `checksums.json` besitzen keinen rekursiven Self-Hash. Der
+authoritative Release-Digest ist SHA-256 über die vollständigen `.ocp`-Bytes und
+wird ohne Lockfile-Schemaänderung in `modules.lock` als `artifact.sha256`
+gespeichert. Der bestehende kanonische Komponenten-Digest bleibt intern für den
+`VerifiedModulePackage`-Handoff erhalten.
+
+## Bauen, prüfen und installieren
+
+```bash
+cd backend
+
+uv run python -m app.cli.modules bundle build \
+  --manifest ../module.yaml \
+  --backend ../dist/ocp_module_energy_analysis-1.4.0-py3-none-any.whl \
+  --frontend ../dist/energy-analysis-1.4.0.tgz \
+  --publisher oklabflensburg \
+  --source-reference releases/energy-analysis-1.4.0 \
+  --source-repository https://github.com/oklabflensburg/ocp-module-energy-analysis \
+  --source-commit 0123456789abcdef0123456789abcdef01234567 \
+  --source-tag v1.4.0 \
+  --build-workflow github-actions/module-release \
+  --license AGPL-3.0-only \
+  --output ../dist/energy-analysis-1.4.0.ocp
+
+uv run python -m app.cli.modules verify ../dist/energy-analysis-1.4.0.ocp
+uv run python -m app.cli.modules install ../dist/energy-analysis-1.4.0.ocp
+uv run python -m app.cli.modules enable energy-analysis
+```
+
+Der Builder validiert Manifest und Artefakttypen und erzeugt bei gleichen Inputs
+byte-identische ZIPs: feste Reihenfolge und Zeitstempel, normalisierte Rechte und
+definierte Deflate-Kompression. `verify` ist read-only; `install` übernimmt die
+bestehende atomare Installer-Semantik und installiert zunächst disabled. Das
+frühere `verified-package-input.json` bleibt ausschließlich ein privater Handoff
+und eine Test-Fixture.
+
+## Sicherheitsgrenzen
+
+Der Reader extrahiert niemals pauschal. Er validiert und liest jedes Member
+einzeln, verifiziert die Payload-Digests und staged nur die exakt deklarierten
+Artefakte in einem automatisch bereinigten `TemporaryDirectory`. Abgelehnt werden
+absolute, nicht normalisierte, Backslash-, NUL- und Traversal-Pfade, doppelte
+Pfade, unbekannte Roots, Verschlüsselung, Symlinks und sonstige Spezialdateien.
+Grenzen gelten für 32 Archiv-Member, 256 MiB je Datei, 512 MiB komprimierte sowie
+512 MiB gesamte unkomprimierte Größe; Dateien über 1 MiB dürfen höchstens ein
+Kompressionsverhältnis von 200:1 haben.
+
+Der Reader prüft beim Wheel nur Pfad, Typ und Digest. Namespace, Distribution,
+Entry Point und `--no-index --no-deps` bleiben Aufgabe des bestehenden Installers.
+Entsprechend validiert dessen bestehender Frontendpfad das verschachtelte `.tgz`,
+`module.json` und den realen Nuxt-Modulvertrag. Fehler verändern weder Installation
+noch `modules.lock`.
+
+## Registry-Übergabe
+
+Eine spätere Registry (#175) kann ID, Version, Publisher, Lizenz, lokale/remote
+Artefaktadresse, vollständigen Bundle-SHA-256 und Compatibility-Zusammenfassung
+indexieren. Version 1 implementiert weder Netzwerkzugriff noch Registry,
+Signatur-PKI, Runtime-Download, Upgrade oder Uninstall.

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -123,10 +123,13 @@ der Erzeugung blockiert das Release Gate und damit das Deployment. Bei Pushes au
 beide SBOM-Dateien. Dafür benötigt der Workflow `id-token: write` und
 `attestations: write`.
 
-Die Anwendung veröffentlicht derzeit kein eigenständiges Container-, Wheel- oder
-Frontend-Archiv. Deshalb gibt es noch kein separates binäres Release-Artefakt als
-Attestations-Subjekt. Sobald ein solches Artefakt eingeführt wird, sollte dessen
-Digest mit der zugehörigen SBOM über `actions/attest-sbom` attestiert werden.
+Separat verteilte Module werden als [`.ocp` Package Bundle v1](modules/package-bundle.md)
+veröffentlicht. SHA-256 über die vollständigen Bundle-Bytes ist der immutable
+Release-Digest und wird in `modules.lock` übernommen. `module.yaml` kann Referenzen
+auf SBOM und Build-Attestation transportieren; eine spätere Registry (#175)
+indexiert Bundle-Digest und Provenance, ohne einen neuen Trust-Grant zu erzeugen.
+Wo eine Modul-Releasepipeline Attestations erzeugt, soll sie den Bundle-Digest mit
+der zugehörigen SBOM über `actions/attest-sbom` binden.
 
 ### Reviewed Community Modules
 
@@ -141,9 +144,9 @@ Eine eigene Signatur-PKI wird erst bewertet, wenn separate Modul-Artefakte und e
 realer Distributionskanal existieren. Bis dahin gilt: checksums/provenance now,
 signing deferred. Siehe
 [Modul-Trust-ADR](architecture/adr-module-trust-model.md). Der
-[Installer mit `modules.lock`](modules/installer.md) prüft lokale Artefakte vor der
-Installation; das Bundle-Format folgt in #174. Discovery und Runtime implementieren
-keine parallele Integritätsprüfung.
+[Installer mit `modules.lock`](modules/installer.md) prüft lokale `.ocp`-Artefakte
+vor der Installation. Discovery und Runtime implementieren keine parallele
+Integritätsprüfung.
 
 ## Kontrolliertes Notfallupdate
 


### PR DESCRIPTION
## Ausgangslage

Separat verteilte Module benötigen ein öffentliches, reproduzierbares Releaseformat. Der bestehende Installer und `modules.lock` bleiben dabei authoritative. Das Bundle führt weder eine zweite Runtime noch einen zweiten Installer ein.

## Umsetzung

- Einführung des passiven, versionierten ZIP-Formats `.ocp` v1
- Definierte Bundle-Struktur mit:
  - `module.yaml`
  - `checksums.json`
  - optional genau einem Backend-Wheel
  - optional genau einem Frontend-`.tgz`
- Strikte Validierung von:
  - Bundle-Formatversion
  - YAML- und JSON-Struktur
  - Modul-ID und Version
  - Artefaktpfaden
  - SHA-256-Digests
- Schutz vor:
  - Path Traversal
  - absoluten und unnormalisierten Pfaden
  - Backslash- und NUL-Pfaden
  - doppelten Archiveinträgen
  - unbekannten Roots
  - Symlinks und Special Files
  - verschlüsselten Archiveinträgen
  - übergroßen oder extrem komprimierten Archiven
- Abbildung validierter Bundles auf den bestehenden `VerifiedModulePackage`-Contract
- Wiederverwendung des vorhandenen `ModuleInstaller`
- Direkte Unterstützung lokaler `.ocp`-Dateien durch:
  - `verify`
  - `install`
- Neuer deterministischer `bundle build`-Befehl
- SHA-256 der vollständigen `.ocp`-Datei als Release-Digest in `modules.lock`
- Keine Änderung des bestehenden `modules.lock`-Formats
- Unterstützung für:
  - Fullstack-Module
  - Backend-only-Module
  - Frontend-only-Module
- Aktualisierung der Dokumentation für Format, Build, Verify, Installation, Security und Registry-Übergabe

## Architektur

Der neue Ablauf lautet:

```text
lokale .ocp-Datei
→ sicherer Bundle-Reader
→ VerifiedModulePackage
→ bestehender ModuleInstaller
→ modules.lock
```

Das bestehende Modulmanifest bleibt Source of Truth für:

- Identität und Version
- Host- und SDK-Kompatibilität
- Dependencies
- Capabilities und Permissions
- Konfiguration
- Persistence und Migrationen

`module.yaml` transportiert dieses Manifest lediglich zusammen mit Distribution- und Provenance-Metadaten.

## Sicherheit

Für `.ocp` v1 gelten folgende Grenzen:

- maximal 32 Archiveinträge
- maximal 256 MiB je Datei
- maximal 512 MiB komprimierte Bundle-Größe
- maximal 512 MiB gesamte unkomprimierte Größe
- maximal 200:1 Kompressionsverhältnis für Dateien über 1 MiB
- keine pauschale Archivextraktion
- keine Scripts, Hooks oder ausführbaren Bundle-Befehle
- keine Runtime-Downloads
- Backend-Wheels weiterhin mit `--no-index --no-deps`
- bestehende Wheel-, Namespace-, Entry-Point- und Frontend-Prüfungen bleiben authoritative

Fehler beim Lesen, Verifizieren oder Installieren verändern weder die Installation noch `modules.lock`.

## Validierung

- Backend-Test-Suite: 941 Tests erfolgreich
- neue Bundle-Test-Suite: 24 Tests erfolgreich
- bestehende Installer-Regressionstests: erfolgreich
- Ruff: erfolgreich
- Migrations-Preflight: erfolgreich
- Module Contract Gate:
  - Backend-Modultests erfolgreich
  - Frontend-Contract-Tests erfolgreich
  - Frontend-Modultests erfolgreich
- Supply-Chain-Verifikation: erfolgreich
- Action-Referenz-Verifikation: erfolgreich
- Supply-Chain-Policy-Tests: 8 erfolgreich
- Backend Dependency Audit: keine bekannten Schwachstellen
- Security-Policy-Prüfung: erfolgreich
- Security-Gate-Tests: 6 erfolgreich
- `git diff --check`: erfolgreich

## Dokumentation

Neu:

- `docs/modules/package-bundle.md`

Aktualisiert:

- `docs/modules/distribution.md`
- `docs/modules/installer.md`
- `docs/modules/getting-started.md`
- `docs/supply-chain.md`

## Bewusster Scope

Nicht enthalten sind:

- Registry
- Netzwerk- oder Runtime-Downloads
- Signatur-PKI
- neue Trust State Machine
- zweiter Installer
- zweite Runtime
- zweites Runtime-Manifest
- Upgrade- oder Uninstall-Engine

Closes #174  
Part of #91  
Parent #108  
Depends on #173 #181  
Coordinates #113  
Next: #175