### PR TITLE
feat(modules): add transactional cache generation bump port

### DIFF
--- a/backend/app/integrations/module_host_ports.py
+++ b/backend/app/integrations/module_host_ports.py
@@ -4,6 +4,7 @@ Only this boundary knows both the public SDK DTOs and private Host services/mode
 The adapters deliberately contain no copied business logic.
 """
 
+from collections.abc import Sequence
 from dataclasses import fields
 from typing import cast
 
@@ -34,7 +35,7 @@ from app.platform.modules.sdk import (
     StatisticValue,
 )
 from app.services import polygon_analytics
-from app.services.cache_versions import cache_version
+from app.services.cache_versions import bump_cache_versions, cache_version
 from app.services.map_previews import MapPreviewError, map_preview_service
 from app.services.public_query_security import (
     guard_public_query,
@@ -74,6 +75,11 @@ class HostCacheGenerations:
 
     async def current(self, session: AsyncSession, resource: str) -> int:
         return await cache_version(session, resource)
+
+    async def bump(
+        self, session: AsyncSession, resources: Sequence[str]
+    ) -> None:
+        await bump_cache_versions(session, resources)
 
 
 class HostPublicQueries:

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -39,7 +39,7 @@ from app.platform.modules.settings import (
 )
 
 logger = logging.getLogger(__name__)
-MODULE_SDK_VERSION = "1.9.0"
+MODULE_SDK_VERSION = "1.10.0"
 
 
 @dataclass(slots=True)

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -337,9 +337,13 @@ class CachePort(Protocol):
 
 
 class CacheGenerationPort(Protocol):
-    """Versioniert geteilte Lesemodelle ohne Redis- oder Cache-Key-Details."""
+    """Versioniert geteilte Lesemodelle in der Transaktion des Aufrufers."""
 
     async def current(self, session: AsyncSession, resource: str) -> int: ...
+
+    async def bump(
+        self, session: AsyncSession, resources: Sequence[str]
+    ) -> None: ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/app/platform/modules/testing.py
+++ b/backend/app/platform/modules/testing.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field, replace
 from types import MappingProxyType
@@ -67,6 +67,25 @@ class FakeCache:
         self.values.clear()
         self.ttls.clear()
         return deleted
+
+
+class FakeCacheGenerations:
+    """In-memory cache-generation port for isolated module contract tests."""
+
+    def __init__(self, generations: Mapping[str, int] | None = None) -> None:
+        self.generations = dict(generations or {})
+        self.bump_calls: list[tuple[str, ...]] = []
+
+    async def current(self, session, resource: str) -> int:
+        del session
+        return self.generations.get(resource, 1)
+
+    async def bump(self, session, resources: Sequence[str]) -> None:
+        del session
+        unique_resources = tuple(dict.fromkeys(resources))
+        self.bump_calls.append(unique_resources)
+        for resource in unique_resources:
+            self.generations[resource] = self.generations.get(resource, 1) + 1
 
 
 class FakeEventBus:
@@ -478,6 +497,7 @@ def create_test_module_context(
         permissions=FakePermissions(),
         permission_dependencies=FakePermissionDependencies(),
         cache=FakeCache(module_id),
+        cache_generations=FakeCacheGenerations(),
         storage=FakeStorage(module_id),
         http=FakeHttpClientFactory(),
         scheduler=FakeJobRegistry(module_id),
@@ -487,6 +507,7 @@ def create_test_module_context(
 
 __all__ = [
     "FakeCache",
+    "FakeCacheGenerations",
     "FakeEventBus",
     "FakeHttpClient",
     "FakeHttpClientFactory",

--- a/backend/app/services/cache_versions.py
+++ b/backend/app/services/cache_versions.py
@@ -7,20 +7,41 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.cache.redis import get_redis
 
 _local_versions: dict[str, tuple[float, int]] = {}
+# Session-local marker; only values from this transaction bypass the process cache.
+_PENDING_BUMPS_KEY = "cache_versions.pending_bumps"
+
+
+def _has_pending_bump(session: AsyncSession, namespace: str) -> bool:
+    info = session.info
+    if not isinstance(info, dict):
+        return False
+    transaction = session.get_transaction()
+    pending = info.get(_PENDING_BUMPS_KEY)
+    return (
+        transaction is not None
+        and isinstance(pending, tuple)
+        and len(pending) == 2
+        and pending[0] is transaction
+        and isinstance(pending[1], set)
+        and namespace in pending[1]
+    )
 
 
 async def cache_version(session: AsyncSession, namespace: str) -> int:
     if get_redis() is None:
         return 1
-    cached = _local_versions.get(namespace)
-    if cached and cached[0] > time.monotonic():
-        return cached[1]
+    transaction_has_bump = _has_pending_bump(session, namespace)
+    if not transaction_has_bump:
+        cached = _local_versions.get(namespace)
+        if cached and cached[0] > time.monotonic():
+            return cached[1]
     value = await session.scalar(
         text("SELECT version FROM cache_versions WHERE namespace=:namespace"),
         {"namespace": namespace},
     )
     version = int(value or 1)
-    _local_versions[namespace] = (time.monotonic() + 5, version)
+    if not transaction_has_bump:
+        _local_versions[namespace] = (time.monotonic() + 5, version)
     return version
 
 
@@ -39,5 +60,19 @@ async def bump_cache_versions(session: AsyncSession, namespaces: Iterable[str]) 
         """),
         {"names": list(names)},
     )
