### PR TITLE
feat(modules): add public backend service ports

### DIFF
--- a/.github/workflows/module-contract.yml
+++ b/.github/workflows/module-contract.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: oklabflensburg/ocp-module-analysis-areas
-          ref: 71815f0396ec8bea545588fd8978dc78b284331a
+          ref: a63af188a0cf4ba10a389302bae4c1e0d80cfeda
           path: .external-analysis-areas
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -107,7 +107,7 @@ jobs:
           (cd .external-analysis-areas/frontend && pnpm install --frozen-lockfile)
       - name: Build the pinned real OCP bundle
         run: |
-          (cd .external-analysis-areas/backend && SOURCE_DATE_EPOCH="$(git -C .. show -s --format=%ct 71815f0396ec8bea545588fd8978dc78b284331a)" uv build --wheel)
+          (cd .external-analysis-areas/backend && SOURCE_DATE_EPOCH="$(git -C .. show -s --format=%ct a63af188a0cf4ba10a389302bae4c1e0d80cfeda)" uv build --wheel)
           (cd .external-analysis-areas/frontend && pnpm build)
           (cd backend && .venv/bin/python -m app.cli.modules bundle build \
             --manifest ../.external-analysis-areas/module.yaml \
@@ -115,7 +115,7 @@ jobs:
             --frontend ../.external-analysis-areas/frontend/dist/analysis-areas-1.0.0.tgz \
             --publisher oklabflensburg --source-reference pull/2 \
             --source-repository https://github.com/oklabflensburg/ocp-module-analysis-areas \
-            --source-commit 71815f0396ec8bea545588fd8978dc78b284331a \
+            --source-commit a63af188a0cf4ba10a389302bae4c1e0d80cfeda \
             --build-workflow github-actions/module-contract --license AGPL-3.0-only \
             --output "${RUNNER_TEMP}/analysis-areas-1.0.0.ocp")
         working-directory: .

--- a/.github/workflows/module-contract.yml
+++ b/.github/workflows/module-contract.yml
@@ -119,6 +119,11 @@ jobs:
             --build-workflow github-actions/module-contract --license AGPL-3.0-only \
             --output "${RUNNER_TEMP}/analysis-areas-1.0.0.ocp")
         working-directory: .
+      - name: Prove the planned public polygon-port consumer flow
+        working-directory: backend
+        run: |
+          .venv/bin/python ../scripts/check_analysis_areas_port_consumer.py \
+            ../.external-analysis-areas/backend/src
       - name: Verify, install disabled and prove migration parity
         working-directory: backend
         run: |

