### PR TITLE
feat(modules): decouple Analysis Areas cutover boundaries

### DIFF
--- a/.github/workflows/module-contract.yml
+++ b/.github/workflows/module-contract.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: oklabflensburg/ocp-module-analysis-areas
-          ref: a63af188a0cf4ba10a389302bae4c1e0d80cfeda
+          ref: fe6d11cb53575e0cbc383d8de714d5f9711f77c0
           path: .external-analysis-areas
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -107,17 +107,17 @@ jobs:
           (cd .external-analysis-areas/frontend && pnpm install --frozen-lockfile)
       - name: Build the pinned real OCP bundle
         run: |
-          (cd .external-analysis-areas/backend && SOURCE_DATE_EPOCH="$(git -C .. show -s --format=%ct a63af188a0cf4ba10a389302bae4c1e0d80cfeda)" uv build --wheel)
+          (cd .external-analysis-areas/backend && SOURCE_DATE_EPOCH="$(git -C .. show -s --format=%ct fe6d11cb53575e0cbc383d8de714d5f9711f77c0)" uv build --wheel)
           (cd .external-analysis-areas/frontend && pnpm build)
           (cd backend && .venv/bin/python -m app.cli.modules bundle build \
             --manifest ../.external-analysis-areas/module.yaml \
-            --backend ../.external-analysis-areas/backend/dist/ocp_module_analysis_areas-1.0.0-py3-none-any.whl \
-            --frontend ../.external-analysis-areas/frontend/dist/analysis-areas-1.0.0.tgz \
-            --publisher oklabflensburg --source-reference pull/2 \
+            --backend ../.external-analysis-areas/backend/dist/ocp_module_analysis_areas-1.4.0-py3-none-any.whl \
+            --frontend ../.external-analysis-areas/frontend/dist/analysis-areas-1.4.0.tgz \
+            --publisher oklabflensburg --source-reference pull/9 \
             --source-repository https://github.com/oklabflensburg/ocp-module-analysis-areas \
-            --source-commit a63af188a0cf4ba10a389302bae4c1e0d80cfeda \
+            --source-commit fe6d11cb53575e0cbc383d8de714d5f9711f77c0 \
             --build-workflow github-actions/module-contract --license AGPL-3.0-only \
-            --output "${RUNNER_TEMP}/analysis-areas-1.0.0.ocp")
+            --output "${RUNNER_TEMP}/analysis-areas-1.4.0.ocp")
         working-directory: .
       - name: Prove the planned public polygon-port consumer flow
         working-directory: backend
@@ -127,11 +127,11 @@ jobs:
       - name: Verify, install disabled and prove migration parity
         working-directory: backend
         run: |
-          .venv/bin/python -m app.cli.modules verify "${RUNNER_TEMP}/analysis-areas-1.0.0.ocp"
-          .venv/bin/python -m app.cli.modules install "${RUNNER_TEMP}/analysis-areas-1.0.0.ocp"
+          .venv/bin/python -m app.cli.modules verify "${RUNNER_TEMP}/analysis-areas-1.4.0.ocp"
+          .venv/bin/python -m app.cli.modules install "${RUNNER_TEMP}/analysis-areas-1.4.0.ocp"
           .venv/bin/python -m app.cli.modules env --format json | tee "${RUNNER_TEMP}/disabled-env.json"
           .venv/bin/python -c 'import json,sys; value=json.load(open(sys.argv[1])); assert value["ENABLED_MODULES"] == ""; assert value["OCP_ENABLED_INSTALLED_BACKEND_PATHS"] == ""; assert value["OCP_EXCLUDED_BUILTIN_MODULES"] == "analysis-areas"' "${RUNNER_TEMP}/disabled-env.json"
-          migration_root="${OCP_MODULE_INSTALL_ROOT}/installed/analysis-areas/1.0.0/backend/site-packages/ocp_module_analysis_areas/migrations/history"
+          migration_root="${OCP_MODULE_INSTALL_ROOT}/installed/analysis-areas/1.4.0/backend/site-packages/ocp_module_analysis_areas/migrations/history"
           for file in 20260814_0014_analysis_areas.py 20260817_0023_area_wikidata.py 20260818_0025_osm_external_links.py 20260819_0032_optimize_area_poi_analytics.py; do
             cmp "alembic/versions/${file}" "${migration_root}/${file}"
           done