+    info = session.info
+    transaction = session.get_transaction() if isinstance(info, dict) else None
+    if transaction is not None:
+        pending = info.get(_PENDING_BUMPS_KEY)
+        resources = (
+            pending[1]
+            if isinstance(pending, tuple)
+            and len(pending) == 2
+            and pending[0] is transaction
+            and isinstance(pending[1], set)
+            else set()
+        )
+        resources.update(names)
+        info[_PENDING_BUMPS_KEY] = (transaction, resources)
     for name in names:
         _local_versions.pop(name, None)

--- a/backend/app/services/cache_versions.py
+++ b/backend/app/services/cache_versions.py
@@ -1,14 +1,42 @@
 import time
 from collections.abc import Iterable
 
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session, SessionTransaction
 
 from app.cache.redis import get_redis
 
 _local_versions: dict[str, tuple[float, int]] = {}
 # Session-local marker; only values from this transaction bypass the process cache.
 _PENDING_BUMPS_KEY = "cache_versions.pending_bumps"
+
+
+def _pending_resources(session: Session) -> set[str] | None:
+    pending = session.info.get(_PENDING_BUMPS_KEY)
+    if (
+        isinstance(pending, tuple)
+        and len(pending) == 2
+        and isinstance(pending[1], set)
+    ):
+        return pending[1]
+    return None
+
+
+@event.listens_for(Session, "after_commit")
+def _invalidate_versions_after_commit(session: Session) -> None:
+    if session.in_nested_transaction():
+        return
+    for namespace in _pending_resources(session) or ():
+        _local_versions.pop(namespace, None)
+
+
+@event.listens_for(Session, "after_transaction_end")
+def _clear_pending_bumps_after_root_transaction(
+    session: Session, transaction: SessionTransaction
+) -> None:
+    if transaction.parent is None:
+        session.info.pop(_PENDING_BUMPS_KEY, None)
 
 
 def _has_pending_bump(session: AsyncSession, namespace: str) -> bool:

--- a/backend/tests/test_module_host_ports.py
+++ b/backend/tests/test_module_host_ports.py
@@ -1,4 +1,5 @@
 import ast
+import inspect
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -53,12 +54,26 @@ async def test_module_cache_namespaces_keys_and_hides_cache_service(monkeypatch)
 @pytest.mark.asyncio
 async def test_cache_generations_delegate_without_exposing_storage(monkeypatch) -> None:
     current = AsyncMock(return_value=7)
+    bump = AsyncMock()
     monkeypatch.setattr(module_host_ports, "cache_version", current)
+    monkeypatch.setattr(module_host_ports, "bump_cache_versions", bump)
     port = HostCacheGenerations()
     session = object()
 
     assert await port.current(session, "analytics") == 7
+    await port.bump(session, ("analytics", "polygons", "analytics"))
+
     current.assert_awaited_once_with(session, "analytics")
