### PR TITLE
hotfix(deploy): tolerate slow API startup and fix systemd dependencies

### DIFF
--- a/deploy/ansible/roles/stadtplaner/tasks/main.yml
+++ b/deploy/ansible/roles/stadtplaner/tasks/main.yml
@@ -1046,7 +1046,7 @@
       ansible.builtin.wait_for:
         host: 127.0.0.1
         port: "{{ stadtplaner_backend_port }}"
-        timeout: 30
+        timeout: 90
 
     - name: Wait for native map renderer readiness
       ansible.builtin.uri:
@@ -1228,7 +1228,7 @@
           ansible.builtin.wait_for:
             host: 127.0.0.1
             port: "{{ stadtplaner_backend_port }}"
-            timeout: 30
+            timeout: 90
 
         - name: Verify API readiness after rollback
           ansible.builtin.uri:

--- a/deploy/ansible/roles/stadtplaner/templates/stadtplaner-api.service.j2
+++ b/deploy/ansible/roles/stadtplaner/templates/stadtplaner-api.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Open City Planner FastAPI API
-After=network-online.target postgresql.service redis-server.service{% if stadtplaner_map_renderer_enabled | bool %} stadtplaner-map-renderer.service{% endif %}{% if stadtplaner_manage_otel_collector | default(false) | bool %} stadtplaner-otel-collector.service{% endif %}
-Wants=network-online.target{% if stadtplaner_map_renderer_enabled | bool %} stadtplaner-map-renderer.service{% endif %}{% if stadtplaner_manage_otel_collector | default(false) | bool %} stadtplaner-otel-collector.service{% endif %}
+After=network-online.target postgresql.service redis-server.service{{ ' stadtplaner-map-renderer.service' if stadtplaner_map_renderer_enabled | bool else '' }}{{ ' stadtplaner-otel-collector.service' if stadtplaner_manage_otel_collector | default(false) | bool else '' }}
+Wants=network-online.target{{ ' stadtplaner-map-renderer.service' if stadtplaner_map_renderer_enabled | bool else '' }}{{ ' stadtplaner-otel-collector.service' if stadtplaner_manage_otel_collector | default(false) | bool else '' }}
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary

This hotfix addresses the two deployment issues observed in Production Deploy #204:

- increase the FastAPI listener wait from 30s to 90s for both rollout and rollback
- render the API systemd `After=` / `Wants=` dependencies without malformed line concatenation

## Why

The production journal shows the target release was healthy but slow to cold-start under resource pressure:

- API service restarted at about 13:21:12 UTC
- application initialization completed and Uvicorn bound to `127.0.0.1:8008` at about 13:21:49 UTC
- Ansible timed out after 30 seconds and started rollback essentially at the moment the API became ready

The journal also repeatedly reported a malformed dependency token similar to:

`stadtplaner-otel-collector.serviceWants=network-online.target`

## Scope

Only two files change, with two line replacements in each:

- `deploy/ansible/roles/stadtplaner/tasks/main.yml`
- `deploy/ansible/roles/stadtplaner/templates/stadtplaner-api.service.j2`

No application/backend behavior is changed.