--- a/architecture/module-contract-rules.json
+++ b/architecture/module-contract-rules.json
@@ -32,6 +32,12 @@
       "checker": "scripts/check_external_module_imports.py"
     },
     {
+      "id": "ARCH-BE-PORT-OWNERSHIP-001",
+      "area": "backend",
+      "summary": "Oeffentliche Host-Port-Adapter haengen nicht vom entfernbaren Built-in Analysis Areas ab.",
+      "checker": "backend/tests/test_module_host_ports.py"
+    },
+    {
       "id": "ARCH-BE-SECRET-001",
       "area": "backend",
       "summary": "Backend-Module lesen Konfiguration und Secrets nur ueber namespacete Host-Primitives.",

--- a/architecture/module-contract-rules.json
+++ b/architecture/module-contract-rules.json
@@ -26,6 +26,12 @@
       "checker": "scripts/check_module_architecture.py"
     },
     {
+      "id": "ARCH-BE-INSTALLED-001",
+      "area": "backend",
+      "summary": "Installierte First-Party-Module importieren den Host nur ueber das oeffentliche SDK.",
+      "checker": "scripts/check_external_module_imports.py"
+    },
+    {
       "id": "ARCH-BE-SECRET-001",
       "area": "backend",
       "summary": "Backend-Module lesen Konfiguration und Secrets nur ueber namespacete Host-Primitives.",

--- a/backend/app/integrations/module_host_ports.py
+++ b/backend/app/integrations/module_host_ports.py
@@ -1,0 +1,317 @@
+"""Composition adapters from public module ports to existing Host owners.
+
+Only this boundary knows both the public SDK DTOs and private Host services/models.
+The adapters deliberately contain no copied business logic.
+"""
+
+from dataclasses import fields
+from typing import cast
+from uuid import UUID
+
+from fastapi import Request
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cache.service import cache_service
+from app.core.config import Settings, get_settings
+from app.models.user_polygon import UserPolygon
+from app.modules.analysis_areas.persistence.models import AnalysisArea, PolygonAnalysisArea
+from app.platform.modules.sdk import (
+    AreaStatistics,
+    AreaStatisticSeries,
+    CachePort,
+    CompletenessValue,
+    CountValue,
+    MapPreviewRequest,
+    MapPreviewResult,
+    MapPreviewUnavailableError,
+    PolygonFilterValues,
+    PolygonMetrics,
+    PublicPolygonSummary,
+    PublicQueryLimits,
+    StatisticsArea,
+    StatisticSeriesPoint,
+    StatisticsSource,
+    StatisticValue,
+)
+from app.services import analytics, area_statistics
+from app.services.cache_versions import cache_version
+from app.services.map_previews import MapPreviewError, map_preview_service
+from app.services.public_query_security import (
+    guard_public_query,
+    is_statement_timeout_error,
+)
+
+
+class HostModuleCache(CachePort):
+    """Redis-backed byte cache scoped to exactly one module ID."""
+
+    def __init__(self, module_id: str) -> None:
+        cache_prefix = get_settings().cache_prefix.strip(":")
+        self._prefix = f"{cache_prefix}:module:{module_id}:"
+
+    def _key(self, key: str) -> str:
+        if not key or "\0" in key:
+            raise ValueError("Module cache keys must be non-empty text without NUL bytes.")
+        return f"{self._prefix}{key}"
+
+    async def get(self, key: str) -> bytes | None:
+        return await cache_service.get(self._key(key))
+
+    async def set(self, key: str, value: bytes, *, ttl_seconds: int) -> bool:
+        if type(ttl_seconds) is not int or ttl_seconds < 1:
+            raise ValueError("Module cache TTLs must be positive integer seconds.")
+        return await cache_service.set(self._key(key), value, ttl_seconds)
+
+    async def delete(self, *keys: str) -> int:
+        return await cache_service.delete(*(self._key(key) for key in keys))
+
+    async def clear(self) -> int:
+        return await cache_service.delete_pattern(f"{self._prefix}*")
+
+
+class HostCacheGenerations:
+    """Adapter for shared read-model invalidation generations."""
+
+    async def current(self, session: AsyncSession, resource: str) -> int:
+        return await cache_version(session, resource)
+
+
+class HostPublicQueries:
+    """Adapter for the existing public-query security policy."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        active = settings or get_settings()
+        self._limits = PublicQueryLimits(
+            max_response_items=active.public_polygon_response_limit,
+            cache_debug_headers=active.cache_debug_headers,
+        )
+
+    @property
+    def limits(self) -> PublicQueryLimits:
+        return self._limits
+
+    async def guard(
+        self, request: Request, session: AsyncSession, resource: str
+    ) -> None:
+        await guard_public_query(request, session, resource)
+
+    def is_timeout(self, error: BaseException) -> bool:
+        return is_statement_timeout_error(error)
+
+
+class HostMapPreviews:
+    """Adapter for the existing native map-preview service."""
+
+    async def render(self, request: MapPreviewRequest) -> MapPreviewResult:
+        try:
+            preview = await map_preview_service.get(
+                slug=request.slug,
+                updated_at=request.updated_at,
+                geometry=dict(request.geometry),
+                bbox=request.bbox,
+                width=request.width,
+                height=request.height,
+                category=request.category,
+                feature_kind=request.feature_kind,
+            )
+        except MapPreviewError as exc:
+            raise MapPreviewUnavailableError(str(exc)) from exc
+        return MapPreviewResult(
+            body=preview.body,
+            content_type="image/webp",
+            etag=preview.etag,
+            cache_hit=preview.cache_hit,
+        )
+
+
+def _area_scope(area_id: UUID):
+    return select(PolygonAnalysisArea.polygon_id).join(
+        AnalysisArea, AnalysisArea.id == PolygonAnalysisArea.analysis_area_id
+    ).where(AnalysisArea.uuid == area_id)
+
+
+def _polygon_filters(area_id: UUID, values: PolygonFilterValues):
+    result = analytics._base_filters(
+        values.floors,
+        values.area_sizes,
+        values.occupancy_statuses,
+        values.business_structures,
+        values.sources,
+    )
+    result.append(UserPolygon.id.in_(_area_scope(area_id)))
+    if values.categories:
+        result.append(UserPolygon.category.in_(values.categories))
+    return result
+
+
+class HostPolygonQueries:
+    """Public read projections owned by the polygon domain."""
+
+    async def list_for_area(
+        self, session: AsyncSession, area_id: UUID, *, limit: int
+    ) -> tuple[PublicPolygonSummary, ...] | None:
+        if type(limit) is not int or limit < 1:
+            raise ValueError("Polygon query limits must be positive integer values.")
+        exists = await session.scalar(select(AnalysisArea.id).where(AnalysisArea.uuid == area_id))
+        if exists is None:
+            return None
+        area_m2 = func.ST_Area(func.ST_Transform(UserPolygon.geometry, 25832))
+        rows = (
+            await session.execute(
+                select(
+                    UserPolygon.uuid,
+                    UserPolygon.slug,
+                    UserPolygon.name,
+                    UserPolygon.category,
+                    UserPolygon.floor,
+                    UserPolygon.address_display_name,
+                    UserPolygon.occupancy_status,
+                    area_m2.label("area_m2"),
+                )
+                .where(UserPolygon.id.in_(_area_scope(area_id)))
+                .order_by(UserPolygon.updated_at.desc(), UserPolygon.id.desc())
+                .limit(limit)
+            )
+        ).mappings()
+        return tuple(
+            PublicPolygonSummary(
+                id=str(row["uuid"]),
+                slug=row["slug"],
+                name=row["name"],
+                category=row["category"],
+                floor=row["floor"],
+                address_display_name=row["address_display_name"],
+                occupancy_status=row["occupancy_status"] or "UNKNOWN",
+                area_m2=float(row["area_m2"]) if row["area_m2"] is not None else None,
+            )
+            for row in rows
+        )
+
+
+def _count_values(values) -> tuple[CountValue, ...]:
+    return tuple(
+        CountValue(
+            key=getattr(value, "key", getattr(value, "category", "")),
+            label=getattr(value, "label", None),
+            count=value.count,
+        )
+        for value in values
+    )
+
+
+class HostPolygonAnalytics:
+    """Public aggregate adapter owned by polygon analytics."""
+
+    async def metrics_for_area(
+        self,
+        session: AsyncSession,
+        area_id: UUID,
+        filters: PolygonFilterValues,
+    ) -> PolygonMetrics | None:
+        if await session.scalar(select(AnalysisArea.id).where(AnalysisArea.uuid == area_id)) is None:
+            return None
+        result = await analytics._benchmark_metrics(
+            session, _polygon_filters(area_id, filters)
+        )
+        return PolygonMetrics(
+            **{
+                field.name: getattr(result, field.name)
+                for field in fields(PolygonMetrics)
+                if field.name
+                not in {
+                    "size_distribution",
+                    "floor_distribution",
+                    "status_distribution",
+                    "business_structure_distribution",
+                    "data_completeness",
+                }
+            },
+            size_distribution=_count_values(result.size_distribution),
+            floor_distribution=_count_values(result.floor_distribution),
+            status_distribution=_count_values(result.status_distribution),
+            business_structure_distribution=_count_values(
+                result.business_structure_distribution
+            ),
+            data_completeness=tuple(
+                CompletenessValue(**item.model_dump()) for item in result.data_completeness
+            ),
+        )
+
+    async def category_counts_for_area(
+        self,
+        session: AsyncSession,
+        area_id: UUID,
+        filters: PolygonFilterValues,
+    ) -> tuple[CountValue, ...] | None:
+        if await session.scalar(select(AnalysisArea.id).where(AnalysisArea.uuid == area_id)) is None:
+            return None
+        values = await analytics._counts(
+            session, _polygon_filters(area_id, filters)
+        )
+        return _count_values(values)
+
+
+def _statistics_area(value) -> StatisticsArea:
+    return StatisticsArea(
+        id=value.id,
+        slug=value.slug,
+        name=value.name,
+        area_type=value.area_type,
+    )
+
+
+def _statistics_source(value) -> StatisticsSource | None:
+    if value is None:
+        return None
+    return StatisticsSource(
+        name=value.name,
+        url=value.url,
+        license=value.license,
+        source_updated_at=value.source_updated_at,
+        last_import_at=value.last_import_at,
+    )
+
+
+class HostStatisticsQueries:
+    """Public DTO adapter owned by the municipal-statistics domain."""
+
+    async def for_area(self, session: AsyncSession, slug: str) -> AreaStatistics | None:
+        value = await area_statistics.area_statistics(session, slug)
+        if value is None:
+            return None
+        return AreaStatistics(
+            area=_statistics_area(value.area),
+            statistics_area=_statistics_area(value.statistics_area),
+            inherited_from_parent=value.inherited_from_parent,
+            source=_statistics_source(value.source),
+            latest=tuple(StatisticValue(**item.model_dump()) for item in value.latest),
+        )
+
+    async def series_for_area(
+        self, session: AsyncSession, slug: str, metric_key: str
+    ) -> AreaStatisticSeries | None:
+        value = await area_statistics.area_statistic_series(session, slug, metric_key)
+        if value is None:
+            return None
+        return AreaStatisticSeries(
+            area=_statistics_area(value.area),
+            statistics_area=_statistics_area(value.statistics_area),
+            inherited_from_parent=value.inherited_from_parent,
+            source=_statistics_source(value.source),
+            metric=cast(dict[str, str], value.metric),
+            series=tuple(
+                StatisticSeriesPoint(**item.model_dump()) for item in value.series
+            ),
+        )
+
+
+__all__ = [
+    "HostCacheGenerations",
+    "HostMapPreviews",
+    "HostModuleCache",
+    "HostPolygonAnalytics",
+    "HostPolygonQueries",
+    "HostPublicQueries",
+    "HostStatisticsQueries",
+]

--- a/backend/app/integrations/module_host_ports.py
+++ b/backend/app/integrations/module_host_ports.py
@@ -6,16 +6,14 @@ The adapters deliberately contain no copied business logic.
 
 from dataclasses import fields
 from typing import cast
-from uuid import UUID
 
 from fastapi import Request
-from sqlalchemy import func, select
+from sqlalchemy import any_, false, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cache.service import cache_service
 from app.core.config import Settings, get_settings
 from app.models.user_polygon import UserPolygon
-from app.modules.analysis_areas.persistence.models import AnalysisArea, PolygonAnalysisArea
 from app.platform.modules.sdk import (
     AreaStatistics,
     AreaStatisticSeries,
@@ -27,6 +25,7 @@ from app.platform.modules.sdk import (
     MapPreviewUnavailableError,
     PolygonFilterValues,
     PolygonMetrics,
+    PolygonScope,
     PublicPolygonSummary,
     PublicQueryLimits,
     StatisticsArea,
@@ -34,7 +33,7 @@ from app.platform.modules.sdk import (
     StatisticsSource,
     StatisticValue,
 )
-from app.services import analytics, area_statistics
+from app.services import polygon_analytics
 from app.services.cache_versions import cache_version
 from app.services.map_previews import MapPreviewError, map_preview_service
 from app.services.public_query_security import (
@@ -125,21 +124,21 @@ class HostMapPreviews:
         )
 
 
-def _area_scope(area_id: UUID):
-    return select(PolygonAnalysisArea.polygon_id).join(
-        AnalysisArea, AnalysisArea.id == PolygonAnalysisArea.analysis_area_id
-    ).where(AnalysisArea.uuid == area_id)
+def _polygon_scope_filter(scope: PolygonScope):
+    if not scope.polygon_ids:
+        return false()
+    return UserPolygon.id == any_(scope.polygon_ids)
 
 
-def _polygon_filters(area_id: UUID, values: PolygonFilterValues):
-    result = analytics._base_filters(
+def _polygon_filters(scope: PolygonScope, values: PolygonFilterValues):
+    result = polygon_analytics.base_filters(
         values.floors,
         values.area_sizes,
         values.occupancy_statuses,
         values.business_structures,
         values.sources,
     )
-    result.append(UserPolygon.id.in_(_area_scope(area_id)))
+    result.append(_polygon_scope_filter(scope))
     if values.categories:
         result.append(UserPolygon.category.in_(values.categories))
     return result
@@ -148,14 +147,11 @@ def _polygon_filters(area_id: UUID, values: PolygonFilterValues):
 class HostPolygonQueries:
     """Public read projections owned by the polygon domain."""
 
-    async def list_for_area(
-        self, session: AsyncSession, area_id: UUID, *, limit: int
-    ) -> tuple[PublicPolygonSummary, ...] | None:
+    async def list_by_scope(
+        self, session: AsyncSession, scope: PolygonScope, *, limit: int
+    ) -> tuple[PublicPolygonSummary, ...]:
         if type(limit) is not int or limit < 1:
             raise ValueError("Polygon query limits must be positive integer values.")
-        exists = await session.scalar(select(AnalysisArea.id).where(AnalysisArea.uuid == area_id))
-        if exists is None:
-            return None
         area_m2 = func.ST_Area(func.ST_Transform(UserPolygon.geometry, 25832))
         rows = (
             await session.execute(
@@ -169,7 +165,7 @@ class HostPolygonQueries:
                     UserPolygon.occupancy_status,
                     area_m2.label("area_m2"),
                 )
-                .where(UserPolygon.id.in_(_area_scope(area_id)))
+                .where(_polygon_scope_filter(scope))
                 .order_by(UserPolygon.updated_at.desc(), UserPolygon.id.desc())
                 .limit(limit)
             )
@@ -203,16 +199,14 @@ def _count_values(values) -> tuple[CountValue, ...]:
 class HostPolygonAnalytics:
     """Public aggregate adapter owned by polygon analytics."""
 
-    async def metrics_for_area(
+    async def metrics(
         self,
         session: AsyncSession,
-        area_id: UUID,
+        scope: PolygonScope,
         filters: PolygonFilterValues,
-    ) -> PolygonMetrics | None:
-        if await session.scalar(select(AnalysisArea.id).where(AnalysisArea.uuid == area_id)) is None:
-            return None
-        result = await analytics._benchmark_metrics(
-            session, _polygon_filters(area_id, filters)
+    ) -> PolygonMetrics:
+        result = await polygon_analytics.benchmark_metrics(
+            session, _polygon_filters(scope, filters)
         )
         return PolygonMetrics(
             **{
@@ -238,16 +232,14 @@ class HostPolygonAnalytics:
             ),
         )
 
-    async def category_counts_for_area(
+    async def category_counts(
         self,
         session: AsyncSession,
-        area_id: UUID,
+        scope: PolygonScope,
         filters: PolygonFilterValues,
-    ) -> tuple[CountValue, ...] | None:
-        if await session.scalar(select(AnalysisArea.id).where(AnalysisArea.uuid == area_id)) is None:
-            return None
-        values = await analytics._counts(
-            session, _polygon_filters(area_id, filters)
+    ) -> tuple[CountValue, ...]:
+        values = await polygon_analytics.counts(
+            session, _polygon_filters(scope, filters)
         )
         return _count_values(values)
 
@@ -277,6 +269,8 @@ class HostStatisticsQueries:
     """Public DTO adapter owned by the municipal-statistics domain."""
 
     async def for_area(self, session: AsyncSession, slug: str) -> AreaStatistics | None:
+        from app.services import area_statistics
+
         value = await area_statistics.area_statistics(session, slug)
         if value is None:
             return None
@@ -291,6 +285,8 @@ class HostStatisticsQueries:
     async def series_for_area(
         self, session: AsyncSession, slug: str, metric_key: str
     ) -> AreaStatisticSeries | None:
+        from app.services import area_statistics
+
         value = await area_statistics.area_statistic_series(session, slug, metric_key)
         if value is None:
             return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,15 @@ from app.auth.module_sdk import HostPermissionDependencies
 from app.cache.redis import close_redis, initialize_redis, redis_health
 from app.core.config import BACKEND_ENV_FILE, get_settings
 from app.db.session import AsyncSessionLocal, database_health, engine
+from app.integrations.module_host_ports import (
+    HostCacheGenerations,
+    HostMapPreviews,
+    HostModuleCache,
+    HostPolygonAnalytics,
+    HostPolygonQueries,
+    HostPublicQueries,
+    HostStatisticsQueries,
+)
 from app.models.user import User
 from app.observability.logging import configure_logging
 from app.observability.metrics import REDIS_AVAILABLE, REGISTRY, set_build_info
@@ -94,6 +103,13 @@ module_runtime = create_module_runtime(
         ModuleHostServices(
             database=HostDatabaseSessionProvider(),
             permission_dependencies=HostPermissionDependencies(),
+            cache_factory=HostModuleCache,
+            cache_generations=HostCacheGenerations(),
+            public_queries=HostPublicQueries(settings),
+            map_previews=HostMapPreviews(),
+            polygons=HostPolygonQueries(),
+            polygon_analytics=HostPolygonAnalytics(),
+            statistics=HostStatisticsQueries(),
         ),
         event_bus=event_bus,
         permission_engine=permission_engine,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -35,11 +35,9 @@ from app.models.user import User
 from app.models.user_polygon import UserPolygon
 from app.models.user_session import UserSession
 from app.models.verification_token import EmailVerificationToken
-from app.modules.analysis_areas.persistence.models import AnalysisArea, PolygonAnalysisArea
 
 __all__ = [
     "AdminAuditLog",
-    "AnalysisArea",
     "AuthMfaChallenge",
     "CacheVersion",
     "CityMetrics",
@@ -59,7 +57,6 @@ __all__ = [
     "OAuthFlowGrant",
     "OsmFeature",
     "PasswordResetToken",
-    "PolygonAnalysisArea",
     "PolygonOsmSource",
     "PolygonOutbox",
     "SocialPublication",

--- a/backend/app/platform/modules/context.py
+++ b/backend/app/platform/modules/context.py
@@ -16,19 +16,25 @@ from app.platform.modules.permissions import (
     RegistryPermissionPort,
 )
 from app.platform.modules.sdk import (
+    CacheGenerationPort,
     CachePort,
     DatabaseSessionProvider,
     EventBusPort,
     HttpClientFactoryPort,
+    MapPreviewPort,
     MetricsPort,
     ModuleContext,
     ModuleSettingsPort,
     ObservabilityPort,
     PermissionDependencyFactory,
     PermissionPort,
+    PolygonAnalyticsPort,
+    PolygonQueryPort,
+    PublicQueryPort,
     SchedulerPort,
     ServiceRegistryPort,
     SpanPort,
+    StatisticsQueryPort,
     StoragePort,
     TracerPort,
 )
@@ -88,7 +94,7 @@ class _ModuleObservability:
 
 @dataclass(frozen=True, slots=True)
 class ModuleHostServices:
-    """Hostseitiges Adapter-Bundle; optionale Ports folgen in ihren Folge-Issues."""
+    """Hostseitiges Adapter-Bundle für öffentliche, typisierte Capabilities."""
 
     database: DatabaseSessionProvider | None = None
     events: EventBusPort | None = None
@@ -96,6 +102,13 @@ class ModuleHostServices:
     permissions: PermissionPort | None = None
     permission_dependencies: PermissionDependencyFactory | None = None
     cache: CachePort | None = None
+    cache_factory: Callable[[str], CachePort] | None = None
+    cache_generations: CacheGenerationPort | None = None
+    public_queries: PublicQueryPort | None = None
+    map_previews: MapPreviewPort | None = None
+    polygons: PolygonQueryPort | None = None
+    polygon_analytics: PolygonAnalyticsPort | None = None
+    statistics: StatisticsQueryPort | None = None
     storage: StoragePort | None = None
     http: HttpClientFactoryPort | None = None
     scheduler: SchedulerPort | None = None
@@ -197,7 +210,17 @@ class ModuleContextFactory:
             services=service_adapter,
             permissions=self._permission_port,
             permission_dependencies=self._services.permission_dependencies,
-            cache=self._services.cache,
+            cache=(
+                self._services.cache_factory(manifest.id)
+                if self._services.cache_factory is not None
+                else self._services.cache
+            ),
+            cache_generations=self._services.cache_generations,
+            public_queries=self._services.public_queries,
+            map_previews=self._services.map_previews,
+            polygons=self._services.polygons,
+            polygon_analytics=self._services.polygon_analytics,
+            statistics=self._services.statistics,
             storage=self._services.storage,
             http=self._services.http,
             scheduler=scheduler_adapter,

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -39,7 +39,7 @@ from app.platform.modules.settings import (
 )
 
 logger = logging.getLogger(__name__)
-MODULE_SDK_VERSION = "1.8.0"
+MODULE_SDK_VERSION = "1.9.0"
 
 
 @dataclass(slots=True)

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -404,6 +404,21 @@ class MapPreviewPort(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
+class PolygonScope:
+    """Fachneutrale Auswahl interner Polygon-IDs aus einer Modulrelation."""
+
+    polygon_ids: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.polygon_ids, tuple):
+            raise TypeError("Polygon scope IDs must be an immutable tuple.")
+        if any(type(value) is not int or value < 1 for value in self.polygon_ids):
+            raise ValueError("Polygon scope IDs must be positive integers.")
+        if len(set(self.polygon_ids)) != len(self.polygon_ids):
+            raise ValueError("Polygon scope IDs must be unique.")
+
+
+@dataclass(frozen=True, slots=True)
 class PolygonFilterValues:
     """Öffentliche Polygonfilter aus stabilen primitiven Werten."""
 
@@ -476,29 +491,29 @@ class PublicPolygonSummary:
 
 
 class PolygonQueryPort(Protocol):
-    """Liest öffentliche Polygonprojektionen für ein räumliches Gebiet."""
+    """Liest öffentliche Polygonprojektionen für eine fachneutrale Auswahl."""
 
-    async def list_for_area(
-        self, session: AsyncSession, area_id: UUID, *, limit: int
-    ) -> tuple[PublicPolygonSummary, ...] | None: ...
+    async def list_by_scope(
+        self, session: AsyncSession, scope: PolygonScope, *, limit: int
+    ) -> tuple[PublicPolygonSummary, ...]: ...
 
 
 class PolygonAnalyticsPort(Protocol):
-    """Berechnet Polygon-Aggregate für ein räumliches Gebiet."""
+    """Berechnet Polygon-Aggregate für eine fachneutrale Auswahl."""
 
-    async def metrics_for_area(
+    async def metrics(
         self,
         session: AsyncSession,
-        area_id: UUID,
+        scope: PolygonScope,
         filters: PolygonFilterValues,
-    ) -> PolygonMetrics | None: ...
+    ) -> PolygonMetrics: ...
 
-    async def category_counts_for_area(
+    async def category_counts(
         self,
         session: AsyncSession,
-        area_id: UUID,
+        scope: PolygonScope,
         filters: PolygonFilterValues,
-    ) -> tuple[CountValue, ...] | None: ...
+    ) -> tuple[CountValue, ...]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -896,6 +911,7 @@ __all__ = [
     "PolygonFilterValues",
     "PolygonMetrics",
     "PolygonQueryPort",
+    "PolygonScope",
     "PublicPolygonSummary",
     "PublicQueryLimits",
     "PublicQueryPort",

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -11,12 +11,13 @@ import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 from types import MappingProxyType
 from typing import Protocol, TypeVar, overload
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from pydantic import BaseModel
 from sqlalchemy import MetaData
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -335,6 +336,245 @@ class CachePort(Protocol):
     async def clear(self) -> int: ...
 
 
+class CacheGenerationPort(Protocol):
+    """Versioniert geteilte Lesemodelle ohne Redis- oder Cache-Key-Details."""
+
+    async def current(self, session: AsyncSession, resource: str) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PublicQueryLimits:
+    """Unveränderliche Limits für öffentliche, potentiell teure Modulabfragen."""
+
+    max_response_items: int
+    cache_debug_headers: bool = False
+
+    def __post_init__(self) -> None:
+        if type(self.max_response_items) is not int or self.max_response_items < 1:
+            raise ValueError("Public query response limits must be positive integers.")
+        if type(self.cache_debug_headers) is not bool:
+            raise TypeError("The cache debug header flag must be a boolean.")
+
+
+class PublicQueryPort(Protocol):
+    """Wendet Host-eigene Rate- und Statement-Timeout-Regeln an."""
+
+    @property
+    def limits(self) -> PublicQueryLimits: ...
+
+    async def guard(
+        self, request: Request, session: AsyncSession, resource: str
+    ) -> None: ...
+
+    def is_timeout(self, error: BaseException) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class MapPreviewRequest:
+    """Technologieneutrale Eingabe für eine öffentliche Kartenvorschau."""
+
+    slug: str
+    updated_at: datetime
+    geometry: Mapping[str, object]
+    bbox: tuple[float, float, float, float]
+    width: int
+    height: int
+    category: str | None = None
+    feature_kind: str = "area"
+
+
+@dataclass(frozen=True, slots=True)
+class MapPreviewResult:
+    """Gerenderte Bytes mit stabilen HTTP-Validierungsmetadaten."""
+
+    body: bytes
+    content_type: str
+    etag: str
+    cache_hit: bool = False
+
+
+class MapPreviewUnavailableError(RuntimeError):
+    """Eine gültige Vorschauanfrage konnte nicht gerendert werden."""
+
+
+class MapPreviewPort(Protocol):
+    """Rendert Vorschauen ohne Renderer-, Dateisystem- oder Cache-Interna."""
+
+    async def render(self, request: MapPreviewRequest) -> MapPreviewResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PolygonFilterValues:
+    """Öffentliche Polygonfilter aus stabilen primitiven Werten."""
+
+    categories: tuple[str, ...] = ()
+    floors: tuple[str, ...] = ()
+    area_sizes: tuple[str, ...] = ()
+    occupancy_statuses: tuple[str, ...] = ()
+    business_structures: tuple[str, ...] = ()
+    sources: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CountValue:
+    """Ein stabiler Schlüssel mit Anzahl und optionaler Beschriftung."""
+
+    key: str
+    count: int
+    label: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CompletenessValue:
+    """Vollständigkeit eines Polygonattributs in einem Aggregat."""
+
+    key: str
+    label: str
+    complete: int
+    total: int
+    percent: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PolygonMetrics:
+    """Öffentliches Aggregat der Polygon-/Analytics-Domäne."""
+
+    polygon_count: int
+    occupied_count: int
+    vacant_count: int
+    chain_count: int
+    independent_count: int
+    known_occupancy_count: int
+    known_business_structure_count: int
+    total_area_m2: float | None = None
+    average_area_m2: float | None = None
+    median_area_m2: float | None = None
+    vacant_area_m2: float | None = None
+    vacancy_area_rate: float | None = None
+    vacancy_rate: float | None = None
+    chain_store_rate: float | None = None
+    data_updated_at: datetime | None = None
+    size_distribution: tuple[CountValue, ...] = ()
+    floor_distribution: tuple[CountValue, ...] = ()
+    status_distribution: tuple[CountValue, ...] = ()
+    business_structure_distribution: tuple[CountValue, ...] = ()
+    data_completeness: tuple[CompletenessValue, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PublicPolygonSummary:
+    """Schreibgeschützte Polygonprojektion, niemals eine Host-ORM-Instanz."""
+
+    id: str
+    slug: str
+    name: str
+    category: str
+    occupancy_status: str
+    floor: str | None = None
+    address_display_name: str | None = None
+    area_m2: float | None = None
+
+
+class PolygonQueryPort(Protocol):
+    """Liest öffentliche Polygonprojektionen für ein räumliches Gebiet."""
+
+    async def list_for_area(
+        self, session: AsyncSession, area_id: UUID, *, limit: int
+    ) -> tuple[PublicPolygonSummary, ...] | None: ...
+
+
+class PolygonAnalyticsPort(Protocol):
+    """Berechnet Polygon-Aggregate für ein räumliches Gebiet."""
+
+    async def metrics_for_area(
+        self,
+        session: AsyncSession,
+        area_id: UUID,
+        filters: PolygonFilterValues,
+    ) -> PolygonMetrics | None: ...
+
+    async def category_counts_for_area(
+        self,
+        session: AsyncSession,
+        area_id: UUID,
+        filters: PolygonFilterValues,
+    ) -> tuple[CountValue, ...] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class StatisticsArea:
+    id: UUID
+    slug: str
+    name: str
+    area_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class StatisticsSource:
+    name: str
+    url: str
+    license: str
+    source_updated_at: datetime | None
+    last_import_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class StatisticValue:
+    key: str
+    name: str
+    category: str
+    value: Decimal | None
+    unit: str
+    period: str
+    period_start: date
+    area_level: str
+    is_calculated: bool
+    municipality_value: Decimal | None = None
+    difference: Decimal | None = None
+    relative_difference: Decimal | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AreaStatistics:
+    area: StatisticsArea
+    statistics_area: StatisticsArea
+    inherited_from_parent: bool
+    source: StatisticsSource | None
+    latest: tuple[StatisticValue, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class StatisticSeriesPoint:
+    period: str
+    period_start: date
+    value: Decimal | None
+    suppressed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class AreaStatisticSeries:
+    area: StatisticsArea
+    statistics_area: StatisticsArea
+    inherited_from_parent: bool
+    source: StatisticsSource | None
+    metric: Mapping[str, str]
+    series: tuple[StatisticSeriesPoint, ...] = ()
+
+    def __post_init__(self) -> None:
+        _validate_string_mapping(self.metric, name="metric")
+        object.__setattr__(self, "metric", MappingProxyType(dict(self.metric)))
+
+
+class StatisticsQueryPort(Protocol):
+    """Liest öffentliche Kommunalstatistik ohne Statistics-ORM-Typen."""
+
+    async def for_area(self, session: AsyncSession, slug: str) -> AreaStatistics | None: ...
+
+    async def series_for_area(
+        self, session: AsyncSession, slug: str, metric_key: str
+    ) -> AreaStatisticSeries | None: ...
+
+
 class MetricsPort(Protocol):
     """Vendor-neutraler Zugriff auf begrenzte Modulmetriken."""
 
@@ -555,6 +795,12 @@ class ModuleContext:
     permissions: PermissionPort | None = None
     permission_dependencies: PermissionDependencyFactory | None = None
     cache: CachePort | None = None
+    cache_generations: CacheGenerationPort | None = None
+    public_queries: PublicQueryPort | None = None
+    map_previews: MapPreviewPort | None = None
+    polygons: PolygonQueryPort | None = None
+    polygon_analytics: PolygonAnalyticsPort | None = None
+    statistics: StatisticsQueryPort | None = None
     storage: StoragePort | None = None
     http: HttpClientFactoryPort | None = None
     scheduler: SchedulerPort | None = None
@@ -605,8 +851,13 @@ class ModuleDefinition:
 
 __all__ = [
     "ApiRegistrar",
+    "AreaStatisticSeries",
+    "AreaStatistics",
     "BackendModule",
+    "CacheGenerationPort",
     "CachePort",
+    "CompletenessValue",
+    "CountValue",
     "DatabaseSessionProvider",
     "DomainEvent",
     "EventBusPort",
@@ -622,6 +873,10 @@ __all__ = [
     "JsonValue",
     "LegacyJobHandler",
     "LifecycleRegistrar",
+    "MapPreviewPort",
+    "MapPreviewRequest",
+    "MapPreviewResult",
+    "MapPreviewUnavailableError",
     "MetricsPort",
     "ModuleContext",
     "ModuleDefinition",
@@ -637,11 +892,23 @@ __all__ = [
     "PermissionDefinition",
     "PermissionDependencyFactory",
     "PermissionPort",
+    "PolygonAnalyticsPort",
+    "PolygonFilterValues",
+    "PolygonMetrics",
+    "PolygonQueryPort",
+    "PublicPolygonSummary",
+    "PublicQueryLimits",
+    "PublicQueryPort",
     "RetryPolicy",
     "SchedulerPort",
     "SerializableDomainEvent",
     "ServiceRegistryPort",
     "SpanPort",
+    "StatisticSeriesPoint",
+    "StatisticValue",
+    "StatisticsArea",
+    "StatisticsQueryPort",
+    "StatisticsSource",
     "StoragePort",
     "TracerPort",
     "event_envelope",

--- a/backend/app/services/analytics.py
+++ b/backend/app/services/analytics.py
@@ -18,10 +18,6 @@ from app.schemas.analytics import (
     AreaCompareMetrics,
     AreaCompareRequest,
     AreaCompareResult,
-    BenchmarkMetrics,
-    CompletenessMetric,
-    DimensionCount,
-    IndustryCount,
     MarketBenchmark,
     MarketBenchmarkResult,
     PrimeRentData,
@@ -29,7 +25,12 @@ from app.schemas.analytics import (
 from app.schemas.polygon_filters import PolygonFilterParams
 from app.services.cache_versions import cache_version
 from app.services.city_metrics import get_public_city_metrics
-from app.services.polygon_filters import floor_group_expression, polygon_filter_clauses
+from app.services.polygon_analytics import base_filters as _polygon_base_filters
+from app.services.polygon_analytics import (
+    benchmark_metrics as _benchmark_metrics,
+)
+from app.services.polygon_analytics import counts as _counts
+from app.services.polygon_filters import polygon_filter_clauses
 
 # A shop is currently a public polygon assigned to one of the maintained retail/service
 # categories. "otherAreas" and unknown/custom categories are deliberately excluded.
@@ -54,13 +55,9 @@ def _base_filters(
     sources: Sequence[str] = (),
     analysis_area_id: int | None = None,
 ) -> list[object]:
-    filters = polygon_filter_clauses(PolygonFilterParams(
-        floors=tuple(floors),
-        area_sizes=tuple(area_sizes),
-        occupancy_statuses=tuple(occupancy_statuses),
-        business_structures=tuple(business_structures),
-        sources=tuple(sources),
-    ))
+    filters = _polygon_base_filters(
+        floors, area_sizes, occupancy_statuses, business_structures, sources
+    )
     if analysis_area_id is not None:
         filters.append(UserPolygon.id.in_(
             select(PolygonAnalysisArea.polygon_id).where(PolygonAnalysisArea.analysis_area_id == analysis_area_id)
@@ -72,20 +69,6 @@ async def _resolve_area(session: AsyncSession, area_id: uuid.UUID | None) -> Ana
     if area_id is None:
         return None
     return await session.scalar(select(AnalysisArea).where(AnalysisArea.uuid == area_id))
-
-
-async def _counts(
-    session: AsyncSession,
-    filters: Sequence[object],
-) -> list[IndustryCount]:
-    statement = (
-        select(UserPolygon.category, func.count(UserPolygon.id))
-        .where(*filters)
-        .group_by(UserPolygon.category)
-        .order_by(UserPolygon.category)
-    )
-    rows = (await session.execute(statement)).all()
-    return [IndustryCount(category=category, count=int(count)) for category, count in rows]
 
 
 async def _analytics_overview_uncached(
@@ -197,100 +180,6 @@ async def analytics_overview(
         compute=valid_compute,
     )
     return AnalyticsOverview.model_validate(data)
-
-
-async def _benchmark_metrics(
-    session: AsyncSession, filters: Sequence[object]
-) -> BenchmarkMetrics:
-    area = func.ST_Area(func.ST_Transform(UserPolygon.geometry, 25832))
-    area_size = UserPolygon.properties["size"].as_string()
-    floor_group = floor_group_expression()
-    statement = select(
-        func.count(UserPolygon.id).label("polygon_count"),
-        func.sum(area).label("total_area_m2"),
-        func.avg(area).label("average_area_m2"),
-        func.percentile_cont(0.5).within_group(area).label("median_area_m2"),
-        func.sum(area).filter(UserPolygon.occupancy_status == "VACANT").label("vacant_area_m2"),
-        func.sum(area).filter(UserPolygon.occupancy_status != "UNKNOWN").label("known_occupancy_area_m2"),
-        func.count(UserPolygon.id).filter(UserPolygon.occupancy_status != "UNKNOWN").label("known_occupancy_count"),
-        func.count(UserPolygon.id).filter(UserPolygon.occupancy_status == "VACANT").label("vacant_count"),
-        func.count(UserPolygon.id).filter(UserPolygon.business_structure != "UNKNOWN").label("known_business_count"),
-        func.count(UserPolygon.id).filter(UserPolygon.business_structure == "CHAIN").label("chain_count"),
-        func.max(UserPolygon.updated_at).label("data_updated_at"),
-        *[
-            func.count(UserPolygon.id).filter(area_size == key).label(f"size_{key.lower()}_count")
-            for key in ("S", "M", "L", "XL")
-        ],
-        *[
-            func.count(UserPolygon.id).filter(floor_group == key).label(f"floor_{key.lower()}_count")
-            for key in ("UG", "EG", "OG")
-        ],
-        func.count(UserPolygon.id).filter(UserPolygon.occupancy_status == "OCCUPIED").label("occupied_count"),
-        func.count(UserPolygon.id).filter(UserPolygon.business_structure == "INDEPENDENT").label("independent_count"),
-        func.count(UserPolygon.id).filter(UserPolygon.category != "custom").label("known_category_count"),
-        func.count(UserPolygon.id).filter(floor_group.is_not(None)).label("known_floor_count"),
-        func.count(UserPolygon.id).filter(area_size.is_not(None)).label("known_size_count"),
-    ).where(*filters)
-    row = (await session.execute(statement)).mappings().one()
-    known_occupancy = int(row["known_occupancy_count"] or 0)
-    known_business = int(row["known_business_count"] or 0)
-    vacant = int(row["vacant_count"] or 0)
-    chains = int(row["chain_count"] or 0)
-    polygon_count = int(row["polygon_count"] or 0)
-    vacant_area = float(row["vacant_area_m2"]) if row.get("vacant_area_m2") is not None else None
-    known_occupancy_area = float(row["known_occupancy_area_m2"]) if row.get("known_occupancy_area_m2") is not None else None
-
-    def distribution(prefix: str, values: Sequence[tuple[str, str]]) -> list[DimensionCount]:
-        return [DimensionCount(key=key, label=label, count=int(row.get(f"{prefix}_{key.lower()}_count") or 0)) for key, label in values]
-
-    def completeness(key: str, label: str, complete: int) -> CompletenessMetric:
-        return CompletenessMetric(
-            key=key, label=label, complete=complete, total=polygon_count,
-            percent=round(complete / polygon_count * 100, 1) if polygon_count else None,
-        )
-
-    return BenchmarkMetrics(
-        polygon_count=polygon_count,
-        occupied_count=known_occupancy - vacant,
-        vacant_count=vacant,
-        chain_count=chains,
-        independent_count=known_business - chains,
-        total_area_m2=float(row["total_area_m2"]) if row["total_area_m2"] is not None else None,
-        average_area_m2=float(row["average_area_m2"]) if row["average_area_m2"] is not None else None,
-        median_area_m2=(float(row["median_area_m2"]) if row.get("median_area_m2") is not None else None),
-        vacant_area_m2=vacant_area,
-        vacancy_area_rate=(round(vacant_area / known_occupancy_area * 100, 2) if vacant_area is not None and known_occupancy_area else None),
-        vacancy_rate=(round(vacant / known_occupancy * 100, 2) if known_occupancy else None),
-        chain_store_rate=(round(chains / known_business * 100, 2) if known_business else None),
-        known_occupancy_count=known_occupancy,
-        known_business_structure_count=known_business,
-        data_updated_at=row.get("data_updated_at"),
-        size_distribution=[
-            *distribution("size", (("S", "S"), ("M", "M"), ("L", "L"), ("XL", "XL"))),
-            DimensionCount(key="UNKNOWN", label="Ohne Angabe", count=polygon_count - int(row.get("known_size_count") or 0)),
-        ],
-        floor_distribution=[
-            *distribution("floor", (("UG", "UG"), ("EG", "EG"), ("OG", "OG"))),
-            DimensionCount(key="UNKNOWN", label="Ohne Angabe", count=polygon_count - int(row.get("known_floor_count") or 0)),
-        ],
-        status_distribution=[
-            DimensionCount(key="OCCUPIED", label="Belegt", count=int(row.get("occupied_count") or (known_occupancy - vacant))),
-            DimensionCount(key="VACANT", label="Leerstehend", count=vacant),
-            DimensionCount(key="UNKNOWN", label="Ohne Angabe", count=polygon_count - known_occupancy),
-        ],
-        business_structure_distribution=[
-            DimensionCount(key="CHAIN", label="Filiale", count=chains),
-            DimensionCount(key="INDEPENDENT", label="Inhabergeführt", count=int(row.get("independent_count") or (known_business - chains))),
-            DimensionCount(key="UNKNOWN", label="Ohne Angabe", count=polygon_count - known_business),
-        ],
-        data_completeness=[
-            completeness("category", "Branche", int(row.get("known_category_count") or 0)),
-            completeness("area_size", "Größenklasse", int(row.get("known_size_count") or 0)),
-            completeness("floor", "Etage", int(row.get("known_floor_count") or 0)),
-            completeness("occupancy_status", "Belegungsstatus", known_occupancy),
-            completeness("business_structure", "Betriebsform", known_business),
-        ],
-    )
 
 
 async def _market_benchmarks_uncached(

--- a/backend/app/services/polygon_analytics.py
+++ b/backend/app/services/polygon_analytics.py
@@ -1,0 +1,206 @@
+"""Polygon-owned query helpers without Analysis Areas dependencies."""
+
+from collections.abc import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user_polygon import UserPolygon
+from app.schemas.analytics import (
+    BenchmarkMetrics,
+    CompletenessMetric,
+    DimensionCount,
+    IndustryCount,
+)
+from app.schemas.polygon_filters import PolygonFilterParams
+from app.services.polygon_filters import floor_group_expression, polygon_filter_clauses
+
+
+def base_filters(
+    floors: Sequence[str],
+    area_sizes: Sequence[str],
+    occupancy_statuses: Sequence[str] = (),
+    business_structures: Sequence[str] = (),
+    sources: Sequence[str] = (),
+) -> list[object]:
+    """Build public polygon filters without adding a foreign-domain scope."""
+
+    return polygon_filter_clauses(
+        PolygonFilterParams(
+            floors=tuple(floors),
+            area_sizes=tuple(area_sizes),
+            occupancy_statuses=tuple(occupancy_statuses),
+            business_structures=tuple(business_structures),
+            sources=tuple(sources),
+        )
+    )
+
+
+async def counts(
+    session: AsyncSession,
+    filters: Sequence[object],
+) -> list[IndustryCount]:
+    statement = (
+        select(UserPolygon.category, func.count(UserPolygon.id))
+        .where(*filters)
+        .group_by(UserPolygon.category)
+        .order_by(UserPolygon.category)
+    )
+    rows = (await session.execute(statement)).all()
+    return [IndustryCount(category=category, count=int(count)) for category, count in rows]
+
+
+async def benchmark_metrics(session: AsyncSession, filters: Sequence[object]) -> BenchmarkMetrics:
+    area = func.ST_Area(func.ST_Transform(UserPolygon.geometry, 25832))
+    area_size = UserPolygon.properties["size"].as_string()
+    floor_group = floor_group_expression()
+    statement = select(
+        func.count(UserPolygon.id).label("polygon_count"),
+        func.sum(area).label("total_area_m2"),
+        func.avg(area).label("average_area_m2"),
+        func.percentile_cont(0.5).within_group(area).label("median_area_m2"),
+        func.sum(area).filter(UserPolygon.occupancy_status == "VACANT").label("vacant_area_m2"),
+        func.sum(area)
+        .filter(UserPolygon.occupancy_status != "UNKNOWN")
+        .label("known_occupancy_area_m2"),
+        func.count(UserPolygon.id)
+        .filter(UserPolygon.occupancy_status != "UNKNOWN")
+        .label("known_occupancy_count"),
+        func.count(UserPolygon.id)
+        .filter(UserPolygon.occupancy_status == "VACANT")
+        .label("vacant_count"),
+        func.count(UserPolygon.id)
+        .filter(UserPolygon.business_structure != "UNKNOWN")
+        .label("known_business_count"),
+        func.count(UserPolygon.id)
+        .filter(UserPolygon.business_structure == "CHAIN")
+        .label("chain_count"),
+        func.max(UserPolygon.updated_at).label("data_updated_at"),
+        *[
+            func.count(UserPolygon.id).filter(area_size == key).label(f"size_{key.lower()}_count")
+            for key in ("S", "M", "L", "XL")
+        ],
+        *[
+            func.count(UserPolygon.id)
+            .filter(floor_group == key)
+            .label(f"floor_{key.lower()}_count")
+            for key in ("UG", "EG", "OG")
+        ],
+        func.count(UserPolygon.id)
+        .filter(UserPolygon.occupancy_status == "OCCUPIED")
+        .label("occupied_count"),
+        func.count(UserPolygon.id)
+        .filter(UserPolygon.business_structure == "INDEPENDENT")
+        .label("independent_count"),
+        func.count(UserPolygon.id)
+        .filter(UserPolygon.category != "custom")
+        .label("known_category_count"),
+        func.count(UserPolygon.id).filter(floor_group.is_not(None)).label("known_floor_count"),
+        func.count(UserPolygon.id).filter(area_size.is_not(None)).label("known_size_count"),
+    ).where(*filters)
+    row = (await session.execute(statement)).mappings().one()
+    known_occupancy = int(row["known_occupancy_count"] or 0)
+    known_business = int(row["known_business_count"] or 0)
+    vacant = int(row["vacant_count"] or 0)
+    chains = int(row["chain_count"] or 0)
+    polygon_count = int(row["polygon_count"] or 0)
+    vacant_area = float(row["vacant_area_m2"]) if row.get("vacant_area_m2") is not None else None
+    known_occupancy_area = (
+        float(row["known_occupancy_area_m2"])
+        if row.get("known_occupancy_area_m2") is not None
+        else None
+    )
+
+    def distribution(prefix: str, values: Sequence[tuple[str, str]]) -> list[DimensionCount]:
+        return [
+            DimensionCount(
+                key=key,
+                label=label,
+                count=int(row.get(f"{prefix}_{key.lower()}_count") or 0),
+            )
+            for key, label in values
+        ]
+
+    def completeness(key: str, label: str, complete: int) -> CompletenessMetric:
+        return CompletenessMetric(
+            key=key,
+            label=label,
+            complete=complete,
+            total=polygon_count,
+            percent=round(complete / polygon_count * 100, 1) if polygon_count else None,
+        )
+
+    return BenchmarkMetrics(
+        polygon_count=polygon_count,
+        occupied_count=known_occupancy - vacant,
+        vacant_count=vacant,
+        chain_count=chains,
+        independent_count=known_business - chains,
+        total_area_m2=(float(row["total_area_m2"]) if row["total_area_m2"] is not None else None),
+        average_area_m2=(
+            float(row["average_area_m2"]) if row["average_area_m2"] is not None else None
+        ),
+        median_area_m2=(
+            float(row["median_area_m2"]) if row.get("median_area_m2") is not None else None
+        ),
+        vacant_area_m2=vacant_area,
+        vacancy_area_rate=(
+            round(vacant_area / known_occupancy_area * 100, 2)
+            if vacant_area is not None and known_occupancy_area
+            else None
+        ),
+        vacancy_rate=(round(vacant / known_occupancy * 100, 2) if known_occupancy else None),
+        chain_store_rate=(round(chains / known_business * 100, 2) if known_business else None),
+        known_occupancy_count=known_occupancy,
+        known_business_structure_count=known_business,
+        data_updated_at=row.get("data_updated_at"),
+        size_distribution=[
+            *distribution("size", (("S", "S"), ("M", "M"), ("L", "L"), ("XL", "XL"))),
+            DimensionCount(
+                key="UNKNOWN",
+                label="Ohne Angabe",
+                count=polygon_count - int(row.get("known_size_count") or 0),
+            ),
+        ],
+        floor_distribution=[
+            *distribution("floor", (("UG", "UG"), ("EG", "EG"), ("OG", "OG"))),
+            DimensionCount(
+                key="UNKNOWN",
+                label="Ohne Angabe",
+                count=polygon_count - int(row.get("known_floor_count") or 0),
+            ),
+        ],
+        status_distribution=[
+            DimensionCount(
+                key="OCCUPIED",
+                label="Belegt",
+                count=int(row.get("occupied_count") or (known_occupancy - vacant)),
+            ),
+            DimensionCount(key="VACANT", label="Leerstehend", count=vacant),
+            DimensionCount(
+                key="UNKNOWN",
+                label="Ohne Angabe",
+                count=polygon_count - known_occupancy,
+            ),
+        ],
+        business_structure_distribution=[
+            DimensionCount(key="CHAIN", label="Filiale", count=chains),
+            DimensionCount(
+                key="INDEPENDENT",
+                label="Inhabergeführt",
+                count=int(row.get("independent_count") or (known_business - chains)),
+            ),
+            DimensionCount(
+                key="UNKNOWN",
+                label="Ohne Angabe",
+                count=polygon_count - known_business,
+            ),
+        ],
+        data_completeness=[
+            completeness("category", "Branche", int(row.get("known_category_count") or 0)),
+            completeness("area_size", "Größenklasse", int(row.get("known_size_count") or 0)),
+            completeness("floor", "Etage", int(row.get("known_floor_count") or 0)),
+            completeness("occupancy_status", "Belegungsstatus", known_occupancy),
+            completeness("business_structure", "Betriebsform", known_business),
+        ],
+    )

--- a/backend/tests/test_external_module_imports.py
+++ b/backend/tests/test_external_module_imports.py
@@ -1,0 +1,35 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/check_external_module_imports.py"
+SPEC = importlib.util.spec_from_file_location("external_import_check", SCRIPT)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+def test_external_module_may_import_only_public_sdk(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text(
+        "from app.platform.modules.sdk import ModuleContext\n",
+        encoding="utf-8",
+    )
+
+    assert checker.private_host_imports(tmp_path) == ()
+
+
+def test_external_module_private_host_import_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "legacy.py"
+    source.write_text(
+        "from app.models.user_polygon import UserPolygon\n"
+        "from app.services.analytics import _counts\n",
+        encoding="utf-8",
+    )
+
+    assert [(item.imported, item.line) for item in checker.private_host_imports(tmp_path)] == [
+        ("app.models.user_polygon", 1),
+        ("app.services.analytics", 2),
+    ]

--- a/backend/tests/test_module_host_ports.py
+++ b/backend/tests/test_module_host_ports.py
@@ -1,0 +1,132 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.integrations import module_host_ports
+from app.integrations.module_host_ports import (
+    HostCacheGenerations,
+    HostMapPreviews,
+    HostModuleCache,
+    HostPolygonAnalytics,
+    HostPublicQueries,
+)
+from app.platform.modules.sdk import (
+    MapPreviewRequest,
+    MapPreviewUnavailableError,
+    PolygonFilterValues,
+)
+from app.schemas.analytics import BenchmarkMetrics
+from app.services.map_previews import MapPreview, MapPreviewError
+
+
+@pytest.mark.asyncio
+async def test_module_cache_namespaces_keys_and_hides_cache_service(monkeypatch) -> None:
+    get = AsyncMock(return_value=b"value")
+    set_value = AsyncMock(return_value=True)
+    clear = AsyncMock(return_value=2)
+    monkeypatch.setattr(module_host_ports.cache_service, "get", get)
+    monkeypatch.setattr(module_host_ports.cache_service, "set", set_value)
+    monkeypatch.setattr(module_host_ports.cache_service, "delete_pattern", clear)
+    cache = HostModuleCache("example")
+
+    assert await cache.get("item") == b"value"
+    assert await cache.set("item", b"new", ttl_seconds=30)
+    assert await cache.clear() == 2
+
+    key = get.await_args.args[0]
+    assert key.endswith(":module:example:item")
+    assert set_value.await_args.args == (key, b"new", 30)
+    assert clear.await_args.args == (key.removesuffix("item") + "*",)
+
+
+@pytest.mark.asyncio
+async def test_cache_generations_delegate_without_exposing_storage(monkeypatch) -> None:
+    current = AsyncMock(return_value=7)
+    monkeypatch.setattr(module_host_ports, "cache_version", current)
+    port = HostCacheGenerations()
+    session = object()
+
+    assert await port.current(session, "analytics") == 7
+    current.assert_awaited_once_with(session, "analytics")
+
+
+@pytest.mark.asyncio
+async def test_public_query_port_delegates_guard_and_abstracts_timeout(monkeypatch) -> None:
+    guard = AsyncMock()
+    monkeypatch.setattr(module_host_ports, "guard_public_query", guard)
+    monkeypatch.setattr(module_host_ports, "is_statement_timeout_error", lambda error: True)
+    settings = SimpleNamespace(public_polygon_response_limit=123, cache_debug_headers=True)
+    port = HostPublicQueries(settings)
+    request, session = object(), object()
+
+    await port.guard(request, session, "expensive-query")
+
+    guard.assert_awaited_once_with(request, session, "expensive-query")
+    assert port.limits.max_response_items == 123
+    assert port.limits.cache_debug_headers is True
+    assert port.is_timeout(RuntimeError()) is True
+
+
+@pytest.mark.asyncio
+async def test_preview_port_returns_public_result_and_maps_private_error(monkeypatch) -> None:
+    request = MapPreviewRequest(
+        slug="mitte",
+        updated_at=datetime.now(UTC),
+        geometry={"type": "Polygon", "coordinates": []},
+        bbox=(9.4, 54.7, 9.5, 54.8),
+        width=640,
+        height=360,
+    )
+    monkeypatch.setattr(
+        module_host_ports.map_preview_service,
+        "get",
+        AsyncMock(return_value=MapPreview(b"RIFF", '"etag"', True)),
+    )
+
+    result = await HostMapPreviews().render(request)
+
+    assert result.body == b"RIFF"
+    assert result.content_type == "image/webp"
+    assert result.etag == '"etag"'
+    assert result.cache_hit is True
+
+    monkeypatch.setattr(
+        module_host_ports.map_preview_service,
+        "get",
+        AsyncMock(side_effect=MapPreviewError("renderer offline")),
+    )
+    with pytest.raises(MapPreviewUnavailableError, match="renderer offline"):
+        await HostMapPreviews().render(request)
+
+
+@pytest.mark.asyncio
+async def test_polygon_analytics_maps_private_schema_to_frozen_sdk_dto(monkeypatch) -> None:
+    session = SimpleNamespace(scalar=AsyncMock(return_value=1))
+    monkeypatch.setattr(module_host_ports.analytics, "_base_filters", lambda *args: [])
+    monkeypatch.setattr(
+        module_host_ports.analytics,
+        "_benchmark_metrics",
+        AsyncMock(
+            return_value=BenchmarkMetrics(
+                polygon_count=2,
+                occupied_count=1,
+                vacant_count=1,
+                chain_count=0,
+                independent_count=1,
+                known_occupancy_count=2,
+                known_business_structure_count=1,
+            )
+        ),
+    )
+
+    result = await HostPolygonAnalytics().metrics_for_area(
+        session, uuid4(), PolygonFilterValues(categories=("food",))
+    )
+
+    assert result is not None
+    assert result.polygon_count == 2
+    assert result.vacancy_rate is None
+    assert not hasattr(result, "_sa_instance_state")

--- a/backend/tests/test_module_host_ports.py
+++ b/backend/tests/test_module_host_ports.py
@@ -1,9 +1,13 @@
+import ast
+import subprocess
+import sys
 from datetime import UTC, datetime
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
-from uuid import uuid4
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
 from app.integrations import module_host_ports
 from app.integrations.module_host_ports import (
@@ -11,15 +15,19 @@ from app.integrations.module_host_ports import (
     HostMapPreviews,
     HostModuleCache,
     HostPolygonAnalytics,
+    HostPolygonQueries,
     HostPublicQueries,
 )
 from app.platform.modules.sdk import (
     MapPreviewRequest,
     MapPreviewUnavailableError,
     PolygonFilterValues,
+    PolygonScope,
 )
 from app.schemas.analytics import BenchmarkMetrics
 from app.services.map_previews import MapPreview, MapPreviewError
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.mark.asyncio
@@ -104,11 +112,11 @@ async def test_preview_port_returns_public_result_and_maps_private_error(monkeyp
 
 @pytest.mark.asyncio
 async def test_polygon_analytics_maps_private_schema_to_frozen_sdk_dto(monkeypatch) -> None:
-    session = SimpleNamespace(scalar=AsyncMock(return_value=1))
-    monkeypatch.setattr(module_host_ports.analytics, "_base_filters", lambda *args: [])
+    session = object()
+    monkeypatch.setattr(module_host_ports.polygon_analytics, "base_filters", lambda *args: [])
     monkeypatch.setattr(
-        module_host_ports.analytics,
-        "_benchmark_metrics",
+        module_host_ports.polygon_analytics,
+        "benchmark_metrics",
         AsyncMock(
             return_value=BenchmarkMetrics(
                 polygon_count=2,
@@ -122,11 +130,101 @@ async def test_polygon_analytics_maps_private_schema_to_frozen_sdk_dto(monkeypat
         ),
     )
 
-    result = await HostPolygonAnalytics().metrics_for_area(
-        session, uuid4(), PolygonFilterValues(categories=("food",))
+    result = await HostPolygonAnalytics().metrics(
+        session, PolygonScope((7, 11)), PolygonFilterValues(categories=("food",))
     )
 
     assert result is not None
     assert result.polygon_count == 2
     assert result.vacancy_rate is None
     assert not hasattr(result, "_sa_instance_state")
+
+
+def test_polygon_scope_uses_one_array_parameter_instead_of_expanding_ids() -> None:
+    expression = module_host_ports._polygon_scope_filter(PolygonScope((7, 11, 13)))
+    compiled = expression.compile(dialect=postgresql.dialect())
+
+    assert "user_polygons.id = ANY" in str(compiled)
+    assert len(compiled.params) == 1
+    assert tuple(next(iter(compiled.params.values()))) == (7, 11, 13)
+
+
+@pytest.mark.asyncio
+async def test_polygon_query_uses_neutral_scope_and_returns_public_dtos() -> None:
+    rows = [
+        {
+            "uuid": "8ed4671e-7080-4bd8-965c-8f4191bb2bb0",
+            "slug": "markt-1",
+            "name": "Markt 1",
+            "category": "food",
+            "floor": "EG",
+            "address_display_name": "Markt 1, Flensburg",
+            "occupancy_status": "OCCUPIED",
+            "area_m2": 42.5,
+        }
+    ]
+    result = SimpleNamespace(mappings=lambda: rows)
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+
+    values = await HostPolygonQueries().list_by_scope(
+        session, PolygonScope((7,)), limit=25
+    )
+
+    assert len(values) == 1
+    assert values[0].slug == "markt-1"
+    statement = session.execute.await_args.args[0]
+    assert "analysis_area" not in str(statement).lower()
+    assert " = ANY" in str(statement)
+
+
+def test_module_port_adapters_do_not_import_analysis_areas() -> None:
+    adapter_root = ROOT / "backend/app/integrations"
+    sources = sorted(adapter_root.glob("*module*port*.py"))
+
+    assert sources
+    for source in sources:
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        imports = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        imports.update(
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        )
+        assert not any(
+            name == "app.modules.analysis_areas"
+            or name.startswith("app.modules.analysis_areas.")
+            for name in imports
+        ), f"{source} must not import app.modules.analysis_areas"
+
+
+def test_module_host_ports_import_without_builtin_analysis_areas() -> None:
+    code = """
+import importlib.abc
+import sys
+
+class BlockAnalysisAreas(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "app.modules.analysis_areas" or fullname.startswith(
+            "app.modules.analysis_areas."
+        ):
+            raise ModuleNotFoundError(fullname)
+        return None
+
+sys.meta_path.insert(0, BlockAnalysisAreas())
+from app.integrations.module_host_ports import HostPolygonAnalytics, HostPolygonQueries
+assert HostPolygonAnalytics and HostPolygonQueries
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT / "backend",
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/backend/tests/test_module_sdk.py
+++ b/backend/tests/test_module_sdk.py
@@ -13,19 +13,26 @@ from app.platform.modules.contracts import ModuleRegistrationContext
 from app.platform.modules.runtime import create_module_runtime
 from app.platform.modules.sdk import (
     ApiRegistrar,
+    CacheGenerationPort,
     CachePort,
     DatabaseSessionProvider,
     EventBusPort,
     HttpClientFactoryPort,
     LifecycleRegistrar,
+    MapPreviewPort,
     ModuleContext,
     ModuleMigrationSource,
     ModuleSettingsPort,
     ObservabilityPort,
     PermissionDependencyFactory,
     PermissionPort,
+    PolygonAnalyticsPort,
+    PolygonQueryPort,
+    PublicQueryLimits,
+    PublicQueryPort,
     SchedulerPort,
     ServiceRegistryPort,
+    StatisticsQueryPort,
     StoragePort,
 )
 from app.platform.modules.testing import (
@@ -62,6 +69,12 @@ def test_module_context_has_typed_public_ports() -> None:
         "permissions": PermissionPort | None,
         "permission_dependencies": PermissionDependencyFactory | None,
         "cache": CachePort | None,
+        "cache_generations": CacheGenerationPort | None,
+        "public_queries": PublicQueryPort | None,
+        "map_previews": MapPreviewPort | None,
+        "polygons": PolygonQueryPort | None,
+        "polygon_analytics": PolygonAnalyticsPort | None,
+        "statistics": StatisticsQueryPort | None,
         "storage": StoragePort | None,
         "http": HttpClientFactoryPort | None,
         "scheduler": SchedulerPort | None,
@@ -96,6 +109,16 @@ def test_migration_adoption_metadata_requires_exact_immutable_ids() -> None:
             revision_namespace="mod_example_module",
             adopted_revisions={"historical_001"},  # type: ignore[arg-type]
         )
+
+
+def test_public_query_limits_are_validated_and_immutable() -> None:
+    limits = PublicQueryLimits(max_response_items=100, cache_debug_headers=True)
+
+    assert limits.max_response_items == 100
+    with pytest.raises(FrozenInstanceError):
+        limits.max_response_items = 10  # type: ignore[misc]
+    with pytest.raises(ValueError, match="positive integers"):
+        PublicQueryLimits(max_response_items=0)
     with pytest.raises(ValueError, match="non-empty exact IDs"):
         ModuleMigrationSource(
             package="example_module",
@@ -117,6 +140,12 @@ def test_runtime_context_is_bound_to_manifest_and_unimplemented_ports_are_absent
     assert context.permissions is None
     assert context.permission_dependencies is None
     assert context.cache is None
+    assert context.cache_generations is None
+    assert context.public_queries is None
+    assert context.map_previews is None
+    assert context.polygons is None
+    assert context.polygon_analytics is None
+    assert context.statistics is None
     assert context.storage is None
     assert context.http is None
     assert context.scheduler is not None
@@ -287,7 +316,9 @@ def test_public_sdk_has_no_host_internal_or_domain_imports() -> None:
         "app.core",
         "app.db",
         "app.models",
+        "app.modules",
         "app.observability",
+        "app.schemas",
         "app.security",
         "app.services",
     )

--- a/backend/tests/test_module_sdk.py
+++ b/backend/tests/test_module_sdk.py
@@ -28,6 +28,7 @@ from app.platform.modules.sdk import (
     PermissionPort,
     PolygonAnalyticsPort,
     PolygonQueryPort,
+    PolygonScope,
     PublicQueryLimits,
     PublicQueryPort,
     SchedulerPort,
@@ -126,6 +127,20 @@ def test_public_query_limits_are_validated_and_immutable() -> None:
             revision_namespace="mod_example_module",
             adopted_revisions=frozenset({" historical_001"}),
         )
+
+
+def test_polygon_scope_is_primitive_immutable_and_validated() -> None:
+    scope = PolygonScope((3, 5, 8))
+
+    assert scope.polygon_ids == (3, 5, 8)
+    with pytest.raises(FrozenInstanceError):
+        scope.polygon_ids = (13,)  # type: ignore[misc]
+    with pytest.raises(TypeError, match="immutable tuple"):
+        PolygonScope([3, 5])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="positive integers"):
+        PolygonScope((0,))
+    with pytest.raises(ValueError, match="unique"):
+        PolygonScope((3, 3))
 
 
 def test_runtime_context_is_bound_to_manifest_and_unimplemented_ports_are_absent() -> None:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -30,7 +30,10 @@ Der Cross-Repo-Teil des Module Contract Gate baut `ocp-module-analysis-areas`
 reproduzierbar vom vollständigen PR-#2-Commit
 `a63af188a0cf4ba10a389302bae4c1e0d80cfeda`, prüft Bundle, deaktivierte
 Installation, Migration Ownership, Enable/Disable/Re-enable und die bestehenden
-API-Characterization-Tests. `scripts/check_external_module_imports.py` steht für
+API-Characterization-Tests. Eine zusätzliche Consumer-Probe liest die
+Area→Polygon-Relation ausschließlich über die Persistenzmodelle des externen
+Moduls und übergibt einen neutralen `PolygonScope` an den Host-Port.
+`scripts/check_external_module_imports.py` steht für
 den koordinierten SDK-1.9-Folgecommit bereit und verbietet dort alle Host-Imports
 außer `app.platform.modules.sdk`.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -26,6 +26,14 @@ bei reinen Dokumentationsänderungen nicht.
 | Supply Chain | `sbom` | transitive CycloneDX-SBOMs für Backend und Frontend |
 | Module Contract Gate | `Module contract gate` | Backend-/Frontend-Importgrenzen, Manifest-, Dependency-, Registry-, Map- und SSR-Verträge ohne Playwright |
 
+Der Cross-Repo-Teil des Module Contract Gate baut `ocp-module-analysis-areas`
+reproduzierbar vom vollständigen PR-#2-Commit
+`a63af188a0cf4ba10a389302bae4c1e0d80cfeda`, prüft Bundle, deaktivierte
+Installation, Migration Ownership, Enable/Disable/Re-enable und die bestehenden
+API-Characterization-Tests. `scripts/check_external_module_imports.py` steht für
+den koordinierten SDK-1.9-Folgecommit bereit und verbietet dort alle Host-Imports
+außer `app.platform.modules.sdk`.
+
 Das Module Contract Gate prüft zusätzlich, dass Repository-Module Settings und
 Secrets über den namespaceten Host-Port beziehen. Diese Architekturregel ist keine
 Sandbox. Die bestehenden Security- und Supply-Chain-Jobs bleiben für First-Party-

--- a/docs/modules/architecture-rules.md
+++ b/docs/modules/architecture-rules.md
@@ -12,6 +12,7 @@ aufeinander verweisen.
 | `ARCH-BE-MODULE-001` | Provider können ihre Interna ändern. | Alpha importiert `beta.contracts` | Alpha importiert `beta.internal` | Python-AST-Checker |
 | `ARCH-BE-PRIVATE-001` | Host-Ports halten Lifecycle und Architekturgrenzen nachvollziehbar. | Modul importiert `app.platform.modules.sdk` | Modul importiert `app.db.session` oder `modules.runtime` | Python-AST-Checker |
 | `ARCH-BE-INSTALLED-001` | Installierte First-Party-Module dürfen keine neue private Host-Kopplung einführen. | Checkout/Wheel importiert `app.platform.modules.sdk` | Checkout/Wheel importiert `app.models.*` oder `app.services.*` | `check_external_module_imports.py` gegen entpackte Modulquellen |
+| `ARCH-BE-PORT-OWNERSHIP-001` | Host-Polygonfähigkeiten bleiben nach dem Built-in-Cutover importierbar. | Adapter verwendet `UserPolygon` hinter `PolygonScope` | Adapter importiert `app.modules.analysis_areas` | AST-Guard und Built-in-Removal-Importtest |
 | `ARCH-BE-SECRET-001` | Secrets bleiben namespaced und auditierbar. | Modul liest `ModuleContext.settings` | Modul liest `os.environ`, dotenv oder eigene `BaseSettings` | Python-AST-Checker |
 | `ARCH-FE-HOST-001` | Der Build-Time-Host bleibt generisch. | Host liest Contribution-Registries | `nuxt.config.ts` importiert `example-module` | TypeScript-AST-Checker |
 | `ARCH-FE-MODULE-001` | Nuxt-Layer bleiben unabhängig. | eigene relative Datei, `#frontend-module-sdk` oder `#imports` | `~/stores/auth` oder `../../beta/internal` | TypeScript-AST-Checker |

--- a/docs/modules/architecture-rules.md
+++ b/docs/modules/architecture-rules.md
@@ -11,6 +11,7 @@ aufeinander verweisen.
 | `ARCH-BE-HOST-001` | Der Host bleibt fachneutral. | `app.platform.modules.sdk` und explizite Infrastrukturadapter | Host importiert `app.services.statistics` | Python-AST-Checker |
 | `ARCH-BE-MODULE-001` | Provider können ihre Interna ändern. | Alpha importiert `beta.contracts` | Alpha importiert `beta.internal` | Python-AST-Checker |
 | `ARCH-BE-PRIVATE-001` | Host-Ports halten Lifecycle und Architekturgrenzen nachvollziehbar. | Modul importiert `app.platform.modules.sdk` | Modul importiert `app.db.session` oder `modules.runtime` | Python-AST-Checker |
+| `ARCH-BE-INSTALLED-001` | Installierte First-Party-Module dürfen keine neue private Host-Kopplung einführen. | Checkout/Wheel importiert `app.platform.modules.sdk` | Checkout/Wheel importiert `app.models.*` oder `app.services.*` | `check_external_module_imports.py` gegen entpackte Modulquellen |
 | `ARCH-BE-SECRET-001` | Secrets bleiben namespaced und auditierbar. | Modul liest `ModuleContext.settings` | Modul liest `os.environ`, dotenv oder eigene `BaseSettings` | Python-AST-Checker |
 | `ARCH-FE-HOST-001` | Der Build-Time-Host bleibt generisch. | Host liest Contribution-Registries | `nuxt.config.ts` importiert `example-module` | TypeScript-AST-Checker |
 | `ARCH-FE-MODULE-001` | Nuxt-Layer bleiben unabhängig. | eigene relative Datei, `#frontend-module-sdk` oder `#imports` | `~/stores/auth` oder `../../beta/internal` | TypeScript-AST-Checker |

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -146,6 +146,9 @@ unter `app.*` ausschließlich den öffentlichen SDK-Pfad verwendet.
 
 ## SDK-Versionierung
 
+Die Capability- und Legacy-Import-Zuordnung für die mit SDK 1.9 ergänzten Ports
+steht in [Öffentliche Backend-Service-Ports](backend-service-ports.md).
+
 `MODULE_SDK_VERSION` ist eine SemVer-Version und unabhängig von Release-SHA und
 Host-API-Version. Der Context wurde unter SDK `1.0.0` eingeführt. Die additive
 Event-/Outbox-API aus #96 erhöhte die SDK-Version auf `1.1.0`. Die additiven
@@ -166,6 +169,11 @@ Auth-Interna Teil des SDK zu machen.
 Die additive, optionale `ModuleMigrationSource.adopted_revisions`-Metadata erhöht
 die SDK-Version auf `1.8.0`. Bestehende Module erhalten standardmäßig eine leere
 unveränderliche Menge und müssen ihren Migration Contract nicht ändern.
+Die additiven öffentlichen Backend-Service-Ports für Cache-Generationen,
+Public-Query-Schutz, Kartenvorschauen, Polygonabfragen und -aggregate,
+Kommunalstatistik erhöhen die SDK-Version auf `1.9.0`.
+Alle Ports sind optional; bestehende Module und ihre Context-Konstruktion bleiben
+damit rückwärtskompatibel.
 
 - **MAJOR:** Entfernen oder Umbenennen öffentlicher Methoden, inkompatible Änderungen
   an vorhandener Semantik oder eine inkompatible Context-Struktur.

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -65,6 +65,12 @@ Sub-Interfaces `context.api` und `context.lifecycle`.
 | `permissions` | `PermissionPort` | hostseitige, fail-closed Policy-Auswertung aus #104 |
 | `permission_dependencies` | `PermissionDependencyFactory` | authentifizierte FastAPI-Dependency mit optionalem CSRF für Modulrouten |
 | `cache` | `CachePort` | optionaler, modulgebundener Byte-Cache |
+| `cache_generations` | `CacheGenerationPort` | Read-Model-Generationen ohne Cache-Interna |
+| `public_queries` | `PublicQueryPort` | öffentliche Query-Policy und Limits |
+| `map_previews` | `MapPreviewPort` | öffentliche Kartenvorschauen |
+| `polygons` | `PolygonQueryPort` | Polygonprojektionen für neutrale `PolygonScope`-IDs |
+| `polygon_analytics` | `PolygonAnalyticsPort` | Aggregate für neutrale `PolygonScope`-IDs |
+| `statistics` | `StatisticsQueryPort` | kommunale Statistikprojektionen |
 | `observability` | `ObservabilityPort` | immer vorhanden; Logger ist an Modul-ID/-Version gebunden |
 | `storage` | `StoragePort` | optionaler modulgebundener Blob-Storage |
 | `http` | `HttpClientFactoryPort` | optionaler sicherer Client-Port |
@@ -95,6 +101,14 @@ Migrationen sind im
 Cache-Schlüssel und Storage-Keys gelten relativ zum aktuellen Modul; konkrete
 Adapter müssen sie entsprechend isolieren. Cache-TTLs sind positive ganze Sekunden.
 Die Ports machen keine Redis-, Dateisystem- oder Cloud-SDK-Typen öffentlich.
+
+### Polygon-Scope
+
+Analysis-Areas-Module besitzen die Zuordnung von Gebieten zu Polygonen. Sie lesen
+die primitiven Polygon-IDs aus ihren eigenen Persistenzmodellen und übergeben
+diese als unveränderlichen `PolygonScope`. Die Host-Ports kennen weder
+`AnalysisArea` noch `PolygonAnalysisArea`; Host-ORM-Modelle werden nicht über die
+SDK-Grenze gereicht.
 
 ### Events, Services, Permissions und Jobs
 

--- a/docs/modules/backend-service-ports.md
+++ b/docs/modules/backend-service-ports.md
@@ -1,0 +1,100 @@
+# Öffentliche Backend-Service-Ports
+
+Stand dieser Inventarisierung ist `ocp-module-analysis-areas` PR #2, exakt Commit
+`a63af188a0cf4ba10a389302bae4c1e0d80cfeda`. Installierte In-Process-Module
+dürfen stabile öffentliche Host-Capabilities verwenden. Sie dürfen nie von
+privaten Implementierungsdetails einer Host-Fachdomäne abhängen.
+
+Alle Verträge werden ausschließlich aus `app.platform.modules.sdk` importiert
+und optional über den unveränderlichen `ModuleContext` injiziert. Konkrete
+Implementierungen liegen in `app.integrations.module_host_ports`; dort wird zu
+den bestehenden Services komponiert, ohne deren Logik in das SDK zu kopieren.
+Die Verträge sind seit SDK 1.9 additiv und stabil. Einen fehlenden optionalen Port
+erkennt das konsumierende Modul bei seiner Registrierung. Validierungsfehler bleiben `ValueError`;
+ein nicht renderbares Preview wird als `MapPreviewUnavailableError` abstrahiert.
+Query-Timeouts werden über `PublicQueryPort.is_timeout()` erkannt, ohne
+DB-Treiberfehler zum Modulvertrag zu machen.
+
+## Portübersicht
+
+| Port | Zweck und Owner | Eingabe | Ausgabe / Fehler |
+| --- | --- | --- | --- |
+| `DatabaseSessionProvider` | Host-eigene Transaktionsgrenze | keine | Async-Kontext mit `AsyncSession`; Exception löst Rollback aus |
+| `CachePort` | modulgebundener Byte-Cache | lokaler Key, Bytes, TTL | Bytes/Status; Backend-Ausfall verhält sich als Cache Miss |
+| `CacheGenerationPort` | geteilte Read-Model-Invalidierung lesen | Session, Ressourcenname | monotone Generation; keine Redis-/Key-Details |
+| `PublicQueryPort` | Host Security | Request, Session, begrenzter Ressourcenname | Guard oder etablierter HTTP-Fehler; `PublicQueryLimits` ist immutable |
+| `MapPreviewPort` | Host Map Rendering | `MapPreviewRequest` mit GeoJSON-Primitiven | Bytes, Content-Type, ETag, Cache-Hit; stabile Preview-Exception |
+| `PolygonQueryPort` | Polygon-Domäne | Session, Gebiet-UUID, Limit | immutable `PublicPolygonSummary`; niemals ORM |
+| `PolygonAnalyticsPort` | Polygon-/Analytics-Domäne | Session, Gebiet-UUID, primitive Filter | `PolygonMetrics` und `CountValue`; niemals SQL-Ausdrücke/ORM |
+| `StatisticsQueryPort` | Kommunalstatistik-Domäne | Session, Slug, optionaler Metrik-Key | immutable Statistik-DTOs oder `None` |
+
+## Legacy-Import-Inventar und Ownership
+
+Die Klassifikation verwendet A = generische Host-Capability, B = fremde
+Fachdomäne, C = Analysis-Areas-owned, D = obsolete Legacy-Kopplung.
+
+| Privater Import / Symbol | Klasse | Öffentlicher Ersatz oder Ziel | Owner |
+| --- | --- | --- | --- |
+| `app.db.session.get_session` | A | `DatabaseSessionProvider`; das Modul definiert daraus seine FastAPI-Dependency | Platform |
+| `app.core.config.get_settings` | A/C | `PublicQueryPort.limits` nur für Host-Limits; Cache-TTLs werden Modulsettings | Platform / Modul |
+| `app.cache.service.cache_service` | A | `CachePort` | Platform |
+| `app.cache.service.last_cache_status` | C | request-lokaler Status im Modul-Cache-Adapter | Modul |
+| `app.cache.keys.build_cache_key` | C | kanonischer Key-Builder im Modul, vor dem bereits Host-seitig namespaceten `CachePort` | Modul |
+| `app.services.cache_versions.cache_version` | A | `CacheGenerationPort.current` | Platform |
+| `app.services.cache_versions.bump_cache_versions` | D | Der unregistrierte externe Legacy-Sync entfällt; kein mutierender Cache-Port | Modul / Platform |
+| `app.services.public_query_security.guard_public_query` | A | `PublicQueryPort.guard` | Platform Security |
+| `app.services.public_query_security.is_statement_timeout_error` | A | `PublicQueryPort.is_timeout` | Platform Security |
+| `app.services.map_previews.map_preview_service` | A | `MapPreviewPort.render` | Map Preview |
+| `app.services.map_previews.MapPreviewError` | A | `MapPreviewUnavailableError` | Map Preview |
+| `app.models.user_polygon.UserPolygon` | B | `PolygonQueryPort` / `PolygonAnalyticsPort` und DTOs | Polygons |
+| `app.services.analytics._base_filters` | B | primitive `PolygonFilterValues` am `PolygonAnalyticsPort` | Polygon Analytics |
+| `app.services.analytics._benchmark_metrics` | B | `PolygonAnalyticsPort.metrics_for_area` | Polygon Analytics |
+| `app.services.analytics._counts` | B | `PolygonAnalyticsPort.category_counts_for_area` | Polygon Analytics |
+| `app.services.area_statistics.area_statistics` | B | `StatisticsQueryPort.for_area` | Statistics |
+| `app.services.area_statistics.area_statistic_series` | B | `StatisticsQueryPort.series_for_area` | Statistics |
+| `app.services.poi_categories.AREA_POI_CATEGORY_SQL` | C | kleine OSM-Tag-Projektion zusammen mit der bestehenden Gebiet-POI-Query im Modul | Modul |
+| `app.services.social_publishing.enqueue_area_publication` | D | Der unregistrierte externe Legacy-Sync entfällt; kein spekulativer Social-Port | Social Publishing |
+| `app.schemas.analytics.BenchmarkMetrics` | B | `PolygonMetrics`, danach module-owned API-Schema | Polygon Analytics / Modul |
+| `app.schemas.analytics.IndustryCount` | B | `CountValue`, danach module-owned API-Schema | Polygon Analytics / Modul |
+| `app.schemas.statistics.AreaStatisticsRead` | B | `AreaStatistics`, danach module-owned Response-Schema | Statistics / Modul |
+| `app.schemas.statistics.AreaStatisticSeriesRead` | B | `AreaStatisticSeries`, danach module-owned Response-Schema | Statistics / Modul |
+| `app.schemas.geojson.AreaGeometry` | C | module-owned GeoJSON-Pydantic-Typ | Modul |
+| `app.schemas.external_links.ExternalLinks` | C | module-owned Response-Typ | Modul |
+| `app.schemas.external_links.WikidataExternalLink` | C | module-owned Response-Typ | Modul |
+| `app.schemas.external_links.WikipediaExternalLink` | C | module-owned Response-Typ | Modul |
+| `app.schemas.polygon_filters.PolygonFilterParams` | C | module-owned HTTP-Parsing; Übergabe als `PolygonFilterValues` | Modul |
+| `app.schemas.polygon_filters.polygon_filter_query` | C | module-owned FastAPI-Dependency | Modul |
+
+`AREA_POI_CATEGORY_SQL`, API-Schemas, Filter-Parsing, Cache-Key-Building,
+Cache-Bumping, Social-Publishing und Response-Mapping werden bewusst nicht als
+Host-Port veröffentlicht: Sie bestimmen
+die konkrete Analysis-Areas-Antwort. Die privaten Analytics-Helfer bleiben privat;
+nur der bestehende Host-Adapter darf sie hinter fachlich benannten Operationen
+aufrufen. Der direkte Sessionimport ist ersatzlos obsolet, weil SDK 1.2 bereits
+die passende Transaktionsgrenze besitzt.
+
+## Lifecycle und Datenschutz
+
+Die Adapter werden einmal beim Host-Composition-Root erzeugt und pro
+`ModuleContext` injiziert. Der Cache wird zusätzlich an die Modul-ID gebunden und
+seine Keys mit dem konfigurierten Deployment-Prefix versehen. Die Ports nehmen
+weder Secrets noch Benutzerobjekte entgegen. Polygonprojektionen enthalten nur
+bereits öffentliche Felder. Keine Exception enthält Query-Text, Parameter oder
+Treiberantworten.
+
+## Settings-Auflösung
+
+Der externe Adapter liest am gepinnten Stand genau
+`public_polygon_response_limit`, `cache_debug_headers`,
+`analysis_area_cache_ttl`, `analytics_cache_ttl` und
+`mastodon_boundary_change_min_ratio`. Die ersten beiden Werte liefert der
+immutable `PublicQueryLimits`-Contract. Die beiden Cache-TTLs sind Policy der
+module-owned Read-Modelle und werden im Folgecommit als kleine namespacete
+Moduleinstellungen mit den bisherigen Defaults geführt. Der Mastodon-Schwellwert
+wird ausschließlich vom nicht registrierten `legacy_sync.py` gelesen; dieser Pfad
+entfällt extern und erhält daher keinen öffentlichen Settings- oder Social-Port.
+
+Host-interne Cachewerte (`cache_prefix`, Payload-Warnschwelle und Lock-TTL) und
+sämtliche Preview-/Rate-Limit-/Statement-Timeout-Konfiguration bleiben vollständig
+hinter ihren Adaptern. Weder `Settings` noch Redis-, Renderer- oder DB-Treiber-Typen
+werden über die Modulgrenze gereicht.

--- a/docs/modules/backend-service-ports.md
+++ b/docs/modules/backend-service-ports.md
@@ -24,8 +24,8 @@ DB-Treiberfehler zum Modulvertrag zu machen.
 | `CacheGenerationPort` | geteilte Read-Model-Invalidierung lesen | Session, Ressourcenname | monotone Generation; keine Redis-/Key-Details |
 | `PublicQueryPort` | Host Security | Request, Session, begrenzter Ressourcenname | Guard oder etablierter HTTP-Fehler; `PublicQueryLimits` ist immutable |
 | `MapPreviewPort` | Host Map Rendering | `MapPreviewRequest` mit GeoJSON-Primitiven | Bytes, Content-Type, ETag, Cache-Hit; stabile Preview-Exception |
-| `PolygonQueryPort` | Polygon-Domäne | Session, Gebiet-UUID, Limit | immutable `PublicPolygonSummary`; niemals ORM |
-| `PolygonAnalyticsPort` | Polygon-/Analytics-Domäne | Session, Gebiet-UUID, primitive Filter | `PolygonMetrics` und `CountValue`; niemals SQL-Ausdrücke/ORM |
+| `PolygonQueryPort` | Polygon-Domäne | Session, immutable `PolygonScope` aus primitiven Polygon-IDs, Limit | immutable `PublicPolygonSummary`; niemals ORM |
+| `PolygonAnalyticsPort` | Polygon-/Analytics-Domäne | Session, `PolygonScope`, primitive Filter | `PolygonMetrics` und `CountValue`; niemals SQL-Ausdrücke/ORM |
 | `StatisticsQueryPort` | Kommunalstatistik-Domäne | Session, Slug, optionaler Metrik-Key | immutable Statistik-DTOs oder `None` |
 
 ## Legacy-Import-Inventar und Ownership
@@ -48,8 +48,8 @@ Fachdomäne, C = Analysis-Areas-owned, D = obsolete Legacy-Kopplung.
 | `app.services.map_previews.MapPreviewError` | A | `MapPreviewUnavailableError` | Map Preview |
 | `app.models.user_polygon.UserPolygon` | B | `PolygonQueryPort` / `PolygonAnalyticsPort` und DTOs | Polygons |
 | `app.services.analytics._base_filters` | B | primitive `PolygonFilterValues` am `PolygonAnalyticsPort` | Polygon Analytics |
-| `app.services.analytics._benchmark_metrics` | B | `PolygonAnalyticsPort.metrics_for_area` | Polygon Analytics |
-| `app.services.analytics._counts` | B | `PolygonAnalyticsPort.category_counts_for_area` | Polygon Analytics |
+| `app.services.analytics._benchmark_metrics` | B | `PolygonAnalyticsPort.metrics` | Polygon Analytics |
+| `app.services.analytics._counts` | B | `PolygonAnalyticsPort.category_counts` | Polygon Analytics |
 | `app.services.area_statistics.area_statistics` | B | `StatisticsQueryPort.for_area` | Statistics |
 | `app.services.area_statistics.area_statistic_series` | B | `StatisticsQueryPort.series_for_area` | Statistics |
 | `app.services.poi_categories.AREA_POI_CATEGORY_SQL` | C | kleine OSM-Tag-Projektion zusammen mit der bestehenden Gebiet-POI-Query im Modul | Modul |
@@ -72,6 +72,29 @@ die konkrete Analysis-Areas-Antwort. Die privaten Analytics-Helfer bleiben priva
 nur der bestehende Host-Adapter darf sie hinter fachlich benannten Operationen
 aufrufen. Der direkte Sessionimport ist ersatzlos obsolet, weil SDK 1.2 bereits
 die passende Transaktionsgrenze besitzt.
+
+## Area→Polygon-Ownership und Consumer-Flow
+
+Der erste Entwurf nahm eine Gebiet-UUID entgegen und löste sie im Host über die
+Built-in-Modelle `AnalysisArea` und `PolygonAnalysisArea` auf. Das war ein
+Ownership Leak: Nach dem Cutover soll dieses Built-in-Package entfernt werden,
+und die Relation gehört fachlich zum externen Modul.
+
+Das externe Modul löst künftig innerhalb einer vom vorhandenen
+`DatabaseSessionProvider` gelieferten Session zunächst seine eigene
+`AnalysisArea` auf. Danach liest es aus seinem eigenen
+`PolygonAnalysisArea`-Modell die primitiven Integer-IDs und erzeugt einen
+unveränderlichen `PolygonScope`. Nur dieser neutrale Scope wird an
+`PolygonQueryPort.list_by_scope`, `PolygonAnalyticsPort.metrics` oder
+`PolygonAnalyticsPort.category_counts` übergeben. Ein nicht vorhandenes Gebiet
+behandelt das Modul vor dem Port-Aufruf selbst.
+
+Der Host kennt dadurch weder Gebiet-UUID noch Relationstabelle. `UserPolygon` und
+die Analytics-Implementierung bleiben vollständig intern. Für größere Scopes
+bindet der Host alle IDs als einen PostgreSQL-Arrayparameter mit `ANY`; er erzeugt
+keine expandierte `IN (...)`-Parameterliste. Die Relation wird in genau einer
+module-owned Query gelesen, das Aggregat anschließend in genau einer Host-Query
+berechnet.
 
 ## Lifecycle und Datenschutz
 

--- a/docs/modules/builtin-cutover.md
+++ b/docs/modules/builtin-cutover.md
@@ -36,12 +36,13 @@ Frontend-Snapshot ein. Aktivierung bleibt ausschließlich in `modules.lock`.
    `enable` mit erneutem Deploy/Restart prüfen.
 
 Für `analysis-areas` ist der geprüfte externe Contract auf Commit
-`71815f0396ec8bea545588fd8978dc78b284331a` gepinnt. Er liefert die Revisionen
+`a63af188a0cf4ba10a389302bae4c1e0d80cfeda` gepinnt. Er liefert die Revisionen
 `20260814_0014`, `20260817_0023`, `20260818_0025` und `20260819_0032` mit
-unveränderten Kanten. Der isolierte Legacy-Adapter greift weiterhin auf reviewte
-Host-Services zu. Das ist kein neuer Trust-Zustand, weil installierte In-Process-
-Module bereits Trusted Code sind; der Cutover weitet diese privaten Imports nicht
-aus und erfindet keine Analysis-Areas-spezifischen Platform-Ports.
+unveränderten Kanten. Der isolierte Legacy-Adapter des Pins ist vollständig in
+[öffentliche Backend-Service-Ports](backend-service-ports.md) inventarisiert.
+SDK 1.9 stellt die öffentlichen Ersatzverträge bereit; der aktuelle Pin bleibt
+bis zum koordinierten Modul-Folgecommit Trusted Code mit der dokumentierten
+Legacy-Grenze.
 
 ## Rollback
 

--- a/docs/modules/builtin-cutover.md
+++ b/docs/modules/builtin-cutover.md
@@ -44,6 +44,13 @@ SDK 1.9 stellt die öffentlichen Ersatzverträge bereit; der aktuelle Pin bleib
 bis zum koordinierten Modul-Folgecommit Trusted Code mit der dokumentierten
 Legacy-Grenze.
 
+Der Cross-Repo-Contract modelliert bereits den geplanten Folgeflow: Das externe
+Modul löst Gebiet und `polygon_analysis_areas` über seine eigenen ORM-Modelle und
+den bestehenden `DatabaseSessionProvider` auf, baut daraus einen neutralen
+`PolygonScope` und ruft erst danach den Host-Polygon-Port auf. Der aktuelle Pin
+verwendet produktiv weiterhin den dokumentierten Legacy-Adapter; der Contract
+behauptet daher noch keinen abgeschlossenen SDK-Cutover.
+
 ## Rollback
 
 1. Externes Modul deaktivieren und einen neuen Deployzustand rendern.

--- a/docs/modules/module-contract-gate.md
+++ b/docs/modules/module-contract-gate.md
@@ -10,6 +10,12 @@ Prozessumgebung laden. Diese Architekturgrenze verspricht keine In-Process-Sandb
 Provenance und Integrität späterer Third-Party-Artefakte werden am Installer-/
 Deploymentrand geprüft (#173 und #174), nicht in der Runtime.
 
+Für ausgecheckte oder entpackte First-Party-Module prüft
+`scripts/check_external_module_imports.py <python-package-root>` zusätzlich die
+Regel `ARCH-BE-INSTALLED-001`. Erlaubt ist aus `app.*` ausschließlich
+`app.platform.modules.sdk`; damit kann dieselbe Negativregel vor Wheel-Build und
+nach Installation auf den tatsächlichen Paketinhalt angewendet werden.
+
 Nach der Installation der gelockten Backend- und Frontend-Abhängigkeiten reicht lokal:
 
 ```bash

--- a/docs/modules/module-contract-gate.md
+++ b/docs/modules/module-contract-gate.md
@@ -15,6 +15,10 @@ Für ausgecheckte oder entpackte First-Party-Module prüft
 Regel `ARCH-BE-INSTALLED-001`. Erlaubt ist aus `app.*` ausschließlich
 `app.platform.modules.sdk`; damit kann dieselbe Negativregel vor Wheel-Build und
 nach Installation auf den tatsächlichen Paketinhalt angewendet werden.
+`ARCH-BE-PORT-OWNERSHIP-001` prüft zusätzlich alle öffentlichen
+Modul-Port-Adapter unter `app.integrations`: Sie dürfen das entfernbare Built-in
+`app.modules.analysis_areas` nicht importieren. Ein separater Importtest blockiert
+dieses Package vollständig und lädt anschließend `module_host_ports` neu.
 
 Nach der Installation der gelockten Backend- und Frontend-Abhängigkeiten reicht lokal:
 

--- a/scripts/check_analysis_areas_port_consumer.py
+++ b/scripts/check_analysis_areas_port_consumer.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Prove the planned external Analysis Areas -> polygon-port consumer boundary."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform.modules.sdk import PolygonQueryPort, PolygonScope
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "module_source",
+        type=Path,
+        help="Path containing the ocp_module_analysis_areas Python package",
+    )
+    return parser.parse_args()
+
+
+async def module_owned_polygon_scope(
+    session: AsyncSession, area_id: UUID
+) -> PolygonScope | None:
+    """Model the future consumer using only module-owned persistence models."""
+
+    from ocp_module_analysis_areas.persistence.models import (
+        AnalysisArea,
+        PolygonAnalysisArea,
+    )
+
+    area_db_id = await session.scalar(
+        select(AnalysisArea.id).where(AnalysisArea.uuid == area_id)
+    )
+    if area_db_id is None:
+        return None
+    polygon_ids = await session.scalars(
+        select(PolygonAnalysisArea.polygon_id).where(
+            PolygonAnalysisArea.analysis_area_id == area_db_id
+        )
+    )
+    return PolygonScope(tuple(polygon_ids))
+
+
+class _ScalarValues:
+    def __iter__(self):
+        return iter((7, 11))
+
+
+class _ContractSession:
+    statements: list[str]
+
+    def __init__(self) -> None:
+        self.statements = []
+
+    async def scalar(self, statement):
+        self.statements.append(str(statement))
+        return 23
+
+    async def scalars(self, statement):
+        self.statements.append(str(statement))
+        return _ScalarValues()
+
+
+class _PolygonConsumer:
+    async def list_by_scope(
+        self, session: AsyncSession, scope: PolygonScope, *, limit: int
+    ) -> tuple[object, ...]:
+        assert session is not None
+        assert scope == PolygonScope((7, 11))
+        assert limit == 25
+        return ()
+
+
+async def check() -> None:
+    session = _ContractSession()
+    scope = await module_owned_polygon_scope(  # type: ignore[arg-type]
+        session, UUID("b0773da4-4782-4dca-8d49-d2db77bba055")
+    )
+    assert scope == PolygonScope((7, 11))
+    assert "analysis_areas" in session.statements[0]
+    assert "polygon_analysis_areas" in session.statements[1]
+    assert "user_polygons" not in " ".join(session.statements)
+
+    polygons: PolygonQueryPort = _PolygonConsumer()  # type: ignore[assignment]
+    await polygons.list_by_scope(session, scope, limit=25)  # type: ignore[arg-type]
+
+
+def main() -> int:
+    args = parse_args()
+    source = args.module_source.resolve()
+    if not (source / "ocp_module_analysis_areas").is_dir():
+        raise SystemExit(f"Analysis Areas package not found below {source}")
+    sys.path.insert(0, str(source))
+    asyncio.run(check())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_external_module_imports.py
+++ b/scripts/check_external_module_imports.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Reject private Host imports in an installed or checked-out Python module."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+PUBLIC_HOST_IMPORTS = ("app.platform.modules.sdk",)
+
+
+@dataclass(frozen=True, slots=True)
+class PrivateHostImport:
+    source: Path
+    imported: str
+    line: int
+
+
+def private_host_imports(root: Path) -> tuple[PrivateHostImport, ...]:
+    violations: list[PrivateHostImport] = []
+    for source in sorted(root.rglob("*.py")):
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in ast.walk(tree):
+            names: tuple[str, ...] = ()
+            if isinstance(node, ast.Import):
+                names = tuple(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = (node.module,)
+            for imported in names:
+                if imported == "app" or (
+                    imported.startswith("app.")
+                    and not imported.startswith(PUBLIC_HOST_IMPORTS)
+                ):
+                    violations.append(PrivateHostImport(source, imported, node.lineno))
+    return tuple(violations)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("module_source", type=Path)
+    args = parser.parse_args()
+    root = args.module_source.resolve()
+    if not root.is_dir():
+        parser.error(f"module source is not a directory: {root}")
+    violations = private_host_imports(root)
+    for violation in violations:
+        print(
+            f"::error file={violation.source},line={violation.line},"
+            "title=ARCH-BE-INSTALLED-001::"
+            f"Private Host import {violation.imported}; use app.platform.modules.sdk."
+        )
+    return int(bool(violations))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/module-contract-gate
+++ b/scripts/module-contract-gate
@@ -7,7 +7,7 @@ scope="${1:-all}"
 run_backend() {
   cd "${repository_root}/backend"
   uv run python ../scripts/check_module_architecture.py
-  uv run pytest tests/test_module_*.py tests/test_domain_events.py tests/modules/reference
+  uv run pytest tests/test_module_*.py tests/test_external_module_imports.py tests/test_domain_events.py tests/modules/reference
 }
 
 run_frontend() {


### PR DESCRIPTION
## Ausgangslage

Das externe Modul `ocp-module-analysis-areas` greift derzeit über einen privaten Legacy-Adapter direkt auf interne Backend-Module des Open City Planner zu. Dadurch ist das Modul eng an die interne Struktur des Hosts gekoppelt und kann nicht ausschließlich über den öffentlichen Backend-Modulvertrag betrieben werden.

Diese Änderung erweitert deshalb das öffentliche Backend Module SDK um die benötigten Service Ports und stellt passende Host-Adapter bereit.

Part of #192

## Umgesetzte Lösung

Das öffentliche Backend Module SDK wurde auf Version `1.9.0` erweitert.

Neu hinzugekommen sind öffentliche Ports und unveränderliche DTOs für:

- Cache-Generationen
- öffentliche Query-Limits
- Kartenvorschauen
- Polygonabfragen
- Polygonmetriken und Kategorieauswertungen
- Statistikabfragen und Zeitreihen

Die Ports werden beim Aufbau des `ModuleContext` durch den Host bereitgestellt. Das externe Modul erhält damit nur klar definierte öffentliche Schnittstellen und muss keine internen Models, Services oder Schemas mehr importieren.

Die konkreten Host-Adapter befinden sich in der Integrationsschicht. Private Implementierungsdetails bleiben dadurch außerhalb des öffentlichen SDK-Vertrags.

## Architektur

Die Abhängigkeiten sind folgendermaßen getrennt:

- Das SDK definiert ausschließlich Ports, DTOs und dokumentierte Fehlerfälle.
- Der Host implementiert die Ports über bestehende Services und SQLAlchemy-Strukturen.
- Module greifen ausschließlich über den `ModuleContext` auf Host-Funktionen zu.
- Modul-Caches werden anhand der konfigurierten Cache-Präfixe und der Modul-ID getrennt.
- Die öffentliche SDK-Schicht importiert keine privaten Domain-Implementierungen.
- Private Host-Imports sind ausschließlich innerhalb der Integrationsadapter zulässig.

Die bisher vom Legacy-Adapter verwendeten Symbole wurden vollständig inventarisiert und nach Zuständigkeit eingeordnet:

- generische Host-Fähigkeiten
- fachfremde Domain-Fähigkeiten
- modul-eigene Funktionalität
- veraltete Legacy-Synchronisation

## Bewusst nicht als öffentliche Ports übernommen

Folgende Bestandteile gehören fachlich zum externen Modul und wurden daher nicht in das Host-SDK verschoben:

- modul-spezifische GeoJSON- und API-Schemas
- externe Link- und Analytics-Response-Schemas
- Parsing der Polygon-HTTP-Filter
- modul-spezifische Cache-Key-Erzeugung
- request-lokaler `X-Cache`-Status
- `AREA_POI_CATEGORY_SQL`
- die Area-POI-Abfrage

Die nicht mehr registrierte Legacy-Synchronisation mit `bump_cache_versions` und `enqueue_area_publication` erhält ebenfalls keine neuen öffentlichen Ports. Diese Logik soll im externen Modul entfernt werden.

## Konfiguration

Die vom Modul benötigten öffentlichen Query-Einstellungen werden als unveränderliche Werte über den Host bereitgestellt:

- `public_polygon_response_limit`
- `cache_debug_headers`

Modul-spezifische Einstellungen verbleiben im Namensraum des externen Moduls:

- `analysis_area_cache_ttl`
- `analytics_cache_ttl`

`mastodon_boundary_change_min_ratio` wird nur von der nicht registrierten Legacy-Synchronisation verwendet und ist deshalb nicht Bestandteil des neuen öffentlichen Vertrags.

Es wurden keine neuen Umgebungsvariablen oder verpflichtenden Konfigurationseinträge eingeführt.

## Datenbank und ORM

Das Modul verwendet weiterhin den bestehenden öffentlichen `DatabaseSessionProvider`. Es wurde keine zweite Datenbank- oder Session-Abstraktion eingeführt.

Die Host-Adapter greifen auf die vorhandenen Models und Services zu und übersetzen Ergebnisse in stabile öffentliche SDK-DTOs. SQLAlchemy-Objekte oder private Host-Schemas werden nicht an externe Module weitergegeben.

## Contract Gate

Ein neuer Import-Check verhindert in ausgecheckten oder entpackten externen Modulen private Backend-Imports.

Erlaubt ist ausschließlich:

```python
from app.platform.modules.sdk import ...
```

Andere Importe aus `app.*`, beispielsweise aus `app.modules`, `app.models`, `app.schemas` oder privaten Services, führen zum Fehlschlag des Module Contract Gates.

Zusätzlich wurde die Architekturregel `ARCH-BE-INSTALLED-001` ergänzt.

## Externes Modul

Der Contract-Workflow verwendet den exakten Commit:

```text
a63af188a0cf4ba10a389302bae4c1e0d80cfeda
```

aus:

```text
https://github.com/oklabflensburg/ocp-module-analysis-areas/pull/2
```

Der aktuelle Stand dieses Commits enthält noch den privaten Legacy-Adapter. Das externe Modul muss deshalb in einem separaten Schritt auf SDK `1.9.0` und die neuen Ports umgestellt werden. Anschließend muss der Legacy-Adapter entfernt werden und der neue Import-Check erfolgreich durchlaufen.

Aus diesem Grund verwendet dieser Pull Request `Part of #192` und nicht `Closes #192`.

## Dokumentation

Ergänzt beziehungsweise aktualisiert wurden:

- Dokumentation der öffentlichen Backend Service Ports
- vollständige Inventarisierung der bisherigen Legacy-Imports
- Einordnung der Zuständigkeiten zwischen Host und Modul
- Eingaben, Ausgaben, Fehlerfälle und Lebenszyklen der Ports
- Backend Module SDK Version `1.9.0`
- Built-in-Cutover und exakter Cross-Repository-Pin
- Architekturregeln
- Module Contract Gate
- CI-Dokumentation

## Tests

Folgende Prüfungen wurden erfolgreich ausgeführt:

```text
uv run ruff check app tests ../scripts/check_external_module_imports.py
```

Ergebnis:

```text
erfolgreich
```

Fokussierte Tests:

```text
21 passed
```

Backend Module Contract Gate:

```text
355 passed
```

Vollständige Backend-Test-Suite:

```text
968 passed, 1 warning
```

Der verbleibende Hinweis stammt aus einem bereits vorhandenen ZIP-Fixture mit doppelter `module.yaml`.

App-Import:

```text
erfolgreich
```

Architekturprüfung:

```text
erfolgreich
```

Alembic-Heads:

```text
20260825_0034 (head)
```

Supply-Chain-Prüfung:

```text
erfolgreich
```

Whitespace- und Patch-Prüfung:

```text
git diff --check
```

Ergebnis:

```text
erfolgreich
```

Zusätzlich wurden für den gepinnten Stand des externen Moduls erfolgreich geprüft:

- Backend-Installation mit eingefrorenem Lockfile
- Ruff
- externe Modultests
- Wheel-Build
- Frontend-Installation mit eingefrorenem Lockfile
- Frontend-Package-Build
- `.ocp`-Bundle-Build
- Bundle-Verifikation
- Prüfung des deaktivierten Installationszustands
- Aktivierung des Moduls
- OpenAPI-Smoke-Test
- Deaktivierung
- erneute Aktivierung
- erneuter OpenAPI-Smoke-Test

Die vollständige externe PostGIS-/API-Charakterisierung wird weiterhin durch den aktualisierten CI-Workflow ausgeführt.

## Migrationen

Es wurden keine Datenbankmigrationen hinzugefügt oder bestehende Migrationen verändert.

## Sicherheit und Datenschutz

- Keine Secrets oder personenbezogenen Daten wurden hinzugefügt.
- Externe Module erhalten keinen direkten Zugriff auf private Host-Implementierungen.
- Query-Limits werden weiterhin serverseitig vorgegeben.
- Der Import-Check verhindert neue private Backend-Abhängigkeiten.
- Bestehende Supply-Chain-Prüfungen bleiben aktiv.
- Der externe Quellstand ist über einen vollständigen Commit-SHA reproduzierbar gepinnt.

## Rollout

1. Host mit Backend Module SDK `1.9.0` bereitstellen.
2. Externes Analysis-Areas-Modul auf die öffentlichen Ports umstellen.
3. Privaten Legacy-Adapter und die nicht mehr verwendete Synchronisationslogik entfernen.
4. Import-Check und vollständige Contract-CI für das externe Modul ausführen.
5. Erst danach den Cross-Repository-Cutover als vollständig abgeschlossen markieren.

## Rollback

Die Änderung führt keine Datenbank- oder Datenmigrationen ein. Ein Rollback erfolgt durch Rückkehr zur vorherigen Host-Version und zum vorherigen externen Modul-Pin.

Solange das externe Modul noch nicht auf SDK `1.9.0` umgestellt wurde, bleibt der bestehende Legacy-Adapter im gepinnten externen Stand erhalten.