+    bump.assert_awaited_once_with(
+        session, ("analytics", "polygons", "analytics")
+    )
+
+
+def test_cache_generation_adapter_is_generic() -> None:
+    source = inspect.getsource(HostCacheGenerations).lower()
+
+    assert "analysis-areas" not in source
+    assert "analysis_areas" not in source
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -1268,6 +1268,60 @@ async def test_cache_generation_port_current_and_committed_bumps(
 
 
 @pytest.mark.asyncio
+async def test_cache_generation_current_does_not_publish_rolled_back_bump(
+    postgres_schemas: SchemaFixture,
+    monkeypatch,
+) -> None:
+    generations, _facts = await _create_cache_generation_test_tables(postgres_schemas)
+    monkeypatch.setattr(cache_versions, "get_redis", lambda: object())
+    cache_versions._local_versions.clear()
+    port = HostCacheGenerations()
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.execute(
+            insert(generations).values(namespace="domain", version=3)
+        )
+
+    async with postgres_schemas.sessions() as writer:
+        await _use_test_schema(writer, postgres_schemas)
+        await port.bump(writer, ("domain",))
+        assert await port.current(writer, "domain") == 4
+        assert "domain" not in cache_versions._local_versions
+        await writer.rollback()
+
+    async with postgres_schemas.sessions() as observer:
+        await _use_test_schema(observer, postgres_schemas)
+        assert await port.current(observer, "domain") == 3
+    assert cache_versions._local_versions["domain"][1] == 3
+
+
+@pytest.mark.asyncio
+async def test_cache_generation_current_after_bump_is_visible_after_commit(
+    postgres_schemas: SchemaFixture,
+    monkeypatch,
+) -> None:
+    generations, _facts = await _create_cache_generation_test_tables(postgres_schemas)
+    monkeypatch.setattr(cache_versions, "get_redis", lambda: object())
+    cache_versions._local_versions.clear()
+    port = HostCacheGenerations()
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.execute(
+            insert(generations).values(namespace="domain", version=3)
+        )
+
+    async with postgres_schemas.sessions() as writer:
+        await _use_test_schema(writer, postgres_schemas)
+        await port.bump(writer, ("domain",))
+        assert await port.current(writer, "domain") == 4
+        assert "domain" not in cache_versions._local_versions
+        await writer.commit()
+
+    async with postgres_schemas.sessions() as observer:
+        await _use_test_schema(observer, postgres_schemas)
+        assert await port.current(observer, "domain") == 4
+    assert cache_versions._local_versions["domain"][1] == 4
+
+
+@pytest.mark.asyncio
 async def test_cache_generation_port_rolls_back_and_commits_with_domain_write(
     postgres_schemas: SchemaFixture,
 ) -> None:

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -1322,6 +1322,70 @@ async def test_cache_generation_current_after_bump_is_visible_after_commit(
 
 
 @pytest.mark.asyncio
+async def test_cache_generation_commit_invalidates_concurrently_recached_value(
+    postgres_schemas: SchemaFixture,
+    monkeypatch,
+) -> None:
+    generations, _facts = await _create_cache_generation_test_tables(postgres_schemas)
+    monkeypatch.setattr(cache_versions, "get_redis", lambda: object())
+    cache_versions._local_versions.clear()
+    port = HostCacheGenerations()
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.execute(
+            insert(generations).values(namespace="domain", version=3)
+        )
+
+    async with postgres_schemas.sessions() as writer:
+        await _use_test_schema(writer, postgres_schemas)
+        await port.bump(writer, ("domain",))
+
+        async with postgres_schemas.sessions() as observer_before_commit:
+            await _use_test_schema(observer_before_commit, postgres_schemas)
+            assert await port.current(observer_before_commit, "domain") == 3
+        assert cache_versions._local_versions["domain"][1] == 3
+
+        await writer.commit()
+
+    async with postgres_schemas.sessions() as observer_after_commit:
+        await _use_test_schema(observer_after_commit, postgres_schemas)
+        assert await port.current(observer_after_commit, "domain") == 4
+
+
+@pytest.mark.asyncio
+async def test_cache_generation_savepoint_is_not_a_commit_boundary(
+    postgres_schemas: SchemaFixture,
+    monkeypatch,
+) -> None:
+    generations, _facts = await _create_cache_generation_test_tables(postgres_schemas)
+    monkeypatch.setattr(cache_versions, "get_redis", lambda: object())
+    cache_versions._local_versions.clear()
+    port = HostCacheGenerations()
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.execute(
+            insert(generations).values(namespace="domain", version=3)
+        )
+
+    async with postgres_schemas.sessions() as writer:
+        await _use_test_schema(writer, postgres_schemas)
+        await port.bump(writer, ("domain",))
+
+        async with postgres_schemas.sessions() as observer_before_commit:
+            await _use_test_schema(observer_before_commit, postgres_schemas)
+            assert await port.current(observer_before_commit, "domain") == 3
+
+        savepoint = await writer.begin_nested()
+        await savepoint.commit()
+        assert cache_versions._local_versions["domain"][1] == 3
+
+        await writer.commit()
+        assert "domain" not in cache_versions._local_versions
+
+    async with postgres_schemas.sessions() as observer_after_commit:
+        await _use_test_schema(observer_after_commit, postgres_schemas)
+        assert await port.current(observer_after_commit, "domain") == 4
+
+
+@pytest.mark.asyncio
 async def test_cache_generation_port_rolls_back_and_commits_with_domain_write(
     postgres_schemas: SchemaFixture,
 ) -> None:

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -27,6 +27,8 @@ from sqlalchemy.ext.asyncio import (
 from app.cli import module_migrations as migration_cli
 from app.core.config import Settings, get_settings
 from app.db.base import Base
+from app.integrations.module_host_ports import HostCacheGenerations
+from app.models.cache_version import CacheVersion
 from app.modules.reference.module import DEFINITION as REFERENCE_DEFINITION
 from app.platform.modules import (
     DuplicatePersistenceSchemaError,
@@ -50,6 +52,7 @@ from app.platform.modules.persistence import (
     resolve_migration_source,
     revision_namespace_for,
 )
+from app.services import cache_versions
 from tests.fixtures.example_backend_module import DEFINITION as EXAMPLE_DEFINITION
 from tests.fixtures.example_persistence_module import DEFINITION as DEPENDENT_DEFINITION
 from tests.test_module_runtime import FakeDiscovery, definition, runtime_for
@@ -1188,6 +1191,116 @@ async def test_host_session_provider_commits_and_rolls_back(
     async with postgres_schemas.sessions() as session:
         names = tuple(await session.scalars(select(postgres_schemas.table_a.c.name)))
     assert names == ("kept",)
+
+
+async def _create_cache_generation_test_tables(
+    fixture: SchemaFixture,
+) -> tuple[Table, Table]:
+    metadata = MetaData()
+    generations = CacheVersion.__table__.to_metadata(
+        metadata, schema=fixture.schema_a
+    )
+    facts = Table(
+        "cache_generation_test_facts",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("value", String(80), nullable=False),
+        schema=fixture.schema_a,
+    )
+    async with fixture.engine.begin() as connection:
+        await connection.run_sync(metadata.create_all)
+    return generations, facts
+
+
+async def _use_test_schema(session: AsyncSession, fixture: SchemaFixture) -> None:
+    await session.execute(
+        text(f'SET LOCAL search_path TO "{fixture.schema_a}", public')
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_generation_port_current_and_committed_bumps(
+    postgres_schemas: SchemaFixture,
+    monkeypatch,
+) -> None:
+    generations, _facts = await _create_cache_generation_test_tables(postgres_schemas)
+    monkeypatch.setattr(cache_versions, "get_redis", lambda: object())
+    cache_versions._local_versions.clear()
+    port = HostCacheGenerations()
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.execute(
+            insert(generations),
+            [
+                {"namespace": "single", "version": 4},
+                {"namespace": "first", "version": 7},
+                {"namespace": "second", "version": 11},
+            ],
+        )
+
+    async with postgres_schemas.sessions() as writer:
+        await _use_test_schema(writer, postgres_schemas)
+        assert await port.current(writer, "single") == 4
+        await port.bump(writer, ("single",))
+        assert await writer.scalar(
+            select(generations.c.version).where(generations.c.namespace == "single")
+        ) == 5
+        async with postgres_schemas.sessions() as observer:
+            assert await observer.scalar(
+                select(generations.c.version).where(
+                    generations.c.namespace == "single"
+                )
+            ) == 4
+        await writer.commit()
+
+    async with postgres_schemas.sessions() as writer:
+        await _use_test_schema(writer, postgres_schemas)
+        await port.bump(writer, ("first", "second", "first"))
+        await writer.commit()
+
+    async with postgres_schemas.sessions() as observer:
+        result = await observer.execute(
+            select(generations.c.namespace, generations.c.version).where(
+                generations.c.namespace.in_(("single", "first", "second"))
+            )
+        )
+        rows = dict(result.tuples().all())
+    assert rows == {"single": 5, "first": 8, "second": 12}
+
+
+@pytest.mark.asyncio
+async def test_cache_generation_port_rolls_back_and_commits_with_domain_write(
+    postgres_schemas: SchemaFixture,
+) -> None:
+    generations, facts = await _create_cache_generation_test_tables(postgres_schemas)
+    port = HostCacheGenerations()
+    async with postgres_schemas.engine.begin() as connection:
+        await connection.execute(
+            insert(generations).values(namespace="domain", version=3)
+        )
+
+    async with postgres_schemas.sessions() as writer:
+        await _use_test_schema(writer, postgres_schemas)
+        await writer.execute(insert(facts).values(id=1, value="rolled-back"))
+        await port.bump(writer, ("domain",))
+        await writer.rollback()
+
+    async with postgres_schemas.sessions() as observer:
+        assert await observer.scalar(select(func.count()).select_from(facts)) == 0
+        assert await observer.scalar(
+            select(generations.c.version).where(generations.c.namespace == "domain")
+        ) == 3
+
+    async with postgres_schemas.sessions() as writer:
+        await _use_test_schema(writer, postgres_schemas)
+        await writer.execute(insert(facts).values(id=2, value="committed"))
+        await port.bump(writer, ("domain",))
+        await writer.commit()
+
+    async with postgres_schemas.sessions() as observer:
+        assert tuple(await observer.scalars(select(facts.c.value))) == ("committed",)
+        assert await observer.scalar(
+            select(generations.c.version).where(generations.c.namespace == "domain")
+        ) == 4
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_module_sdk.py
+++ b/backend/tests/test_module_sdk.py
@@ -1,9 +1,11 @@
 import ast
+import inspect
 import subprocess
 import sys
 from dataclasses import FrozenInstanceError, dataclass
 from pathlib import Path
 from typing import Protocol, get_type_hints
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import APIRouter, FastAPI
@@ -38,6 +40,7 @@ from app.platform.modules.sdk import (
 )
 from app.platform.modules.testing import (
     FakeCache,
+    FakeCacheGenerations,
     FakeEventBus,
     FakeHttpClientFactory,
     FakeHttpResponse,
@@ -243,6 +246,7 @@ async def test_public_test_context_fakes_need_no_infrastructure() -> None:
     )
 
     assert isinstance(context.cache, FakeCache)
+    assert isinstance(context.cache_generations, FakeCacheGenerations)
     assert isinstance(context.events, FakeEventBus)
     assert isinstance(context.services, FakeServiceRegistry)
     assert isinstance(context.permissions, FakePermissions)
@@ -256,6 +260,17 @@ async def test_public_test_context_fakes_need_no_infrastructure() -> None:
     assert await context.cache.set("key", b"value", ttl_seconds=30)
     assert await context.cache.get("key") == b"value"
     assert context.cache.ttls == {"key": 30}
+
+    session = AsyncMock()
+    await context.cache_generations.bump(
+        session, ("example-read-model", "example-analytics", "example-read-model")
+    )
+    assert await context.cache_generations.current(session, "example-read-model") == 2
+    assert await context.cache_generations.current(session, "example-analytics") == 2
+    assert context.cache_generations.bump_calls == [
+        ("example-read-model", "example-analytics")
+    ]
+    session.commit.assert_not_awaited()
 
     event = ExampleEvent()
     await context.events.publish(event)
@@ -315,6 +330,13 @@ def test_public_sdk_import_does_not_start_application() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_cache_generation_contract_is_generic() -> None:
+    source = inspect.getsource(CacheGenerationPort).lower()
+
+    assert "analysis-areas" not in source
+    assert "analysis_areas" not in source
 
 
 def test_public_sdk_has_no_host_internal_or_domain_imports() -> None:

--- a/backend/tests/test_module_test_host.py
+++ b/backend/tests/test_module_test_host.py
@@ -6,7 +6,11 @@ import pytest
 from app.platform.modules.dependency_graph import resolve_module_order
 from app.platform.modules.errors import ModuleCompatibilityError, ModuleDependencyCycleError
 from app.platform.modules.manifest import parse_manifest, validate_manifest
-from app.platform.modules.testing import FakeServiceRegistry, ModuleTestHost
+from app.platform.modules.testing import (
+    FakeCacheGenerations,
+    FakeServiceRegistry,
+    ModuleTestHost,
+)
 from tests.fixtures.service_modules.analysis_areas.module import DEFINITION
 
 FIXTURES = Path(__file__).parent / "fixtures/module_contracts"
@@ -25,6 +29,18 @@ def test_module_test_host_registers_example_without_infrastructure() -> None:
     assert context.module_id == "analysis-areas-fixture"
     assert isinstance(context.services, FakeServiceRegistry)
     assert context.services.sealed is True
+
+
+@pytest.mark.asyncio
+async def test_module_test_host_exposes_mutable_cache_generations() -> None:
+    host = ModuleTestHost(DEFINITION)
+
+    context = host.register()
+    assert isinstance(context.cache_generations, FakeCacheGenerations)
+
+    await context.cache_generations.bump(object(), ("fixture-resource",))
+
+    assert await context.cache_generations.current(object(), "fixture-resource") == 2
 
 
 def test_module_test_host_closes_registration_after_bootstrap() -> None:

--- a/backend/tests/test_redis_cache.py
+++ b/backend/tests/test_redis_cache.py
@@ -195,8 +195,11 @@ async def test_osm_v2_ignores_old_viewport_cache_with_peninsula(monkeypatch) -> 
 @pytest.mark.asyncio
 async def test_version_bump_is_persisted_for_namespace_invalidation() -> None:
     session = AsyncMock()
-    await cache_versions.bump_cache_versions(session, ("analytics", "polygons"))
+    await cache_versions.bump_cache_versions(
+        session, ("analytics", "polygons", "analytics")
+    )
     assert session.execute.await_args.args[1] == {"names": ["analytics", "polygons"]}
+    session.commit.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_redis_cache.py
+++ b/backend/tests/test_redis_cache.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -193,8 +193,26 @@ async def test_osm_v2_ignores_old_viewport_cache_with_peninsula(monkeypatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_cache_version_reuses_committed_safe_local_value(monkeypatch) -> None:
+    monkeypatch.setattr(cache_versions, "get_redis", lambda: object())
+    cache_versions._local_versions.clear()
+    session = MagicMock()
+    session.info = {}
+    session.get_transaction.return_value = None
+    session.scalar = AsyncMock(return_value=7)
+
+    assert await cache_versions.cache_version(session, "domain") == 7
+    assert await cache_versions.cache_version(session, "domain") == 7
+    session.scalar.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_version_bump_is_persisted_for_namespace_invalidation() -> None:
-    session = AsyncMock()
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    session.info = {}
+    session.get_transaction.return_value = None
     await cache_versions.bump_cache_versions(
         session, ("analytics", "polygons", "analytics")
     )

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -65,7 +65,7 @@ Sub-Interfaces `context.api` und `context.lifecycle`.
 | `permissions` | `PermissionPort` | hostseitige, fail-closed Policy-Auswertung aus #104 |
 | `permission_dependencies` | `PermissionDependencyFactory` | authentifizierte FastAPI-Dependency mit optionalem CSRF für Modulrouten |
 | `cache` | `CachePort` | optionaler, modulgebundener Byte-Cache |
-| `cache_generations` | `CacheGenerationPort` | Read-Model-Generationen ohne Cache-Interna |
+| `cache_generations` | `CacheGenerationPort` | Read-Model-Generationen transaktional lesen und erhöhen |
 | `public_queries` | `PublicQueryPort` | öffentliche Query-Policy und Limits |
 | `map_previews` | `MapPreviewPort` | öffentliche Kartenvorschauen |
 | `polygons` | `PolygonQueryPort` | Polygonprojektionen für neutrale `PolygonScope`-IDs |
@@ -101,6 +101,15 @@ Migrationen sind im
 Cache-Schlüssel und Storage-Keys gelten relativ zum aktuellen Modul; konkrete
 Adapter müssen sie entsprechend isolieren. Cache-TTLs sind positive ganze Sekunden.
 Die Ports machen keine Redis-, Dateisystem- oder Cloud-SDK-Typen öffentlich.
+
+`CachePort.clear()` und `CacheGenerationPort.bump()` haben unterschiedliche
+Aufgaben: `clear()` löscht die Keys des aktuellen Moduls. `bump(session,
+resources)` erhöht dagegen die Generationen gemeinsam genutzter Lesemodelle über
+die vom Aufrufer bereitgestellte Datenbank-Session. Der Bump nimmt vollständig an
+dieser caller-owned Transaktion teil und committet niemals implizit. Dadurch können
+fachlicher Write und Generation-Bump gemeinsam committed oder gemeinsam
+zurückgerollt werden. Doppelte Resource-IDs werden in stabiler Eingabereihenfolge
+dedupliziert und pro Aufruf genau einmal erhöht.
 
 ### Polygon-Scope
 
@@ -186,6 +195,9 @@ unveränderliche Menge und müssen ihren Migration Contract nicht ändern.
 Die additiven öffentlichen Backend-Service-Ports für Cache-Generationen,
 Public-Query-Schutz, Kartenvorschauen, Polygonabfragen und -aggregate,
 Kommunalstatistik erhöhen die SDK-Version auf `1.9.0`.
+Die additive transaktionale `CacheGenerationPort.bump()`-Methode erhöht die
+SDK-Version auf `1.10.0`. `current()` bleibt unverändert; `bump()` verwendet die
+Caller-Session, öffnet keine zweite Transaktion und committet nicht selbst.
 Alle Ports sind optional; bestehende Module und ihre Context-Konstruktion bleiben
 damit rückwärtskompatibel.
 

--- a/docs/modules/backend-service-ports.md
+++ b/docs/modules/backend-service-ports.md
@@ -9,7 +9,8 @@ Alle Verträge werden ausschließlich aus `app.platform.modules.sdk` importiert
 und optional über den unveränderlichen `ModuleContext` injiziert. Konkrete
 Implementierungen liegen in `app.integrations.module_host_ports`; dort wird zu
 den bestehenden Services komponiert, ohne deren Logik in das SDK zu kopieren.
-Die Verträge sind seit SDK 1.9 additiv und stabil. Einen fehlenden optionalen Port
+Die Leseverträge sind seit SDK 1.9 additiv und stabil; die transaktionale
+Cache-Generation-Mutation ist seit SDK 1.10 verfügbar. Einen fehlenden optionalen Port
 erkennt das konsumierende Modul bei seiner Registrierung. Validierungsfehler bleiben `ValueError`;
 ein nicht renderbares Preview wird als `MapPreviewUnavailableError` abstrahiert.
 Query-Timeouts werden über `PublicQueryPort.is_timeout()` erkannt, ohne
@@ -21,7 +22,7 @@ DB-Treiberfehler zum Modulvertrag zu machen.
 | --- | --- | --- | --- |
 | `DatabaseSessionProvider` | Host-eigene Transaktionsgrenze | keine | Async-Kontext mit `AsyncSession`; Exception löst Rollback aus |
 | `CachePort` | modulgebundener Byte-Cache | lokaler Key, Bytes, TTL | Bytes/Status; Backend-Ausfall verhält sich als Cache Miss |
-| `CacheGenerationPort` | geteilte Read-Model-Invalidierung lesen | Session, Ressourcenname | monotone Generation; keine Redis-/Key-Details |
+| `CacheGenerationPort` | geteilte Read-Model-Invalidierung lesen oder transaktional erhöhen | Session, Ressourcenname beziehungsweise Sequenz | monotone Generation; `bump()` committet nie selbst; keine Redis-/Key-Details |
 | `PublicQueryPort` | Host Security | Request, Session, begrenzter Ressourcenname | Guard oder etablierter HTTP-Fehler; `PublicQueryLimits` ist immutable |
 | `MapPreviewPort` | Host Map Rendering | `MapPreviewRequest` mit GeoJSON-Primitiven | Bytes, Content-Type, ETag, Cache-Hit; stabile Preview-Exception |
 | `PolygonQueryPort` | Polygon-Domäne | Session, immutable `PolygonScope` aus primitiven Polygon-IDs, Limit | immutable `PublicPolygonSummary`; niemals ORM |
@@ -41,7 +42,7 @@ Fachdomäne, C = Analysis-Areas-owned, D = obsolete Legacy-Kopplung.
 | `app.cache.service.last_cache_status` | C | request-lokaler Status im Modul-Cache-Adapter | Modul |
 | `app.cache.keys.build_cache_key` | C | kanonischer Key-Builder im Modul, vor dem bereits Host-seitig namespaceten `CachePort` | Modul |
 | `app.services.cache_versions.cache_version` | A | `CacheGenerationPort.current` | Platform |
-| `app.services.cache_versions.bump_cache_versions` | D | Der unregistrierte externe Legacy-Sync entfällt; kein mutierender Cache-Port | Modul / Platform |
+| `app.services.cache_versions.bump_cache_versions` | A | `CacheGenerationPort.bump`; delegiert an dieselbe Host-Implementierung und Caller-Transaktion | Platform |
 | `app.services.public_query_security.guard_public_query` | A | `PublicQueryPort.guard` | Platform Security |
 | `app.services.public_query_security.is_statement_timeout_error` | A | `PublicQueryPort.is_timeout` | Platform Security |
 | `app.services.map_previews.map_preview_service` | A | `MapPreviewPort.render` | Map Preview |
@@ -66,8 +67,8 @@ Fachdomäne, C = Analysis-Areas-owned, D = obsolete Legacy-Kopplung.
 | `app.schemas.polygon_filters.polygon_filter_query` | C | module-owned FastAPI-Dependency | Modul |
 
 `AREA_POI_CATEGORY_SQL`, API-Schemas, Filter-Parsing, Cache-Key-Building,
-Cache-Bumping, Social-Publishing und Response-Mapping werden bewusst nicht als
-Host-Port veröffentlicht: Sie bestimmen
+Social-Publishing und Response-Mapping werden bewusst nicht als Host-Port
+veröffentlicht: Sie bestimmen
 die konkrete Analysis-Areas-Antwort. Die privaten Analytics-Helfer bleiben privat;
 nur der bestehende Host-Adapter darf sie hinter fachlich benannten Operationen
 aufrufen. Der direkte Sessionimport ist ersatzlos obsolet, weil SDK 1.2 bereits


### PR DESCRIPTION
## Summary

Adds a public transactional cache-generation mutation for trusted in-process modules.

Closes #198

Coordinates:
- #184
- oklabflensburg/ocp-module-analysis-areas#5

## Contract

`CacheGenerationPort` now exposes:

- `current(session, resource) -> int`
- `bump(session, resources: Sequence[str]) -> None`

`bump(...)` participates in the caller-owned database transaction and never commits implicitly.

The additive public capability updates the Backend Module SDK from `1.9.0` to `1.10.0` according to the documented SemVer policy. Existing `current(...)` consumers remain compatible.

## Architecture

The public Module SDK delegates through `HostCacheGenerations` to the existing Host `bump_cache_versions(...)` implementation.

No domain-specific or Analysis-Areas-specific logic is introduced. No parallel cache implementation, session, or transaction is created.

## Transaction semantics

Supported:

```text
domain write
→ generation bump
→ optional current
→ caller commit or rollback
```

Rollback rolls back both the domain write and generation update. Process-local generation caching never exposes values from rolled-back transactions. Reads after a bump bypass the process-local cache until the caller-owned transaction ends; committed-safe reads retain the existing five-second optimization.

Process-local generation caching is also invalidated after the caller transaction commits, so a concurrent read of the previous committed generation cannot remain cached after the new generation becomes visible. Savepoint completion is not treated as the final commit boundary.

Duplicate resource IDs are deduplicated in stable input order and incremented exactly once per call, preserving the existing Host behavior.

`CachePort.clear()` remains distinct: it deletes module-owned cache keys, while `CacheGenerationPort.bump()` transactionally invalidates generation-based consumers.

## Tests

Executed locally:

- `cd backend && uv run ruff check app tests` — passed
- focused cache, SDK, Host-port and persistence suite — 89 passed
- `cd backend && uv run pytest` — 983 passed
- `scripts/module-contract-gate backend` — architecture check passed; 369 tests passed
- `cd backend && uv run python -c "from app.main import app; assert app.title"` — passed
- `git diff --check` — passed

Coverage includes:

- existing `current(...)` compatibility and committed-safe local-cache reuse
- single resource bump
- multiple resources
- stable duplicate deduplication
- no implicit commit and pre-commit isolation
- bump → current → rollback without process-local leakage
- bump → current → commit visibility
- concurrent pre-commit recache followed by outer-commit invalidation
- savepoints do not act as final cache-invalidation boundaries
- atomic domain write plus bump commit
- `create_test_module_context()` and `ModuleTestHost` fake access
- generic/no-domain-hardcode architecture assertions

## Non-goals

- no Analysis-Areas implementation
- no Wikidata job activation
- no OSM contract
- no Polygon contract
- no cache redesign