--- a/backend/alembic/versions/20260901_0035_decouple_statistics_areas.py
+++ b/backend/alembic/versions/20260901_0035_decouple_statistics_areas.py
@@ -1,0 +1,167 @@
+"""Decouple municipal statistics from Analysis Areas persistence.
+
+Revision ID: 20260901_0035
+Revises: 20260825_0034
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260901_0035"
+down_revision = "20260825_0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "external_area_mappings",
+        sa.Column("level", sa.String(length=40), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE external_area_mappings mapping
+        SET level = area.area_type
+        FROM analysis_areas area
+        WHERE area.id = mapping.analysis_area_id
+        """
+    )
+    op.alter_column("external_area_mappings", "level", nullable=False)
+
+    op.add_column(
+        "statistical_observations",
+        sa.Column("statistical_area_id", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE statistical_observations observation
+        SET statistical_area_id = mapping.id
+        FROM external_area_mappings mapping
+        WHERE mapping.analysis_area_id = observation.analysis_area_id
+        """
+    )
+    op.alter_column("statistical_observations", "statistical_area_id", nullable=False)
+    op.drop_constraint(
+        "uq_statistical_observation", "statistical_observations", type_="unique"
+    )
+    op.drop_index(
+        "idx_statistical_observations_area_period",
+        table_name="statistical_observations",
+    )
+    op.drop_constraint(
+        "statistical_observations_analysis_area_id_fkey",
+        "statistical_observations",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "statistical_observations_statistical_area_id_fkey",
+        "statistical_observations",
+        "external_area_mappings",
+        ["statistical_area_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_unique_constraint(
+        "uq_statistical_observation",
+        "statistical_observations",
+        ["metric_id", "statistical_area_id", "period_start", "source_area_id"],
+    )
+    op.create_index(
+        "idx_statistical_observations_area_period",
+        "statistical_observations",
+        ["statistical_area_id", "period_start"],
+    )
+    op.drop_column("statistical_observations", "analysis_area_id")
+
+    op.drop_index("idx_external_area_mapping_area", table_name="external_area_mappings")
+    op.drop_constraint(
+        "external_area_mappings_analysis_area_id_fkey",
+        "external_area_mappings",
+        type_="foreignkey",
+    )
+    op.drop_column("external_area_mappings", "analysis_area_id")
+    op.create_index(
+        "idx_external_area_mapping_name_level",
+        "external_area_mappings",
+        ["external_area_name", "level"],
+    )
+
+
+def downgrade() -> None:
+    op.add_column(
+        "external_area_mappings",
+        sa.Column("analysis_area_id", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE external_area_mappings mapping
+        SET analysis_area_id = area.id
+        FROM analysis_areas area
+        WHERE area.name = mapping.external_area_name
+          AND area.area_type = mapping.level
+        """
+    )
+    op.alter_column("external_area_mappings", "analysis_area_id", nullable=False)
+    op.create_foreign_key(
+        "external_area_mappings_analysis_area_id_fkey",
+        "external_area_mappings",
+        "analysis_areas",
+        ["analysis_area_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.drop_index(
+        "idx_external_area_mapping_name_level", table_name="external_area_mappings"
+    )
+    op.create_index(
+        "idx_external_area_mapping_area",
+        "external_area_mappings",
+        ["analysis_area_id"],
+    )
+
+    op.add_column(
+        "statistical_observations",
+        sa.Column("analysis_area_id", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE statistical_observations observation
+        SET analysis_area_id = mapping.analysis_area_id
+        FROM external_area_mappings mapping
+        WHERE mapping.id = observation.statistical_area_id
+        """
+    )
+    op.alter_column("statistical_observations", "analysis_area_id", nullable=False)
+    op.drop_constraint(
+        "uq_statistical_observation", "statistical_observations", type_="unique"
+    )
+    op.drop_index(
+        "idx_statistical_observations_area_period",
+        table_name="statistical_observations",
+    )
+    op.drop_constraint(
+        "statistical_observations_statistical_area_id_fkey",
+        "statistical_observations",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "statistical_observations_analysis_area_id_fkey",
+        "statistical_observations",
+        "analysis_areas",
+        ["analysis_area_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_unique_constraint(
+        "uq_statistical_observation",
+        "statistical_observations",
+        ["metric_id", "analysis_area_id", "period_start", "source_area_id"],
+    )
+    op.create_index(
+        "idx_statistical_observations_area_period",
+        "statistical_observations",
+        ["analysis_area_id", "period_start"],
+    )
+    op.drop_column("statistical_observations", "statistical_area_id")
+    op.drop_column("external_area_mappings", "level")

--- a/backend/app/integrations/module_host_ports.py
+++ b/backend/app/integrations/module_host_ports.py
@@ -45,6 +45,7 @@ from app.platform.modules.sdk import (
     PublicQueryLimits,
     StatisticsArea,
     StatisticSeriesPoint,
+    StatisticsSelection,
     StatisticsSource,
     StatisticValue,
 )
@@ -441,10 +442,12 @@ def _statistics_source(value) -> StatisticsSource | None:
 class HostStatisticsQueries:
     """Public DTO adapter owned by the municipal-statistics domain."""
 
-    async def for_area(self, session: AsyncSession, slug: str) -> AreaStatistics | None:
+    async def for_selection(
+        self, session: AsyncSession, selection: StatisticsSelection
+    ) -> AreaStatistics | None:
         from app.services import area_statistics
 
-        value = await area_statistics.area_statistics(session, slug)
+        value = await area_statistics.area_statistics(session, selection)
         if value is None:
             return None
         return AreaStatistics(
@@ -455,12 +458,17 @@ class HostStatisticsQueries:
             latest=tuple(StatisticValue(**item.model_dump()) for item in value.latest),
         )
 
-    async def series_for_area(
-        self, session: AsyncSession, slug: str, metric_key: str
+    async def series_for_selection(
+        self,
+        session: AsyncSession,
+        selection: StatisticsSelection,
+        metric_key: str,
     ) -> AreaStatisticSeries | None:
         from app.services import area_statistics
 
-        value = await area_statistics.area_statistic_series(session, slug, metric_key)
+        value = await area_statistics.area_statistic_series(
+            session, selection, metric_key
+        )
         if value is None:
             return None
         return AreaStatisticSeries(

--- a/backend/app/models/statistics.py
+++ b/backend/app/models/statistics.py
@@ -76,9 +76,7 @@ class ExternalAreaMapping(Base):
     source: Mapped[str] = mapped_column(String(40), nullable=False)
     external_area_id: Mapped[str] = mapped_column(String(80), nullable=False)
     external_area_name: Mapped[str] = mapped_column(String(200), nullable=False)
-    analysis_area_id: Mapped[int] = mapped_column(
-        ForeignKey("analysis_areas.id", ondelete="CASCADE"), nullable=False
-    )
+    level: Mapped[str] = mapped_column(String(40), nullable=False)
     valid_from: Mapped[date | None] = mapped_column(Date)
     valid_to: Mapped[date | None] = mapped_column(Date)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
@@ -89,7 +87,7 @@ class ExternalAreaMapping(Base):
     __table_args__ = (
         UniqueConstraint("source", "external_area_id", name="uq_external_area_mapping_id"),
         UniqueConstraint("source", "external_area_name", name="uq_external_area_mapping_name"),
-        Index("idx_external_area_mapping_area", "analysis_area_id"),
+        Index("idx_external_area_mapping_name_level", "external_area_name", "level"),
     )
 
 
@@ -100,8 +98,8 @@ class StatisticalObservation(Base):
     metric_id: Mapped[int] = mapped_column(
         ForeignKey("statistical_metrics.id", ondelete="CASCADE"), nullable=False
     )
-    analysis_area_id: Mapped[int] = mapped_column(
-        ForeignKey("analysis_areas.id", ondelete="CASCADE"), nullable=False
+    statistical_area_id: Mapped[int] = mapped_column(
+        ForeignKey("external_area_mappings.id", ondelete="RESTRICT"), nullable=False
     )
     period_type: Mapped[str] = mapped_column(String(24), default="YEAR", nullable=False)
     period_start: Mapped[date] = mapped_column(Date, nullable=False)
@@ -117,14 +115,14 @@ class StatisticalObservation(Base):
     __table_args__ = (
         UniqueConstraint(
             "metric_id",
-            "analysis_area_id",
+            "statistical_area_id",
             "period_start",
             "source_area_id",
             name="uq_statistical_observation",
         ),
         Index(
             "idx_statistical_observations_area_period",
-            "analysis_area_id",
+            "statistical_area_id",
             "period_start",
         ),
         Index(

--- a/backend/app/modules/analysis_areas/api/router.py
+++ b/backend/app/modules/analysis_areas/api/router.py
@@ -17,6 +17,7 @@ from ..application.legacy_queries import (
     area_uuid_by_slug,
     areas_geojson,
     list_areas,
+    statistics_selection,
 )
 from ..integrations.legacy import (
     AreaStatisticSeriesRead,
@@ -171,7 +172,10 @@ async def get_area_statistics(
     slug: str, session: SessionDep, request: Request
 ) -> AreaStatisticsRead:
     await guard_public_query(request, session, "area-statistics")
-    result = await area_statistics(session, slug)
+    area = await area_detail_by_slug(session, slug)
+    if area is None:
+        raise HTTPException(404, "Das Gebiet wurde nicht gefunden.")
+    result = await area_statistics(session, statistics_selection(area))
     if result is None:
         raise HTTPException(404, "Das Gebiet wurde nicht gefunden.")
     return result
@@ -187,7 +191,12 @@ async def get_area_statistic_series(
     slug: str, metric_key: str, session: SessionDep, request: Request
 ) -> AreaStatisticSeriesRead:
     await guard_public_query(request, session, "area-statistic-series")
-    result = await area_statistic_series(session, slug, metric_key)
+    area = await area_detail_by_slug(session, slug)
+    if area is None:
+        raise HTTPException(404, "Das Gebiet wurde nicht gefunden.")
+    result = await area_statistic_series(
+        session, statistics_selection(area), metric_key
+    )
     if result is None:
         raise HTTPException(404, "Die Gebietsstatistik wurde nicht gefunden.")
     return result

--- a/backend/app/modules/analysis_areas/application/legacy_queries.py
+++ b/backend/app/modules/analysis_areas/application/legacy_queries.py
@@ -19,6 +19,7 @@ from app.modules.analysis_areas.api.schemas import (
     MetricDifference,
 )
 from app.modules.analysis_areas.persistence.models import AnalysisArea, PolygonAnalysisArea
+from app.platform.modules.sdk import StatisticsArea, StatisticsSelection
 
 from ..integrations.legacy import (
     AREA_POI_CATEGORY_SQL,
@@ -51,6 +52,39 @@ SELECT area.uuid::text AS id, area.slug, area.name, area.area_type, parent.uuid:
        (SELECT count(*) FROM analysis_areas child WHERE child.parent_id=area.id) AS child_count
 FROM analysis_areas area LEFT JOIN analysis_areas parent ON parent.id=area.parent_id
 """)
+
+
+def statistics_selection(area: AnalysisAreaDetail) -> StatisticsSelection:
+    """Resolve Analysis-Areas hierarchy before crossing into Statistics."""
+
+    requested = StatisticsArea(
+        id=uuid.UUID(area.id),
+        slug=area.slug,
+        name=area.name,
+        area_type=area.area_type,
+    )
+    target_value = area.parent if area.area_type == "QUARTER" else area
+    municipality_value = area if area.area_type == "MUNICIPALITY" else area.municipality
+    if target_value is None or municipality_value is None:
+        raise ValueError("Analysis area has no complete statistics hierarchy")
+    target = StatisticsArea(
+        id=uuid.UUID(target_value.id),
+        slug=target_value.slug,
+        name=target_value.name,
+        area_type=target_value.area_type,
+    )
+    municipality = StatisticsArea(
+        id=uuid.UUID(municipality_value.id),
+        slug=municipality_value.slug,
+        name=municipality_value.name,
+        area_type=municipality_value.area_type,
+    )
+    return StatisticsSelection(
+        requested=requested,
+        target=target,
+        municipality=municipality,
+        inherited=requested.id != target.id,
+    )
 
 
 POI_TAG_PREDICATE_SQL = """

--- a/backend/app/modules/reference/persistence/migrations/20260901_mod_reference_0002_merge_host_statistics.py
+++ b/backend/app/modules/reference/persistence/migrations/20260901_mod_reference_0002_merge_host_statistics.py
@@ -1,0 +1,14 @@
+"""Merge the reference-module branch with the Host statistics migration."""
+
+revision = "mod_reference_20260901_0002"
+down_revision = ("mod_reference_20260826_0001", "20260901_0035")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/platform/modules/runtime.py
+++ b/backend/app/platform/modules/runtime.py
@@ -39,7 +39,7 @@ from app.platform.modules.settings import (
 )
 
 logger = logging.getLogger(__name__)
-MODULE_SDK_VERSION = "1.13.0"
+MODULE_SDK_VERSION = "1.14.0"
 
 
 @dataclass(slots=True)

--- a/backend/app/platform/modules/sdk.py
+++ b/backend/app/platform/modules/sdk.py
@@ -892,6 +892,16 @@ class StatisticsArea:
 
 
 @dataclass(frozen=True, slots=True)
+class StatisticsSelection:
+    """Vom aufrufenden Fachmodul vollständig aufgelöster Statistikbezug."""
+
+    requested: StatisticsArea
+    target: StatisticsArea
+    municipality: StatisticsArea
+    inherited: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class StatisticsSource:
     name: str
     url: str
@@ -948,12 +958,14 @@ class AreaStatisticSeries:
 
 
 class StatisticsQueryPort(Protocol):
-    """Liest öffentliche Kommunalstatistik ohne Statistics-ORM-Typen."""
+    """Liest Kommunalstatistik für einen fachlich bereits aufgelösten Bezug."""
 
-    async def for_area(self, session: AsyncSession, slug: str) -> AreaStatistics | None: ...
+    async def for_selection(
+        self, session: AsyncSession, selection: StatisticsSelection
+    ) -> AreaStatistics | None: ...
 
-    async def series_for_area(
-        self, session: AsyncSession, slug: str, metric_key: str
+    async def series_for_selection(
+        self, session: AsyncSession, selection: StatisticsSelection, metric_key: str
     ) -> AreaStatisticSeries | None: ...
 
 
@@ -1320,6 +1332,7 @@ __all__ = [
     "StatisticValue",
     "StatisticsArea",
     "StatisticsQueryPort",
+    "StatisticsSelection",
     "StatisticsSource",
     "StoragePort",
     "TracerPort",

--- a/backend/app/services/area_statistics.py
+++ b/backend/app/services/area_statistics.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.cache.keys import build_cache_key
 from app.cache.service import cache_service
 from app.core.config import get_settings
+from app.platform.modules.sdk import StatisticsArea, StatisticsSelection
 from app.schemas.statistics import (
     AreaStatisticSeriesRead,
     AreaStatisticsRead,
@@ -21,23 +22,31 @@ def _relative(value: Decimal | None, reference: Decimal | None) -> Decimal | Non
     return ((value - reference) / reference * 100).quantize(Decimal("0.01"))
 
 
-async def _area_context(session: AsyncSession, slug: str) -> dict | None:
+async def _mapping_context(
+    session: AsyncSession, selection: StatisticsSelection
+) -> dict | None:
     row = (
         await session.execute(
             text("""
-              SELECT requested.id,requested.uuid,requested.slug,requested.name,requested.area_type,
-                     stats.id AS statistics_id,stats.uuid AS statistics_uuid,
-                     stats.slug AS statistics_slug,stats.name AS statistics_name,
-                     stats.area_type AS statistics_type,
+              SELECT target.id AS statistics_id,
                      municipality.id AS municipality_id
-              FROM analysis_areas requested
-              JOIN analysis_areas stats ON stats.id=CASE
-                WHEN requested.area_type='QUARTER' THEN requested.parent_id ELSE requested.id END
-              JOIN analysis_areas municipality ON municipality.area_type='MUNICIPALITY'
-              WHERE requested.slug=:slug
-              ORDER BY municipality.id LIMIT 1
+              FROM external_area_mappings target
+              JOIN external_area_mappings municipality
+                ON municipality.source=target.source
+              WHERE target.source=:source
+                AND target.external_area_name=:target_name
+                AND target.level=:target_level
+                AND municipality.external_area_name=:municipality_name
+                AND municipality.level=:municipality_level
+              LIMIT 1
             """),
-            {"slug": slug},
+            {
+                "source": SOURCE,
+                "target_name": selection.target.name,
+                "target_level": selection.target.area_type,
+                "municipality_name": selection.municipality.name,
+                "municipality_level": selection.municipality.area_type,
+            },
         )
     ).mappings().first()
     return dict(row) if row else None
@@ -64,26 +73,19 @@ async def _source(session: AsyncSession) -> dict | None:
     }
 
 
-def _references(context: dict) -> tuple[dict, dict]:
-    requested = {
-        "id": context["uuid"],
-        "slug": context["slug"],
-        "name": context["name"],
-        "area_type": context["area_type"],
+def _reference(value: StatisticsArea) -> dict:
+    return {
+        "id": value.id,
+        "slug": value.slug,
+        "name": value.name,
+        "area_type": value.area_type,
     }
-    statistics_area = {
-        "id": context["statistics_uuid"],
-        "slug": context["statistics_slug"],
-        "name": context["statistics_name"],
-        "area_type": context["statistics_type"],
-    }
-    return requested, statistics_area
 
 
 async def _area_statistics_uncached(
-    session: AsyncSession, slug: str
+    session: AsyncSession, selection: StatisticsSelection
 ) -> AreaStatisticsRead | None:
-    context = await _area_context(session, slug)
+    context = await _mapping_context(session, selection)
     if context is None:
         return None
     rows = (
@@ -94,7 +96,7 @@ async def _area_statistics_uncached(
                   PARTITION BY observation.metric_id ORDER BY observation.period_start DESC
                 ) AS rank
                 FROM statistical_observations observation
-                WHERE observation.analysis_area_id=:statistics_id
+                WHERE observation.statistical_area_id=:statistics_id
               )
               SELECT metric.key,metric.name,metric.category,metric.unit,
                      ranked.value_numeric,ranked.period_start,ranked.is_calculated,
@@ -102,7 +104,7 @@ async def _area_statistics_uncached(
               FROM ranked JOIN statistical_metrics metric ON metric.id=ranked.metric_id
               LEFT JOIN statistical_observations city
                 ON city.metric_id=ranked.metric_id
-               AND city.analysis_area_id=:municipality_id
+               AND city.statistical_area_id=:municipality_id
                AND city.period_start=ranked.period_start
               WHERE ranked.rank=1 AND metric.public=true
               ORDER BY CASE metric.category
@@ -115,7 +117,6 @@ async def _area_statistics_uncached(
             },
         )
     ).mappings().all()
-    requested, statistics_area = _references(context)
     latest = []
     for row in rows:
         value = row["value_numeric"]
@@ -129,7 +130,7 @@ async def _area_statistics_uncached(
                 "unit": row["unit"],
                 "period": str(row["period_start"].year),
                 "period_start": row["period_start"],
-                "area_level": context["statistics_type"],
+                "area_level": selection.target.area_type,
                 "is_calculated": row["is_calculated"],
                 "municipality_value": municipality,
                 "difference": value - municipality
@@ -139,35 +140,45 @@ async def _area_statistics_uncached(
             }
         )
     return AreaStatisticsRead(
-        area=requested,
-        statistics_area=statistics_area,
-        inherited_from_parent=context["id"] != context["statistics_id"],
+        area=_reference(selection.requested),
+        statistics_area=_reference(selection.target),
+        inherited_from_parent=selection.inherited,
         source=await _source(session),
         latest=latest,
     )
 
 
-async def area_statistics(session: AsyncSession, slug: str) -> AreaStatisticsRead | None:
+async def area_statistics(
+    session: AsyncSession, selection: StatisticsSelection
+) -> AreaStatisticsRead | None:
     version = await cache_version(session, "statistics")
-    key = build_cache_key("analysis-area:statistics", {"slug": slug}, version=version)
+    key = build_cache_key(
+        "statistics:selection",
+        {
+            "requested": str(selection.requested.id),
+            "target": str(selection.target.id),
+            "municipality": str(selection.municipality.id),
+        },
+        version=version,
+    )
 
     async def compute() -> dict | None:
-        result = await _area_statistics_uncached(session, slug)
+        result = await _area_statistics_uncached(session, selection)
         return result.model_dump(mode="json") if result else None
 
     data, _status = await cache_service.get_or_compute(
         key,
         ttl=get_settings().statistics_cache_ttl,
-        resource="analysis-area-statistics",
+        resource="statistics-selection",
         compute=compute,
     )
     return AreaStatisticsRead.model_validate(data) if data else None
 
 
 async def _area_statistic_series_uncached(
-    session: AsyncSession, slug: str, metric_key: str
+    session: AsyncSession, selection: StatisticsSelection, metric_key: str
 ) -> AreaStatisticSeriesRead | None:
-    context = await _area_context(session, slug)
+    context = await _mapping_context(session, selection)
     if context is None:
         return None
     metric = (
@@ -186,17 +197,16 @@ async def _area_statistic_series_uncached(
             text("""
               SELECT period_start,value_numeric,value_text
               FROM statistical_observations
-              WHERE metric_id=:metric_id AND analysis_area_id=:area_id
+              WHERE metric_id=:metric_id AND statistical_area_id=:area_id
               ORDER BY period_start
             """),
             {"metric_id": metric["id"], "area_id": context["statistics_id"]},
         )
     ).mappings().all()
-    requested, statistics_area = _references(context)
     return AreaStatisticSeriesRead(
-        area=requested,
-        statistics_area=statistics_area,
-        inherited_from_parent=context["id"] != context["statistics_id"],
+        area=_reference(selection.requested),
+        statistics_area=_reference(selection.target),
+        inherited_from_parent=selection.inherited,
         source=await _source(session),
         metric={key: str(metric[key]) for key in ("key", "name", "unit", "category")},
         series=[
@@ -212,23 +222,28 @@ async def _area_statistic_series_uncached(
 
 
 async def area_statistic_series(
-    session: AsyncSession, slug: str, metric_key: str
+    session: AsyncSession, selection: StatisticsSelection, metric_key: str
 ) -> AreaStatisticSeriesRead | None:
     version = await cache_version(session, "statistics")
     key = build_cache_key(
-        "analysis-area:statistics-series",
-        {"slug": slug, "metric": metric_key},
+        "statistics:selection-series",
+        {
+            "requested": str(selection.requested.id),
+            "target": str(selection.target.id),
+            "municipality": str(selection.municipality.id),
+            "metric": metric_key,
+        },
         version=version,
     )
 
     async def compute() -> dict | None:
-        result = await _area_statistic_series_uncached(session, slug, metric_key)
+        result = await _area_statistic_series_uncached(session, selection, metric_key)
         return result.model_dump(mode="json") if result else None
 
     data, _status = await cache_service.get_or_compute(
         key,
         ttl=get_settings().statistics_cache_ttl,
-        resource="analysis-area-statistics-series",
+        resource="statistics-selection-series",
         compute=compute,
     )
     return AreaStatisticSeriesRead.model_validate(data) if data else None

--- a/backend/app/services/assistant_tools.py
+++ b/backend/app/services/assistant_tools.py
@@ -11,6 +11,7 @@ from app.modules.analysis_areas.application.legacy_queries import (
     area_polygons_by_slug,
     area_uuid_by_slug,
     list_areas,
+    statistics_selection,
 )
 from app.schemas.analytics import AreaCompareFilters, AreaCompareRequest
 from app.schemas.assistant import (
@@ -156,7 +157,8 @@ async def _area_analytics(session: AsyncSession, raw: BaseModel) -> AreaAnalytic
 
 async def _area_statistics(session: AsyncSession, raw: BaseModel) -> AreaStatisticsToolResult:
     args = AreaSlugInput.model_validate(raw)
-    result = await area_statistics(session, args.slug)
+    area = await area_detail_by_slug(session, args.slug)
+    result = await area_statistics(session, statistics_selection(area)) if area else None
     if result is None:
         raise AssistantToolError("STATISTICS_NOT_FOUND", "Für das Gebiet liegen keine Statistiken vor.", 404)
     return AreaStatisticsToolResult(data=result)
@@ -164,7 +166,12 @@ async def _area_statistics(session: AsyncSession, raw: BaseModel) -> AreaStatist
 
 async def _statistic_series(session: AsyncSession, raw: BaseModel) -> StatisticSeriesToolResult:
     args = StatisticSeriesInput.model_validate(raw)
-    result = await area_statistic_series(session, args.slug, args.metric_key)
+    area = await area_detail_by_slug(session, args.slug)
+    result = (
+        await area_statistic_series(session, statistics_selection(area), args.metric_key)
+        if area
+        else None
+    )
     if result is None:
         raise AssistantToolError("STATISTIC_NOT_FOUND", "Die Statistik-Zeitreihe wurde nicht gefunden.", 404)
     return StatisticSeriesToolResult(data=result)

--- a/backend/app/services/flensburg_statistics_import.py
+++ b/backend/app/services/flensburg_statistics_import.py
@@ -18,15 +18,12 @@ from app.models.statistics import (
     StatisticalMetric,
     StatisticalObservation,
 )
-from app.modules.analysis_areas.persistence.models import AnalysisArea
 from app.services.cache_versions import bump_cache_versions
 from app.services.flensburg_superset import DATASET_SPECS, FlensburgSupersetClient
 from app.services.notification_policy import DomainEvent, NotificationEventType
 from app.services.notifications import (
     notify_superusers,
-    notify_users,
     publish_notifications,
-    subscription_recipient_ids,
 )
 from app.services.social_publishing import enqueue_statistics_summary
 
@@ -243,21 +240,6 @@ def normalize_rows(
 
 
 async def _ensure_mappings(session: AsyncSession) -> dict[str, ExternalAreaMapping]:
-    names = [name for name, _area_type in AREA_MAPPING.values()]
-    areas = (await session.scalars(select(AnalysisArea).where(AnalysisArea.name.in_(names)))).all()
-    by_key = {(area.name, area.area_type): area for area in areas}
-    missing = [
-        f"{name} ({area_type})"
-        for name, area_type in AREA_MAPPING.values()
-        if (name, area_type) not in by_key
-    ]
-    if missing:
-        raise ValueError(
-            "Required analysis areas are missing: "
-            f"{', '.join(missing)}. Synchronize them first with "
-            "`python -m app.cli.sync_analysis_areas --municipality Flensburg` "
-            "after loading the OSM boundary data."
-        )
     existing = {
         mapping.external_area_id: mapping
         for mapping in (
@@ -267,17 +249,16 @@ async def _ensure_mappings(session: AsyncSession) -> dict[str, ExternalAreaMappi
         ).all()
     }
     for external_id, (name, area_type) in AREA_MAPPING.items():
-        area = by_key[(name, area_type)]
         mapping = existing.get(external_id)
         if mapping:
-            if mapping.external_area_name != name or mapping.analysis_area_id != area.id:
+            if mapping.external_area_name != name or mapping.level != area_type:
                 raise ValueError(f"Conflicting reviewed mapping for external area {external_id}")
         else:
             mapping = ExternalAreaMapping(
                 source=SOURCE,
                 external_area_id=external_id,
                 external_area_name=name,
-                analysis_area_id=area.id,
+                level=area_type,
             )
             session.add(mapping)
             existing[external_id] = mapping
@@ -390,12 +371,11 @@ async def import_flensburg_statistics(
         datasets, metrics = await _ensure_catalog(session, source_updated_at)
         existing_rows = (await session.scalars(select(StatisticalObservation))).all()
         existing = {
-            (row.metric_id, row.analysis_area_id, row.period_start, row.source_area_id): row
+            (row.metric_id, row.statistical_area_id, row.period_start, row.source_area_id): row
             for row in existing_rows
         }
         external_ids = {name: external_id for external_id, (name, _type) in AREA_MAPPING.items()}
         inserted = updated = unchanged = 0
-        changed_area_ids: set[object] = set()
         imported_at = datetime.now(UTC)
         for (metric_key, area_name, year), value in observations.items():
             metric = metrics[metric_key]
@@ -403,7 +383,7 @@ async def import_flensburg_statistics(
             external_id = external_ids[area_name]
             period_start = date(year, 1, 1)
             row_hash = _source_hash(metric_key, external_id, year, value)
-            identity = (metric.id, mapping.analysis_area_id, period_start, external_id)
+            identity = (metric.id, mapping.id, period_start, external_id)
             current = existing.get(identity)
             change = observation_change(current.source_row_hash if current else None, row_hash)
             if change == "unchanged":
@@ -411,7 +391,7 @@ async def import_flensburg_statistics(
                 continue
             statement = insert(StatisticalObservation).values(
                 metric_id=metric.id,
-                analysis_area_id=mapping.analysis_area_id,
+                statistical_area_id=mapping.id,
                 period_type="YEAR",
                 period_start=period_start,
                 period_end=date(year, 12, 31),
@@ -439,7 +419,6 @@ async def import_flensburg_statistics(
                 updated += 1
             else:
                 inserted += 1
-            changed_area_ids.add(mapping.analysis_area_id)
         for dataset in datasets.values():
             dataset.last_import_at = imported_at
         run = await session.get(StatisticalImportRun, run_id)
@@ -457,34 +436,8 @@ async def import_flensburg_statistics(
         run.column_names = json.dumps(column_names, ensure_ascii=False, sort_keys=True)
         session.add(AdminAuditLog(action="FLENSBURG_STATISTICS_SYNC"))
         await enqueue_statistics_summary(session, inserted + updated)
-        await bump_cache_versions(session, ("statistics", "analysis-areas"))
-        notifications = []
-        if changed_area_ids:
-            areas = await session.scalars(
-                select(AnalysisArea).where(AnalysisArea.id.in_(changed_area_ids))
-            )
-            for area in areas:
-                recipients = await subscription_recipient_ids(
-                    session,
-                    resource_type="AREA",
-                    resource_id=str(area.id),
-                    event_type=NotificationEventType.AREA_STATISTICS_UPDATED,
-                )
-                notifications.extend(
-                    await notify_users(
-                        session,
-                        recipients,
-                        DomainEvent(
-                            event_type=NotificationEventType.AREA_STATISTICS_UPDATED,
-                            resource_type="AREA",
-                            resource_id=str(area.id),
-                            resource_slug=area.slug,
-                            resource_title=area.name,
-                        ),
-                    )
-                )
+        await bump_cache_versions(session, ("statistics",))
         await session.commit()
-        publish_notifications(notifications)
         return StatisticsImportReport(
             status="SUCCESS",
             rows_downloaded=run.rows_downloaded,

--- a/backend/tests/e2e_seed.py
+++ b/backend/tests/e2e_seed.py
@@ -10,7 +10,12 @@ from geoalchemy2.elements import WKTElement
 
 from app.auth.passwords import hash_password
 from app.db.session import AsyncSessionLocal
-from app.models.statistics import StatisticalDataset, StatisticalMetric, StatisticalObservation
+from app.models.statistics import (
+    ExternalAreaMapping,
+    StatisticalDataset,
+    StatisticalMetric,
+    StatisticalObservation,
+)
 from app.models.user import User
 from app.models.user_polygon import UserPolygon
 from app.modules.analysis_areas.persistence.models import AnalysisArea, PolygonAnalysisArea
@@ -59,15 +64,15 @@ def area(
 
 def observation(
     metric_id: int,
-    area_id: int,
+    statistical_area_id: int,
     year: int,
     value: int,
     source_area_id: str,
 ) -> StatisticalObservation:
-    fingerprint = f"{metric_id}:{area_id}:{year}:{value}"
+    fingerprint = f"{metric_id}:{statistical_area_id}:{year}:{value}"
     return StatisticalObservation(
         metric_id=metric_id,
-        analysis_area_id=area_id,
+        statistical_area_id=statistical_area_id,
         period_type="YEAR",
         period_start=date(year, 1, 1),
         period_end=date(year, 12, 31),
@@ -218,12 +223,26 @@ async def seed() -> None:
         )
         session.add(metric)
         await session.flush()
+        flensburg_mapping = ExternalAreaMapping(
+            source="FLENSBURG_STATISTICS",
+            external_area_id="00",
+            external_area_name="Flensburg",
+            level="MUNICIPALITY",
+        )
+        altstadt_mapping = ExternalAreaMapping(
+            source="FLENSBURG_STATISTICS",
+            external_area_id="01",
+            external_area_name="Altstadt",
+            level="DISTRICT",
+        )
+        session.add_all([flensburg_mapping, altstadt_mapping])
+        await session.flush()
         session.add_all(
             [
-                observation(metric.id, flensburg.id, 2020, 90_164, "flensburg"),
-                observation(metric.id, flensburg.id, 2025, 98_040, "flensburg"),
-                observation(metric.id, altstadt.id, 2020, 3_412, "altstadt"),
-                observation(metric.id, altstadt.id, 2025, 3_657, "altstadt"),
+                observation(metric.id, flensburg_mapping.id, 2020, 90_164, "flensburg"),
+                observation(metric.id, flensburg_mapping.id, 2025, 98_040, "flensburg"),
+                observation(metric.id, altstadt_mapping.id, 2020, 3_412, "altstadt"),
+                observation(metric.id, altstadt_mapping.id, 2025, 3_657, "altstadt"),
             ]
         )
         await session.commit()

--- a/backend/tests/fixtures/module_migrations/example_a/20260825_mod_example_a_0001.py
+++ b/backend/tests/fixtures/module_migrations/example_a/20260825_mod_example_a_0001.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "mod_example_a_20260825_0001"
-down_revision = "20260825_0034"
+down_revision = "20260901_0035"
 branch_labels = None
 depends_on = None
 

--- a/backend/tests/test_area_statistics_boundary.py
+++ b/backend/tests/test_area_statistics_boundary.py
@@ -1,0 +1,191 @@
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+from app.platform.modules.sdk import StatisticsArea, StatisticsSelection
+from app.services.area_statistics import (
+    _area_statistic_series_uncached,
+    _area_statistics_uncached,
+)
+
+
+class MappingResult:
+    def __init__(self, *, first=None, rows=()) -> None:
+        self._first = first
+        self._rows = list(rows)
+
+    def mappings(self):
+        return self
+
+    def first(self):
+        return self._first
+
+    def all(self):
+        return self._rows
+
+
+def area(identifier: str, slug: str, name: str, level: str) -> StatisticsArea:
+    return StatisticsArea(
+        id=UUID(identifier), slug=slug, name=name, area_type=level
+    )
+
+
+MUNICIPALITY = area(
+    "11111111-1111-4111-8111-111111111111",
+    "flensburg",
+    "Flensburg",
+    "MUNICIPALITY",
+)
+DISTRICT = area(
+    "22222222-2222-4222-8222-222222222222",
+    "altstadt-15630273",
+    "Altstadt",
+    "DISTRICT",
+)
+QUARTER = area(
+    "33333333-3333-4333-8333-333333333333",
+    "nordertor-15651154",
+    "Nordertor",
+    "QUARTER",
+)
+SOURCE = {
+    "last_import_at": datetime(2026, 1, 2, tzinfo=UTC),
+    "source_updated_at": datetime(2026, 1, 1, tzinfo=UTC),
+}
+
+
+@pytest.mark.asyncio
+async def test_district_statistics_use_neutral_mapping_and_municipality_comparison() -> None:
+    session = SimpleNamespace(
+        execute=AsyncMock(
+            side_effect=[
+                MappingResult(first={"statistics_id": 7, "municipality_id": 1}),
+                MappingResult(
+                    rows=[
+                        {
+                            "key": "population",
+                            "name": "Bevölkerung",
+                            "category": "Bevölkerung",
+                            "unit": "persons",
+                            "value_numeric": Decimal(3657),
+                            "period_start": date(2025, 1, 1),
+                            "is_calculated": False,
+                            "municipality_value": Decimal(98040),
+                        }
+                    ]
+                ),
+                MappingResult(first=SOURCE),
+            ]
+        )
+    )
+
+    result = await _area_statistics_uncached(
+        session,
+        StatisticsSelection(
+            requested=DISTRICT,
+            target=DISTRICT,
+            municipality=MUNICIPALITY,
+        ),
+    )
+
+    assert result is not None
+    assert result.area.slug == DISTRICT.slug
+    assert result.statistics_area.slug == DISTRICT.slug
+    assert result.inherited_from_parent is False
+    assert result.latest[0].municipality_value == Decimal(98040)
+    assert result.latest[0].difference == Decimal(-94383)
+    assert "analysis_areas" not in " ".join(
+        str(call.args[0]).lower() for call in session.execute.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_quarter_response_preserves_requested_area_and_inherited_target() -> None:
+    session = SimpleNamespace(
+        execute=AsyncMock(
+            side_effect=[
+                MappingResult(first={"statistics_id": 7, "municipality_id": 1}),
+                MappingResult(rows=[]),
+                MappingResult(first=SOURCE),
+            ]
+        )
+    )
+
+    result = await _area_statistics_uncached(
+        session,
+        StatisticsSelection(
+            requested=QUARTER,
+            target=DISTRICT,
+            municipality=MUNICIPALITY,
+            inherited=True,
+        ),
+    )
+
+    assert result is not None
+    assert result.area.slug == QUARTER.slug
+    assert result.statistics_area.slug == DISTRICT.slug
+    assert result.inherited_from_parent is True
+
+
+@pytest.mark.asyncio
+async def test_series_uses_the_selected_statistics_mapping() -> None:
+    session = SimpleNamespace(
+        execute=AsyncMock(
+            side_effect=[
+                MappingResult(first={"statistics_id": 7, "municipality_id": 1}),
+                MappingResult(
+                    first={
+                        "id": 9,
+                        "key": "population",
+                        "name": "Bevölkerung",
+                        "unit": "persons",
+                        "category": "Bevölkerung",
+                    }
+                ),
+                MappingResult(
+                    rows=[
+                        {
+                            "period_start": date(2025, 1, 1),
+                            "value_numeric": Decimal(3657),
+                            "value_text": None,
+                        }
+                    ]
+                ),
+                MappingResult(first=SOURCE),
+            ]
+        )
+    )
+
+    result = await _area_statistic_series_uncached(
+        session,
+        StatisticsSelection(
+            requested=DISTRICT,
+            target=DISTRICT,
+            municipality=MUNICIPALITY,
+        ),
+        "population",
+    )
+
+    assert result is not None
+    assert result.series[0].value == Decimal(3657)
+    assert "statistical_area_id" in str(session.execute.await_args_list[2].args[0])
+
+
+@pytest.mark.asyncio
+async def test_missing_statistics_mapping_returns_none() -> None:
+    session = SimpleNamespace(execute=AsyncMock(return_value=MappingResult(first=None)))
+
+    result = await _area_statistics_uncached(
+        session,
+        StatisticsSelection(
+            requested=MUNICIPALITY,
+            target=MUNICIPALITY,
+            municipality=MUNICIPALITY,
+        ),
+    )
+
+    assert result is None

--- a/backend/tests/test_module_host_ports.py
+++ b/backend/tests/test_module_host_ports.py
@@ -243,3 +243,17 @@ assert HostPolygonAnalytics and HostPolygonQueries
     )
 
     assert completed.returncode == 0, completed.stderr
+
+
+def test_statistics_runtime_has_no_analysis_areas_persistence_dependency() -> None:
+    sources = [
+        ROOT / "backend/app/models/statistics.py",
+        ROOT / "backend/app/services/area_statistics.py",
+        ROOT / "backend/app/services/flensburg_statistics_import.py",
+        ROOT / "backend/app/integrations/module_host_ports.py",
+    ]
+    combined = "\n".join(source.read_text(encoding="utf-8") for source in sources)
+
+    assert "analysis_areas" not in combined
+    assert "analysis_area_id" not in combined
+    assert "area_type == \"QUARTER\"" not in combined

--- a/backend/tests/test_module_persistence.py
+++ b/backend/tests/test_module_persistence.py
@@ -468,7 +468,7 @@ def test_interleaved_adopted_history_has_one_host_head_and_alternating_steps(
         ).splitlines()
     )
 
-    assert scripts.get_heads() == ["20260825_0034"]
+    assert scripts.get_heads() == ["20260901_0035"]
     for revision_id in ("20260814_0014", "20260817_0023", "20260818_0025", "20260819_0032"):
         revision_path = Path(scripts.get_revision(revision_id).path).resolve()
         assert revision_path.is_relative_to(module_versions.resolve())
@@ -476,6 +476,7 @@ def test_interleaved_adopted_history_has_one_host_head_and_alternating_steps(
     assert scripts.get_revision("20260819_0032").down_revision == "20260819_0031"
     assert scripts.get_revision("20260822_0033").down_revision == "20260819_0032"
     assert scripts.get_revision("20260825_0034").down_revision == "20260822_0033"
+    assert scripts.get_revision("20260901_0035").down_revision == "20260825_0034"
     assert [(step.module_id, step.revision) for step in plan] == [
         ("host", "20260814_0013"),
         ("example-adopted-module", "20260814_0014"),
@@ -485,7 +486,7 @@ def test_interleaved_adopted_history_has_one_host_head_and_alternating_steps(
         ("example-adopted-module", "20260818_0025"),
         ("host", "20260819_0031"),
         ("example-adopted-module", "20260819_0032"),
-        ("host", "20260825_0034"),
+        ("host", "20260901_0035"),
     ]
 
 
@@ -493,7 +494,7 @@ def test_future_module_revision_must_extend_current_global_head(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     coordinator = interleaved_coordinator(
-        tmp_path, monkeypatch, future_parent="20260825_0034"
+        tmp_path, monkeypatch, future_parent="20260901_0035"
     )
 
     plan = coordinator.preflight()
@@ -502,7 +503,7 @@ def test_future_module_revision_must_extend_current_global_head(
     assert scripts.get_heads() == ["mod_example_adopted_module_0001"]
     assert (
         scripts.get_revision("mod_example_adopted_module_0001").down_revision
-        == "20260825_0034"
+        == "20260901_0035"
     )
     assert [
         revision.revision
@@ -511,6 +512,7 @@ def test_future_module_revision_must_extend_current_global_head(
         )
     ] == [
         "mod_example_adopted_module_0001",
+        "20260901_0035",
         "20260825_0034",
         "20260822_0033",
     ]
@@ -675,7 +677,7 @@ def test_migration_preflight_combines_host_and_modules_in_dependency_order() -> 
     plan = MigrationCoordinator(config, registry).preflight()
 
     assert [(step.module_id, step.revision) for step in plan[-3:]] == [
-        ("host", "20260825_0034"),
+        ("host", "20260901_0035"),
         ("example-a", "mod_example_a_20260825_0001"),
         ("example-b", "mod_example_b_20260825_0001"),
     ]
@@ -796,11 +798,11 @@ async def test_existing_database_at_host_head_only_runs_future_module_revision(
         historical_revision = await connection.scalar(
             text("SELECT version_num FROM alembic_version")
         )
-    assert historical_revision == "20260825_0034"
+    assert historical_revision == "20260901_0035"
 
     write_future_revision(
         Path(historical._config.get_main_option("version_locations").splitlines()[1]),
-        down_revision="20260825_0034",
+        down_revision="20260901_0035",
     )
     upgrade_targets: list[str] = []
     real_upgrade = module_migrations.command.upgrade
@@ -822,6 +824,95 @@ async def test_existing_database_at_host_head_only_runs_future_module_revision(
     assert final_revision == "mod_example_adopted_module_0001"
     assert final_marker == "mod_example_adopted_module_0001"
     assert upgrade_targets == ["mod_example_adopted_module_0001"]
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_statistics_area_migration_preserves_existing_rows_and_round_trips(
+    fresh_database_url: str,
+) -> None:
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    config.attributes["database_url"] = fresh_database_url
+    await asyncio.to_thread(module_migrations.command.upgrade, config, "20260825_0034")
+
+    engine = create_async_engine(fresh_database_url)
+    async with engine.begin() as connection:
+        await connection.execute(
+            text("""
+                INSERT INTO analysis_areas
+                  (id, uuid, slug, name, area_type, geometry, centroid, area_m2)
+                VALUES
+                  (41, '11111111-1111-4111-8111-111111111111', 'altstadt-15630273',
+                   'Altstadt', 'DISTRICT',
+                   ST_Multi(ST_GeomFromText('POLYGON((9 54,10 54,10 55,9 55,9 54))', 4326)),
+                   ST_GeomFromText('POINT(9.5 54.5)', 4326), 1000)
+            """)
+        )
+        await connection.execute(
+            text("""
+                INSERT INTO external_area_mappings
+                  (id, source, external_area_id, external_area_name, analysis_area_id)
+                VALUES (7, 'FLENSBURG_STATISTICS', '01', 'Altstadt', 41)
+            """)
+        )
+        await connection.execute(
+            text("""
+                INSERT INTO statistical_datasets
+                  (id, source, external_dataset_id, name, source_url, license,
+                   update_frequency)
+                VALUES (3, 'FLENSBURG_STATISTICS', '6', 'Bevölkerung',
+                        'https://example.test', 'DL-DE-Zero-2.0', 'annual')
+            """)
+        )
+        await connection.execute(
+            text("""
+                INSERT INTO statistical_metrics
+                  (id, dataset_id, key, name, unit, category)
+                VALUES (5, 3, 'population', 'Bevölkerung', 'persons', 'Bevölkerung')
+            """)
+        )
+        await connection.execute(
+            text("""
+                INSERT INTO statistical_observations
+                  (id, metric_id, analysis_area_id, period_start, period_end,
+                   value_numeric, source_area_id, source_row_hash)
+                VALUES (9, 5, 41, '2025-01-01', '2025-12-31', 3657, '01',
+                        repeat('a', 64))
+            """)
+        )
+
+    await asyncio.to_thread(module_migrations.command.upgrade, config, "20260901_0035")
+    async with engine.connect() as connection:
+        migrated = (
+            await connection.execute(
+                text("""
+                    SELECT observation.value_numeric, mapping.external_area_id,
+                           mapping.level
+                    FROM statistical_observations observation
+                    JOIN external_area_mappings mapping
+                      ON mapping.id = observation.statistical_area_id
+                    WHERE observation.id = 9
+                """)
+            )
+        ).one()
+    assert tuple(migrated) == (3657, "01", "DISTRICT")
+
+    await asyncio.to_thread(module_migrations.command.downgrade, config, "20260825_0034")
+    async with engine.connect() as connection:
+        restored = (
+            await connection.execute(
+                text("""
+                    SELECT observation.value_numeric, observation.analysis_area_id,
+                           mapping.analysis_area_id
+                    FROM statistical_observations observation
+                    JOIN external_area_mappings mapping
+                      ON mapping.id = 7
+                    WHERE observation.id = 9
+                """)
+            )
+        ).one()
+    assert tuple(restored) == (3657, 41, 41)
+
     await engine.dispose()
 
 
@@ -884,7 +975,7 @@ async def test_reference_module_migration_up_down_and_seed_data(
         count = await connection.scalar(text("SELECT count(*) FROM reference.items"))
         revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
     assert count == 2
-    assert revision == "mod_reference_20260826_0001"
+    assert revision == "mod_reference_20260901_0002"
 
     await asyncio.to_thread(coordinator.downgrade, "20260825_0034")
     async with engine.connect() as connection:
@@ -899,7 +990,7 @@ async def test_reference_module_migration_up_down_and_seed_data(
     await asyncio.to_thread(coordinator.upgrade)
     async with engine.connect() as connection:
         revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
-    assert revision == "mod_reference_20260826_0001"
+    assert revision == "mod_reference_20260901_0002"
     await engine.dispose()
 
 
@@ -953,7 +1044,7 @@ async def test_reference_module_disable_and_reenable_keep_graph_revision_and_dat
 
     assert (disabled_plan[-1].module_id, disabled_plan[-1].revision) == (
         "reference",
-        "mod_reference_20260826_0001",
+        "mod_reference_20260901_0002",
     )
     assert enabled_revision == disabled_revision == reenabled_revision
     assert (before_disable, while_disabled, after_reenable) == (2, 2, 2)
@@ -992,7 +1083,7 @@ async def test_successful_migration_then_startup_failure_does_not_downgrade(
     async with engine.connect() as connection:
         revision = await connection.scalar(text("SELECT version_num FROM alembic_version"))
         count = await connection.scalar(text("SELECT count(*) FROM reference.items"))
-    assert revision == "mod_reference_20260826_0001"
+    assert revision == "mod_reference_20260901_0002"
     assert count == 2
     await engine.dispose()
 

--- a/backend/tests/test_module_settings.py
+++ b/backend/tests/test_module_settings.py
@@ -249,7 +249,7 @@ def test_disabled_available_migration_does_not_validate_required_settings(
 
     assert (plan[-1].module_id, plan[-1].revision) == (
         "reference",
-        "mod_reference_20260826_0001",
+        "mod_reference_20260901_0002",
     )
 
 

--- a/docs/architecture/adr-frontend-build-time-modules.md
+++ b/docs/architecture/adr-frontend-build-time-modules.md
@@ -76,7 +76,9 @@ enthält nur:
 - Compatibility-Ranges für Host, Frontend-SDK und optionales Backend-Modul;
 - lokalen Layer-Pfad;
 - kleine Modulabhängigkeitsmenge;
-- öffentliche Routenmetadaten.
+- öffentliche Routenmetadaten;
+- optionale statische und dynamische Sitemap-Contributions für bereits deklarierte
+  Routen.
 
 IDs spiegeln die Backend-Regel aus #93: lowercase kebab-case, maximal 63 Zeichen.
 Ein Fullstack-Modul verwendet auf beiden Seiten dieselbe ID. Versionen und Ranges

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -27,15 +27,14 @@ bei reinen Dokumentationsänderungen nicht.
 | Module Contract Gate | `Module contract gate` | Backend-/Frontend-Importgrenzen, Manifest-, Dependency-, Registry-, Map- und SSR-Verträge ohne Playwright |
 
 Der Cross-Repo-Teil des Module Contract Gate baut `ocp-module-analysis-areas`
-reproduzierbar vom vollständigen PR-#2-Commit
-`a63af188a0cf4ba10a389302bae4c1e0d80cfeda`, prüft Bundle, deaktivierte
+reproduzierbar vom vollständigen PR-#9-Commit
+`fe6d11cb53575e0cbc383d8de714d5f9711f77c0`, prüft Bundle, deaktivierte
 Installation, Migration Ownership, Enable/Disable/Re-enable und die bestehenden
 API-Characterization-Tests. Eine zusätzliche Consumer-Probe liest die
 Area→Polygon-Relation ausschließlich über die Persistenzmodelle des externen
 Moduls und übergibt einen neutralen `PolygonScope` an den Host-Port.
-`scripts/check_external_module_imports.py` steht für
-den koordinierten SDK-1.9-Folgecommit bereit und verbietet dort alle Host-Imports
-außer `app.platform.modules.sdk`.
+`scripts/check_external_module_imports.py` verbietet im installierbaren Paket
+alle Host-Imports außer `app.platform.modules.sdk`.
 
 Das Module Contract Gate prüft zusätzlich, dass Repository-Module Settings und
 Secrets über den namespaceten Host-Port beziehen. Diese Architekturregel ist keine

--- a/docs/modules/analysis-areas-module.md
+++ b/docs/modules/analysis-areas-module.md
@@ -17,6 +17,19 @@ Modulvertrag im [Backend-README](../../backend/app/modules/analysis_areas/README
   Statistics (#128), Polygons (#129) und Host-Primitives bleiben hinter einem
   engen, dokumentierten Strangler-Adapter.
 
+## Finale Statistics- und Sitemap-Grenze
+
+Seit SDK 1.14 löst das Analysis-Areas-Modul Requested Area, tatsächliches
+Statistikziel und Municipality-Vergleich selbst auf. Der Host erhält nur eine
+`StatisticsSelection`; Quartier-, Parent- und Slug-Semantik liegen nicht mehr in
+der Statistikdomäne. Deren Beobachtungen referenzieren eine eigene
+`external_area_mappings`-Zeile statt `analysis_areas`.
+
+Seit Frontend-SDK 1.5 deklariert das Modul `/gebiete` und seinen dynamischen
+Sitemap-Provider im Manifest. Der Host verarbeitet diese Contribution generisch
+und kennt weder Gebietsroute noch Analysis-Areas-Endpunkt. Die Navigation von
+Gebiets-POIs zur Karte wird ebenfalls als module-owned Helper ausgeliefert.
+
 ## Lessons learned für #108
 
 Einfach waren Manifest, Router-Contribution, build-time Nuxt-Routen, Navigation

--- a/docs/modules/backend-module-sdk.md
+++ b/docs/modules/backend-module-sdk.md
@@ -258,6 +258,12 @@ Der additive, über die Service-Registry aufgelöste `PolygonIdentityPort` erhö
 SDK-Version auf `1.13.0`. Er löst stabile öffentliche Polygon-UUIDs begrenzt und
 deterministisch in die bereits von `PolygonScope` und bestehenden Relationsschemas
 benötigte Host-Identität auf, ohne ORM-Typen oder Transaktionsownership offenzulegen.
+SDK `1.14.0` korrigiert die Statistics-Grenze: Consumer übergeben eine vollständig
+aufgelöste `StatisticsSelection` aus Requested-, Target- und Municipality-Referenz.
+Damit entscheidet die owning Fachdomäne über Hierarchie und Vererbung; die
+Kommunalstatistik liest ausschließlich ihre eigene Gebietszuordnung und kennt weder
+fremde Tabellen noch Slug- oder Parent-Semantik. Module, die den Statistics-Port
+verwenden, müssen deshalb mindestens SDK 1.14 deklarieren.
 Alle Ports sind optional; bestehende Module und ihre Context-Konstruktion bleiben
 damit rückwärtskompatibel.
 

--- a/docs/modules/backend-service-ports.md
+++ b/docs/modules/backend-service-ports.md
@@ -1,7 +1,7 @@
 # Öffentliche Backend-Service-Ports
 
-Stand dieser Inventarisierung ist `ocp-module-analysis-areas` PR #2, exakt Commit
-`a63af188a0cf4ba10a389302bae4c1e0d80cfeda`. Installierte In-Process-Module
+Stand dieser Inventarisierung ist `ocp-module-analysis-areas` PR #9, exakt Commit
+`fe6d11cb53575e0cbc383d8de714d5f9711f77c0`. Installierte In-Process-Module
 dürfen stabile öffentliche Host-Capabilities verwenden. Sie dürfen nie von
 privaten Implementierungsdetails einer Host-Fachdomäne abhängen.
 

--- a/docs/modules/backend-service-ports.md
+++ b/docs/modules/backend-service-ports.md
@@ -27,7 +27,7 @@ DB-Treiberfehler zum Modulvertrag zu machen.
 | `MapPreviewPort` | Host Map Rendering | `MapPreviewRequest` mit GeoJSON-Primitiven | Bytes, Content-Type, ETag, Cache-Hit; stabile Preview-Exception |
 | `PolygonQueryPort` | Polygon-Domäne | Session, immutable `PolygonScope` aus primitiven Polygon-IDs, Limit | immutable `PublicPolygonSummary`; niemals ORM |
 | `PolygonAnalyticsPort` | Polygon-/Analytics-Domäne | Session, `PolygonScope`, primitive Filter | `PolygonMetrics` und `CountValue`; niemals SQL-Ausdrücke/ORM |
-| `StatisticsQueryPort` | Kommunalstatistik-Domäne | Session, Slug, optionaler Metrik-Key | immutable Statistik-DTOs oder `None` |
+| `StatisticsQueryPort` | Kommunalstatistik-Domäne | Session, fachlich aufgelöste `StatisticsSelection`, optionaler Metrik-Key | immutable Statistik-DTOs oder `None` |
 | `OsmSnapshotQueryPort` | Plattform-eigener OSM-Snapshot | Session, immutable und begrenzte `OsmSnapshotQuery` | cursor-paginierte, ORM-freie `OsmFeatureSnapshot`-DTOs; Details im [OSM-Vertrag](osm-public-contract.md) |
 | `PolygonSpatialMatchPort` | Polygon-Domäne | Session, immutable Area-Geometrien mit EWKB | stabile Polygon-UUIDs und räumliche Match-Metriken; Details im [Polygon-Spatial-Match-Vertrag](polygon-assignment-contract.md) |
 | `PolygonIdentityPort` (`platform.polygon-identity@1`) | Polygon-Domäne | Caller-Session, höchstens 5.000 stabile Polygon-UUIDs | immutable UUID↔interne-ID-Zuordnungen und explizite unbekannte UUIDs; niemals ORM |
@@ -56,8 +56,8 @@ Fachdomäne, C = Analysis-Areas-owned, D = obsolete Legacy-Kopplung.
 | `app.services.analytics._base_filters` | B | primitive `PolygonFilterValues` am `PolygonAnalyticsPort` | Polygon Analytics |
 | `app.services.analytics._benchmark_metrics` | B | `PolygonAnalyticsPort.metrics` | Polygon Analytics |
 | `app.services.analytics._counts` | B | `PolygonAnalyticsPort.category_counts` | Polygon Analytics |
-| `app.services.area_statistics.area_statistics` | B | `StatisticsQueryPort.for_area` | Statistics |
-| `app.services.area_statistics.area_statistic_series` | B | `StatisticsQueryPort.series_for_area` | Statistics |
+| `app.services.area_statistics.area_statistics` | B | `StatisticsQueryPort.for_selection` | Statistics |
+| `app.services.area_statistics.area_statistic_series` | B | `StatisticsQueryPort.series_for_selection` | Statistics |
 | `app.services.poi_categories.AREA_POI_CATEGORY_SQL` | C | kleine OSM-Tag-Projektion zusammen mit der bestehenden Gebiet-POI-Query im Modul | Modul |
 | `app.services.social_publishing.enqueue_area_publication` | D | Der unregistrierte externe Legacy-Sync entfällt; kein spekulativer Social-Port | Social Publishing |
 | `app.schemas.analytics.BenchmarkMetrics` | B | `PolygonMetrics`, danach module-owned API-Schema | Polygon Analytics / Modul |
@@ -96,6 +96,15 @@ ab; der Host liest oder schreibt diese fremde Relation nie.
 Für Polygon-Lese- und Analytics-Flows bleibt `PolygonScope` der neutrale Scope.
 `UserPolygon` und räumliche Berechnung bleiben Host-intern; domänenspezifische
 Assignment-Persistenz bleibt Consumer-intern.
+
+## Kommunalstatistik-Grenze
+
+Die Gebietsdomain bestimmt Requested Area, tatsächliches Statistikziel,
+Municipality-Vergleich und Vererbungsstatus. Sie übergibt diese Entscheidung als
+immutable `StatisticsSelection`. Der Statistics-Owner ordnet das gewählte Ziel
+anschließend seiner eigenen `(source, external_area_id)`-Identität zu. Beobachtungen
+referenzieren die Host-eigene Mapping-Zeile; es gibt weder einen Foreign Key noch
+Runtime-SQL auf einer fremden Gebietstabelle.
 
 ## Lifecycle und Datenschutz
 

--- a/docs/modules/builtin-cutover.md
+++ b/docs/modules/builtin-cutover.md
@@ -36,20 +36,18 @@ Frontend-Snapshot ein. Aktivierung bleibt ausschließlich in `modules.lock`.
    `enable` mit erneutem Deploy/Restart prüfen.
 
 Für `analysis-areas` ist der geprüfte externe Contract auf Commit
-`a63af188a0cf4ba10a389302bae4c1e0d80cfeda` gepinnt. Er liefert die Revisionen
+`fe6d11cb53575e0cbc383d8de714d5f9711f77c0` gepinnt. Er liefert die Revisionen
 `20260814_0014`, `20260817_0023`, `20260818_0025` und `20260819_0032` mit
-unveränderten Kanten. Der isolierte Legacy-Adapter des Pins ist vollständig in
+unveränderten Kanten. Seine Host-Capabilities sind vollständig in
 [öffentliche Backend-Service-Ports](backend-service-ports.md) inventarisiert.
-SDK 1.9 stellt die öffentlichen Ersatzverträge bereit; der aktuelle Pin bleibt
-bis zum koordinierten Modul-Folgecommit Trusted Code mit der dokumentierten
-Legacy-Grenze.
+Das Paket importiert ausschließlich das öffentliche SDK; Gebietsfachlogik und
+Persistenz bleiben im Modul.
 
-Der Cross-Repo-Contract modelliert bereits den geplanten Folgeflow: Das externe
+Der Cross-Repo-Contract prüft den produktiven Flow: Das externe
 Modul löst Gebiet und `polygon_analysis_areas` über seine eigenen ORM-Modelle und
 den bestehenden `DatabaseSessionProvider` auf, baut daraus einen neutralen
-`PolygonScope` und ruft erst danach den Host-Polygon-Port auf. Der aktuelle Pin
-verwendet produktiv weiterhin den dokumentierten Legacy-Adapter; der Contract
-behauptet daher noch keinen abgeschlossenen SDK-Cutover.
+`PolygonScope` und ruft erst danach den Host-Polygon-Port auf. Die
+Statistikhierarchie wird ebenso vor dem neutralen Host-Port im Modul aufgelöst.
 
 ## Rollback
 

--- a/docs/modules/frontend-ui-contributions.md
+++ b/docs/modules/frontend-ui-contributions.md
@@ -9,10 +9,17 @@ bereitstellen. Die Architekturentscheidung steht im
 Das öffentliche SDK wird über `#frontend-module-sdk` exportiert. Die wichtigsten
 Typen sind `UiSlotId`, `FrontendModuleUiContribution`, `NavigationContribution`,
 `HeaderActionContribution`, `UiVisibilityRule` und `UiVisibilityContext`.
-`FRONTEND_MODULE_SDK_VERSION` ist additiv `1.4.0`; die UI-Verträge aus
+`FRONTEND_MODULE_SDK_VERSION` ist additiv `1.5.0`; die UI-Verträge aus
 Versionen `1.1.0` bis `1.3.0` bleiben unverändert kompatibel. Die zusätzlichen
 Platform-Ports sind separat unter
 [Frontend-Platform-Ports](frontend-platform-ports.md) beschrieben.
+
+SDK 1.5 ergänzt eine optionale Sitemap-Contribution. `staticRoutes` enthält
+explizit indexierbare, bereits deklarierte Modulrouten. `dynamicRoutes` verbindet
+eine deklarierte Route mit genau einem `:slug`-Parameter mit einem sicheren,
+relativen Backend-Endpunkt. Dieser liefert ausschließlich `slug` und optional
+`updated_at`. Nur aktivierte Module gelangen in die Build-Time-Registry; der Host
+kennt weder fachliche Pfade noch Tabellen oder Endpunkte.
 
 Unterstützte Slots:
 
@@ -44,6 +51,10 @@ neue Host-Layout- oder Map-Runtime.
       {
         "path": "/module-example",
         "source": "layer/app/pages/module-example.vue"
+      },
+      {
+        "path": "/module-example/:slug",
+        "source": "layer/app/pages/module-example/[slug].vue"
       }
     ],
     "ui": [
@@ -62,7 +73,16 @@ neue Host-Layout- oder Map-Runtime.
         "source": "layer/app/components/ExampleModuleAction.vue",
         "accessibleLabel": "Frontend-Modulbeispiel öffnen"
       }
-    ]
+    ],
+    "sitemap": {
+      "staticRoutes": ["/module-example"],
+      "dynamicRoutes": [
+        {
+          "route": "/module-example/:slug",
+          "endpoint": "/module-example/sitemap"
+        }
+      ]
+    }
   }
 }
 ```

--- a/frontend/app/utils/poiCategories.ts
+++ b/frontend/app/utils/poiCategories.ts
@@ -67,10 +67,6 @@ export function isPoiCategoryToken(category: unknown): category is string {
   return typeof category === 'string' && /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,79}$/.test(category)
 }
 
-export function areaPoiMapLink(areaSlug: string, category: string) {
-  return { path: '/karte', query: { gebiet: areaSlug, poi: category } }
-}
-
 export function withoutPoiQuery<T extends Record<string, unknown>>(query: T) {
   const result = { ...query }
   delete result.poi

--- a/frontend/frontend-modules/analysis-areas/layer/app/pages/gebiete/[slug].vue
+++ b/frontend/frontend-modules/analysis-areas/layer/app/pages/gebiete/[slug].vue
@@ -140,12 +140,12 @@
 
 <script setup lang="ts">
 import {
-  areaPoiMapLink,
   getIndustryColor,
   getIndustryLabel,
   getPoiCategoryLabel,
   useModuleSession
 } from '#frontend-module-sdk'
+import { areaPoiMapLink } from '../../utils/areaPoiMapLink'
 
 const route = useRoute()
 const session = useModuleSession()

--- a/frontend/frontend-modules/analysis-areas/layer/app/utils/areaPoiMapLink.ts
+++ b/frontend/frontend-modules/analysis-areas/layer/app/utils/areaPoiMapLink.ts
@@ -1,0 +1,3 @@
+export function areaPoiMapLink(areaSlug: string, category: string) {
+  return { path: '/karte', query: { gebiet: areaSlug, poi: category } }
+}

--- a/frontend/frontend-modules/analysis-areas/module.json
+++ b/frontend/frontend-modules/analysis-areas/module.json
@@ -5,7 +5,7 @@
   "backendModuleId": "analysis-areas",
   "compatibility": {
     "host": ">=1.0.0 <2.0.0",
-    "sdk": ">=1.4.0 <2.0.0",
+    "sdk": ">=1.5.0 <2.0.0",
     "backend": ">=1.0.0 <2.0.0"
   },
   "layer": "layer",
@@ -69,6 +69,12 @@
         { "id": "analysis-areas.quarter", "sourceId": "analysis-areas.data", "group": "analysis", "priority": 31, "layer": { "type": "line", "minzoom": 11.5, "maxzoom": 24, "filter": ["==", ["get", "area_type"], "QUARTER"], "paint": { "line-color": "#b45309", "line-opacity": 0.72, "line-width": 1 } } },
         { "id": "analysis-areas.quarter-label", "sourceId": "analysis-areas.data", "group": "labels", "priority": 30, "layer": { "type": "symbol", "minzoom": 12.3, "maxzoom": 24, "filter": ["==", ["get", "area_type"], "QUARTER"], "layout": { "text-field": ["get", "name"], "text-font": ["noto_sans_regular"], "text-size": 11, "text-optional": true }, "paint": { "text-color": "#b45309", "text-halo-color": "#ffffff", "text-halo-width": 1.5 } } },
         { "id": "analysis-areas.assistant-highlight", "sourceId": "analysis-areas.data", "group": "overlay", "priority": 100, "layer": { "type": "line", "filter": ["in", ["get", "slug"], ["literal", []]], "paint": { "line-color": "#e11d48", "line-opacity": 0.95, "line-width": 4 } } }
+      ]
+    },
+    "sitemap": {
+      "staticRoutes": ["/gebiete"],
+      "dynamicRoutes": [
+        { "route": "/gebiete/:slug", "endpoint": "/analysis-areas/sitemap" }
       ]
     }
   }

--- a/frontend/module-host/contract.ts
+++ b/frontend/module-host/contract.ts
@@ -2,7 +2,7 @@ import type { FrontendModuleUiContribution } from './ui-contract.ts'
 import type { FrontendModuleMapContributions } from './map-contract.ts'
 
 export const FRONTEND_HOST_VERSION = '1.0.0'
-export const FRONTEND_MODULE_SDK_VERSION = '1.4.0'
+export const FRONTEND_MODULE_SDK_VERSION = '1.5.0'
 
 export interface FrontendModuleCompatibility {
   host: string
@@ -15,10 +15,21 @@ export interface FrontendModuleRouteContribution {
   source: string
 }
 
+export interface FrontendModuleSitemapDynamicRoute {
+  route: string
+  endpoint: string
+}
+
+export interface FrontendModuleSitemapContributions {
+  readonly staticRoutes: readonly string[]
+  readonly dynamicRoutes: readonly FrontendModuleSitemapDynamicRoute[]
+}
+
 export interface FrontendModulePublicContributions {
   readonly routes: readonly FrontendModuleRouteContribution[]
   readonly ui: readonly FrontendModuleUiContribution[]
   readonly map: FrontendModuleMapContributions
+  readonly sitemap: FrontendModuleSitemapContributions
 }
 
 export interface FrontendModuleRequirements {

--- a/frontend/module-host/discovery.ts
+++ b/frontend/module-host/discovery.ts
@@ -65,6 +65,11 @@ const route = z.strictObject({
   path: z.string().startsWith('/'),
   source: z.string().min(1)
 })
+const sitemapRoute = z.string().startsWith('/')
+const sitemapDynamicRoute = z.strictObject({
+  route: sitemapRoute,
+  endpoint: z.string().startsWith('/')
+})
 const mapSourceContribution = z.strictObject({
   id: z.string().min(3),
   source: z.record(z.string(), z.json())
@@ -97,7 +102,11 @@ const definitionSchema = z.strictObject({
     map: z.strictObject({
       sources: z.array(mapSourceContribution).default([]),
       layers: z.array(mapLayerContribution).default([])
-    }).default({ sources: [], layers: [] })
+    }).default({ sources: [], layers: [] }),
+    sitemap: z.strictObject({
+      staticRoutes: z.array(sitemapRoute).default([]),
+      dynamicRoutes: z.array(sitemapDynamicRoute).default([])
+    }).default({ staticRoutes: [], dynamicRoutes: [] })
   })
 })
 
@@ -204,6 +213,7 @@ export function discoverFrontendModules(
         throw new FrontendModuleError(`Layer for frontend module "${definition.id}" does not exist at ${layerPath}.`)
       }
       validateLayerBoundaries(definition, moduleRoot, layerPath)
+      validateSitemapContributions(definition, source)
       for (const contribution of definition.publicContributions.routes) {
         const routeSource = safeChildPath(moduleRoot, contribution.source, `route source of frontend module "${definition.id}"`)
         if (!existsSync(routeSource) || !statSync(routeSource).isFile()) {
@@ -234,6 +244,27 @@ export function discoverFrontendModules(
     throw new FrontendModuleError(`Excluded built-in frontend module "${unknownExclusion}" was not found; correct OCP_EXCLUDED_BUILTIN_MODULES.`)
   }
   return discovered.sort((left, right) => left.id.localeCompare(right.id, 'en'))
+}
+
+function validateSitemapContributions(
+  definition: FrontendModuleDefinition,
+  source: string
+) {
+  const declaredRoutes = new Set(definition.publicContributions.routes.map(item => normalizeRoute(item.path)))
+  for (const route of definition.publicContributions.sitemap.staticRoutes) {
+    if (route.includes(':') || !declaredRoutes.has(normalizeRoute(route))) {
+      throw new FrontendModuleError(`Static sitemap route "${route}" in ${source} must be a declared non-dynamic module route.`)
+    }
+  }
+  for (const contribution of definition.publicContributions.sitemap.dynamicRoutes) {
+    if (!/^\/[^?#]*:slug[^?#]*$/.test(contribution.route)
+      || !declaredRoutes.has(normalizeRoute(contribution.route))) {
+      throw new FrontendModuleError(`Dynamic sitemap route "${contribution.route}" in ${source} must be a declared module route with one :slug parameter.`)
+    }
+    if (!/^\/[A-Za-z0-9/_-]+$/.test(contribution.endpoint)) {
+      throw new FrontendModuleError(`Dynamic sitemap endpoint "${contribution.endpoint}" in ${source} must be a safe relative API path.`)
+    }
+  }
 }
 
 export function parseExcludedBuiltinModules(value: string | readonly string[]): string[] {

--- a/frontend/module-host/public.ts
+++ b/frontend/module-host/public.ts
@@ -2,7 +2,9 @@ export {
   FRONTEND_HOST_VERSION,
   FRONTEND_MODULE_SDK_VERSION,
   type FrontendModuleCompatibility,
-  type FrontendModuleDefinition
+  type FrontendModuleDefinition,
+  type FrontendModuleSitemapContributions,
+  type FrontendModuleSitemapDynamicRoute
 } from './contract.ts'
 export {
   DEFAULT_UI_CONTRIBUTION_PRIORITY,
@@ -94,4 +96,4 @@ export {
   toMetaDescription
 } from '../app/utils/seo'
 export { getIndustryColor, getIndustryLabel } from '../app/utils/industries'
-export { areaPoiMapLink, getPoiCategoryLabel } from '../app/utils/poiCategories'
+export { getPoiCategoryLabel } from '../app/utils/poiCategories'

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -101,6 +101,10 @@ export default defineNuxtConfig({
     apiInternalBaseUrl: process.env.NUXT_API_INTERNAL_BASE_URL || '',
     public: {
       frontendModules: frontendModules.map(module => module.id),
+      frontendSitemapContributions: frontendModules.map(module => ({
+        moduleId: module.id,
+        ...module.publicContributions.sitemap
+      })),
       frontendUiContributions: [...frontendContributionRegistry.all()],
       frontendMapContributions: mapExtensionDefinitions,
       siteName: 'OK Lab Flensburg',

--- a/frontend/server/routes/sitemap.xml.ts
+++ b/frontend/server/routes/sitemap.xml.ts
@@ -1,21 +1,38 @@
 import type { PolygonSitemapEntry } from '~/types/geo'
-import type { AnalysisAreaSitemapEntry } from '~/types/analysisArea'
 import { buildAbsoluteUrl } from '~/utils/seo'
 import { documentationPaths } from '~/config/documentation'
-import { buildSitemapXml, type SitemapUrl } from '../utils/sitemap'
+import { buildSitemapXml, moduleSitemapPaths, type SitemapUrl } from '../utils/sitemap'
 
-const STATIC_PATHS = ['/', '/karte', '/gebiete', '/vergleich', '/ueber-das-projekt', '/open-data', '/kontakt', ...documentationPaths]
+const STATIC_PATHS = ['/', '/karte', '/vergleich', '/ueber-das-projekt', '/open-data', '/kontakt', ...documentationPaths]
+
+interface ModuleSitemapEntry {
+  slug: string
+  updated_at?: string
+}
+
+interface ModuleSitemapContribution {
+  moduleId: string
+  staticRoutes: string[]
+  dynamicRoutes: Array<{ route: string, endpoint: string }>
+}
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
   const apiBaseUrl = config.apiInternalBaseUrl || config.public.apiBaseUrl
-  const [entries, areas] = await Promise.all([
+  const moduleContributions = (
+    config.public.frontendSitemapContributions ?? []
+  ) as ModuleSitemapContribution[]
+  const [entries, dynamicEntries] = await Promise.all([
     $fetch<PolygonSitemapEntry[]>(`${apiBaseUrl}/polygons/sitemap`, {
       headers: { 'X-Request-ID': event.context.requestId }
     }),
-    $fetch<AnalysisAreaSitemapEntry[]>(`${apiBaseUrl}/analysis-areas/sitemap`, {
-      headers: { 'X-Request-ID': event.context.requestId }
-    })
+    Promise.all(moduleContributions.flatMap(contribution => contribution.dynamicRoutes.map(async route => ({
+      moduleId: contribution.moduleId,
+      route: route.route,
+      entries: await $fetch<ModuleSitemapEntry[]>(`${apiBaseUrl}${route.endpoint}`, {
+        headers: { 'X-Request-ID': event.context.requestId }
+      })
+    }))))
   ])
   const urls: SitemapUrl[] = [
     ...STATIC_PATHS.map(path => ({ loc: buildAbsoluteUrl(config.public.siteUrl, path) })),
@@ -23,9 +40,17 @@ export default defineEventHandler(async (event) => {
       loc: buildAbsoluteUrl(config.public.siteUrl, `/flaechen/${entry.slug}`),
       lastmod: entry.updated_at
     })),
-    ...areas.map(area => ({
-      loc: buildAbsoluteUrl(config.public.siteUrl, `/gebiete/${area.slug}`),
-      lastmod: area.updated_at
+    ...moduleSitemapPaths(moduleContributions.map(contribution => ({
+      staticRoutes: contribution.staticRoutes,
+      dynamicRoutes: contribution.dynamicRoutes.map(route => ({
+        route: route.route,
+        entries: dynamicEntries.find(provider => (
+          provider.moduleId === contribution.moduleId && provider.route === route.route
+        ))?.entries ?? []
+      }))
+    }))).map(entry => ({
+      loc: buildAbsoluteUrl(config.public.siteUrl, entry.path),
+      lastmod: entry.lastmod
     }))
   ]
 

--- a/frontend/server/utils/sitemap.ts
+++ b/frontend/server/utils/sitemap.ts
@@ -1,4 +1,23 @@
 export type SitemapUrl = { loc: string; lastmod?: string }
+export type SitemapPath = { path: string; lastmod?: string }
+
+export interface ResolvedModuleSitemap {
+  staticRoutes: string[]
+  dynamicRoutes: Array<{
+    route: string
+    entries: Array<{ slug: string, updated_at?: string }>
+  }>
+}
+
+export function moduleSitemapPaths(modules: ResolvedModuleSitemap[]): SitemapPath[] {
+  return modules.flatMap(module => [
+    ...module.staticRoutes.map(path => ({ path })),
+    ...module.dynamicRoutes.flatMap(provider => provider.entries.map(entry => ({
+      path: provider.route.replace(':slug', encodeURIComponent(entry.slug)),
+      lastmod: entry.updated_at
+    })))
+  ])
+}
 
 export function buildSitemapXml(urls: SitemapUrl[]) {
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.map(url => `  <url>\n    <loc>${escapeXml(url.loc)}</loc>${url.lastmod ? `\n    <lastmod>${escapeXml(url.lastmod)}</lastmod>` : ''}\n  </url>`).join('\n')}\n</urlset>\n`

--- a/frontend/tests/analysis-areas-module.test.ts
+++ b/frontend/tests/analysis-areas-module.test.ts
@@ -28,6 +28,13 @@ describe('Analysis Areas frontend module', () => {
       '/gebiete',
       '/gebiete/:slug'
     ])
+    expect(modules[0]?.publicContributions.sitemap).toEqual({
+      staticRoutes: ['/gebiete'],
+      dynamicRoutes: [{
+        route: '/gebiete/:slug',
+        endpoint: '/analysis-areas/sitemap'
+      }]
+    })
     expect(createFrontendContributionRegistry(modules, []).all()).toContainEqual(
       expect.objectContaining({
         id: 'analysis-areas.primary-navigation',

--- a/frontend/tests/area-poi-navigation.test.ts
+++ b/frontend/tests/area-poi-navigation.test.ts
@@ -1,8 +1,11 @@
 import { createPinia, setActivePinia } from 'pinia'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useOsmViewportStore } from '../app/stores/osmViewport'
 import { fallbackIndustryColor, getIndustryColor } from '../app/utils/industries'
-import { areaPoiMapLink, getPoiCategoryLabel, isPoiCategoryToken, withoutPoiQuery } from '../app/utils/poiCategories'
+import { getPoiCategoryLabel, isPoiCategoryToken, withoutPoiQuery } from '../app/utils/poiCategories'
+import { areaPoiMapLink } from '../frontend-modules/analysis-areas/layer/app/utils/areaPoiMapLink'
 
 describe('Gebietsfarben und Orte', () => {
   it('uses deterministic central industry colors and a neutral fallback', () => {
@@ -25,6 +28,8 @@ describe('Gebietsfarben und Orte', () => {
     })
     expect(isPoiCategoryToken('restaurant')).toBe(true)
     expect(isPoiCategoryToken('drop table')).toBe(false)
+    const publicSdk = readFileSync(fileURLToPath(new URL('../module-host/public.ts', import.meta.url)), 'utf8')
+    expect(publicSdk).not.toContain('areaPoiMapLink')
   })
 
   it('removes only the place filter from a map query', () => {

--- a/frontend/tests/frontend-module-host.test.ts
+++ b/frontend/tests/frontend-module-host.test.ts
@@ -182,14 +182,14 @@ describe('frontend build-time module host', () => {
   it('accepts compatible SDK versions and rejects incompatible versions', () => {
     const paths = fixture()
     addModule(paths.modulesDirectory, 'compatible')
-    expect(FRONTEND_MODULE_SDK_VERSION).toBe('1.4.0')
+    expect(FRONTEND_MODULE_SDK_VERSION).toBe('1.5.0')
     expect(resolveFrontendModules({ ...paths, enabledModules: 'compatible' })).toHaveLength(1)
 
     addModule(paths.modulesDirectory, 'future', {
       compatibility: { host: '>=1.0.0 <2.0.0', sdk: '>=2.0.0 <3.0.0' }
     })
     expect(() => resolveFrontendModules({ ...paths, enabledModules: 'future' }))
-      .toThrowError(/requires frontend module SDK >=2.0.0 <3.0.0, but found 1.4.0/)
+      .toThrowError(/requires frontend module SDK >=2.0.0 <3.0.0, but found 1.5.0/)
   })
 
   it('requires one shared module ID and validates an explicit backend inventory', () => {

--- a/frontend/tests/sitemap.test.ts
+++ b/frontend/tests/sitemap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildSitemapXml } from '../server/utils/sitemap'
+import { buildSitemapXml, moduleSitemapPaths } from '../server/utils/sitemap'
 
 describe('XML sitemap', () => {
   it('renders public pages and polygon lastmod as valid escaped XML', () => {
@@ -27,11 +27,29 @@ describe('XML sitemap', () => {
     }
   })
 
+  it('includes module routes only for supplied enabled contributions', () => {
+    expect(moduleSitemapPaths([])).toEqual([])
+    expect(moduleSitemapPaths([{
+      staticRoutes: ['/gebiete'],
+      dynamicRoutes: [{
+        route: '/gebiete/:slug',
+        entries: [{ slug: 'altstadt-15630273', updated_at: '2026-09-01T10:00:00Z' }]
+      }]
+    }])).toEqual([
+      { path: '/gebiete' },
+      {
+        path: '/gebiete/altstadt-15630273',
+        lastmod: '2026-09-01T10:00:00Z'
+      }
+    ])
+  })
+
   it('keeps the public Open Data collection address stable', async () => {
     const source = await import('../server/routes/sitemap.xml.ts?raw').then(module => module.default)
     expect(source).toContain("'/open-data'")
-    expect(source).toContain("'/gebiete'")
-    expect(source).toContain('/analysis-areas/sitemap')
-    expect(source).toContain('`/gebiete/${area.slug}`')
+    expect(source).toContain('frontendSitemapContributions')
+    expect(source).toContain('moduleSitemapPaths')
+    expect(source).not.toContain("'/gebiete'")
+    expect(source).not.toContain('/analysis-areas/sitemap')
   })
 })


### PR DESCRIPTION
## Ausgangslage

Der finale Analysis-Areas-Cutover in #196 war durch Host-Fachkopplungen in POI-Navigation, Statistik-Hierarchie und -Persistenz sowie durch eine hart codierte Sitemap blockiert.

## Lösung

- führt den neutralen StatisticsSelection-Vertrag im Backend-SDK 1.14 ein
- lässt das Fachmodul Zielgebiet, Kommune und Quartier-Vererbung auflösen
- entkoppelt Statistik-Mappings und -Beobachtungen per eigener FK-Identität von analysis_areas
- migriert vorhandene Statistikdaten mit Upgrade-/Downgrade-Pfad
- führt generische, manifestbasierte Sitemap-Beiträge im Frontend-SDK 1.5 ein
- entfernt areaPoiMapLink aus dem öffentlichen Host-SDK und lokalisiert den Built-in-Helfer
- dokumentiert die neuen Ownership-Grenzen

## Tests

- Backend: Ruff, vollständiges Pytest (1014 passed, 7 skipped vor dem zusätzlichen Migrationsdatentest), App-Import und Module-Contract-Gate
- Migration: echter PostGIS-Datenerhalt sowie alembic upgrade head / downgrade -1 / upgrade head
- Frontend: 526 Vitest-Tests, Typecheck, Builds mit und ohne Analysis-Areas-Modul, Language-Audit und SEO-Audit
- External Contract: vollständiger ocp-module-analysis-areas Host-Contract gegen diesen Commit inklusive echter PostGIS-Kette, Typecheck und Production-Build

## Migration / Rollout

Die neue Host-Migration 20260901_0035 muss vor dem finalen Built-in-Cutover laufen. Sie ersetzt die Analysis-Areas-FKs durch external_area_mappings und ist rückrollbar. Das externe Modul PR ist auf den exakten Commit dieses PRs gepinnt.

## Abhängigkeiten

Voraussetzung für oklabflensburg/ocp-module-analysis-areas#9. Unterstützt die Fortsetzung von #196; dieser PR merged oder verändert #196 nicht.