### PR TITLE
refactor(map): standardize POI query contract on poi

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           uv run python -m app.cli.module_migrations upgrade
           uv run python tests/e2e_seed.py
+          uv run python tests/fixtures/poi_query_e2e_seed.py
       - name: Install Chromium
         working-directory: frontend
         run: pnpm exec playwright install --with-deps chromium

--- a/backend/app/schemas/osm.py
+++ b/backend/app/schemas/osm.py
@@ -70,6 +70,12 @@ class OsmViewportQuery(BaseModel):
     north: float = Field(ge=-90, le=90)
     zoom: float = Field(ge=0, le=24)
     osm_categories: str | None = None
+    poi: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=80,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,79}$",
+    )
     buildings: bool = False
     limit: int = Field(default=2_000, ge=1, le=2_500)
 

--- a/backend/app/services/osm_features.py
+++ b/backend/app/services/osm_features.py
@@ -28,7 +28,11 @@ from app.services.osm_canonical import (
 from app.services.osm_exclusions import should_exclude_osm_feature
 from app.services.osm_lookup import normalize_osm_tags
 from app.services.osm_occupancy import detect_osm_occupancy_status
-from app.services.poi_categories import OSM_FEATURE_CATEGORIES, OSM_FEATURE_CATEGORY_SQL
+from app.services.poi_categories import (
+    OSM_FEATURE_CATEGORIES,
+    OSM_FEATURE_CATEGORY_SQL,
+    POI_TYPE_SQL,
+)
 
 OSM_VIEWPORT_CACHE_RESOURCE = "osm:viewport:v5"
 
@@ -43,6 +47,7 @@ WITH bounds AS (
   SELECT osm.osm_type, osm.osm_id, osm.tags, osm.geometry, osm.imported_at,
          ST_Dimension(osm.geometry) AS dimension,
          {OSM_FEATURE_CATEGORY_SQL} AS category,
+         {POI_TYPE_SQL} AS poi,
          {CANONICAL_CATEGORY_SQL} AS canonical_category,
          {CANONICAL_FLOOR_SQL} AS canonical_floor,
          {CANONICAL_STATUS_SQL} AS canonical_status,
@@ -79,6 +84,7 @@ WITH bounds AS (
     END AS output_geometry
   FROM categorized
   WHERE category IS NOT NULL
+    AND (CAST(:poi AS text) IS NULL OR poi = CAST(:poi AS text))
     AND (NOT :deduplicate_linked OR NOT is_linked)
     AND (cardinality(CAST(:osm_categories AS text[])) = 0 OR category = ANY(CAST(:osm_categories AS text[])))
     AND (canonical_category IS NULL OR (
@@ -117,10 +123,7 @@ SELECT selected.osm_type, selected.osm_id, selected.tags, selected.category,
        facets.canonical_facets,
        COALESCE(linked.polygons, '[]'::json) AS linked_polygons,
        ST_AsGeoJSON(output_geometry, 6)::json AS geometry,
-       COALESCE(tags->>'shop', tags->>'amenity', tags->>'office', tags->>'craft',
-                tags->>'tourism', tags->>'leisure', tags->>'healthcare',
-                tags->>'public_transport', tags->>'building', tags->>'landuse',
-                tags->>'natural') AS primary_type
+       selected.poi AS primary_type
 FROM facets
 LEFT JOIN limited selected ON true
 LEFT JOIN LATERAL (
@@ -168,6 +171,7 @@ def osm_viewport_cache_params(
         "y_range": [bucket["y_min"], bucket["y_max"]],
         "zoom": round(query.zoom, 1),
         "categories": sorted(categories),
+        "poi": query.poi,
         "buildings": query.buildings,
         "limit": query.limit,
         "filters": filters.cache_params(),
@@ -257,6 +261,7 @@ async def viewport_features_json(
                     "east": bucket["east"],
                     "north": bucket["north"],
                     "zoom": query.zoom,
+                    "poi": query.poi,
                     "osm_categories": list(categories),
                     "gis_categories": list(filters.categories),
                     "floors": list(filters.floors),
@@ -284,6 +289,7 @@ async def viewport_features_json(
         rows = [
             row for row in rows
             if not should_exclude_osm_feature(row["tags"] or {})
+            and (query.poi is None or row.get("primary_type") == query.poi)
             and (not deduplicate_linked or not row.get("linked_polygons"))
             and _matches_business_filters(
                 row["tags"] or {}, filters,

--- a/backend/app/services/poi_categories.py
+++ b/backend/app/services/poi_categories.py
@@ -63,3 +63,13 @@ END
 """
 
 OSM_FEATURE_CATEGORIES = frozenset(POI_CATEGORY_LABELS)
+
+# Semantic POI type exposed to map consumers. The precedence mirrors the
+# existing ``primary_type`` response property while keeping OSM tag names an
+# implementation detail of this provider.
+POI_TYPE_SQL = """
+COALESCE(tags->>'shop', tags->>'amenity', tags->>'office', tags->>'craft',
+         tags->>'tourism', tags->>'leisure', tags->>'healthcare',
+         tags->>'public_transport', tags->>'building', tags->>'landuse',
+         tags->>'natural')
+"""

--- a/backend/tests/e2e_seed.py
+++ b/backend/tests/e2e_seed.py
@@ -7,7 +7,6 @@ from geoalchemy2.elements import WKTElement
 
 from app.auth.passwords import hash_password
 from app.db.session import AsyncSessionLocal
-from app.models.osm_feature import OsmFeature
 from app.models.user import User
 from app.models.user_polygon import UserPolygon
 
@@ -58,18 +57,6 @@ async def seed() -> None:
                         srid=4326,
                     ),
                     properties={"source": "e2e"},
-                ),
-                OsmFeature(
-                    osm_type="node",
-                    osm_id=216001,
-                    geometry=WKTElement("POINT(9.435 54.783)", srid=4326),
-                    tags={"name": "E2E Café", "amenity": "cafe"},
-                ),
-                OsmFeature(
-                    osm_type="node",
-                    osm_id=216002,
-                    geometry=WKTElement("POINT(9.436 54.7835)", srid=4326),
-                    tags={"name": "E2E Restaurant", "amenity": "restaurant"},
                 ),
             ]
         )

--- a/backend/tests/e2e_seed.py
+++ b/backend/tests/e2e_seed.py
@@ -7,6 +7,7 @@ from geoalchemy2.elements import WKTElement
 
 from app.auth.passwords import hash_password
 from app.db.session import AsyncSessionLocal
+from app.models.osm_feature import OsmFeature
 from app.models.user import User
 from app.models.user_polygon import UserPolygon
 
@@ -57,6 +58,18 @@ async def seed() -> None:
                         srid=4326,
                     ),
                     properties={"source": "e2e"},
+                ),
+                OsmFeature(
+                    osm_type="node",
+                    osm_id=216001,
+                    geometry=WKTElement("POINT(9.435 54.783)", srid=4326),
+                    tags={"name": "E2E Café", "amenity": "cafe"},
+                ),
+                OsmFeature(
+                    osm_type="node",
+                    osm_id=216002,
+                    geometry=WKTElement("POINT(9.436 54.7835)", srid=4326),
+                    tags={"name": "E2E Restaurant", "amenity": "restaurant"},
                 ),
             ]
         )

--- a/backend/tests/fixtures/poi_query_e2e_seed.py
+++ b/backend/tests/fixtures/poi_query_e2e_seed.py
@@ -1,0 +1,33 @@
+"""Deterministische OSM-Daten für den POI-Query-E2E-Test."""
+
+import asyncio
+
+from geoalchemy2.elements import WKTElement
+
+from app.db.session import AsyncSessionLocal
+from app.models.osm_feature import OsmFeature
+
+
+async def seed() -> None:
+    async with AsyncSessionLocal() as session:
+        session.add_all(
+            [
+                OsmFeature(
+                    osm_type="node",
+                    osm_id=216001,
+                    geometry=WKTElement("POINT(9.435 54.783)", srid=4326),
+                    tags={"name": "E2E Café", "amenity": "cafe"},
+                ),
+                OsmFeature(
+                    osm_type="node",
+                    osm_id=216002,
+                    geometry=WKTElement("POINT(9.436 54.7835)", srid=4326),
+                    tags={"name": "E2E Restaurant", "amenity": "restaurant"},
+                ),
+            ]
+        )
+        await session.commit()
+
+
+if __name__ == "__main__":
+    asyncio.run(seed())

--- a/backend/tests/test_osm_viewport.py
+++ b/backend/tests/test_osm_viewport.py
@@ -57,6 +57,14 @@ def test_category_filter_is_allowlisted() -> None:
         selected_categories("retail,drop table")
 
 
+def test_poi_filter_accepts_only_a_single_safe_semantic_category() -> None:
+    assert query(poi="cafe").poi == "cafe"
+    with pytest.raises(ValidationError):
+        query(poi="cafe,restaurant")
+    with pytest.raises(ValidationError):
+        query(poi="drop table")
+
+
 def test_central_exclusion_policy_only_rejects_peninsulas() -> None:
     assert should_exclude_osm_feature({"natural": "peninsula"}) is True
     assert should_exclude_osm_feature({"natural": "wood"}) is False
@@ -145,6 +153,7 @@ def test_viewport_sql_preserves_spatial_index_and_zoom_policy() -> None:
     assert "group_rank <= :polygon_limit" in sql
     assert "group_rank <= :building_limit" in sql
     assert "canonical_category" in sql
+    assert "CAST(:poi AS text) IS NULL OR poi = CAST(:poi AS text)" in sql
     assert "canonical_floor" in sql
     assert "canonical_status" in sql
     assert "polygon_osm_sources" in sql
@@ -171,6 +180,23 @@ async def test_business_filters_apply_to_osm_while_context_pois_remain_visible()
     assert result.meta.business_count == 1
     assert result.meta.context_count == 1
     assert result.meta.canonical_summary == {"fashion": 1}
+
+
+@pytest.mark.asyncio
+async def test_semantic_poi_filter_is_applied_before_viewport_results_are_limited() -> None:
+    imported_at = datetime(2026, 8, 13, tzinfo=UTC)
+    rows = [
+        {"osm_type": "node", "osm_id": 30, "tags": {"amenity": "restaurant"}, "category": "gastronomy", "dimension": 0, "imported_at": imported_at, "geometry": {"type": "Point", "coordinates": [9.43, 54.78]}, "primary_type": "restaurant"},
+        {"osm_type": "node", "osm_id": 31, "tags": {"amenity": "cafe"}, "category": "gastronomy", "dimension": 0, "imported_at": imported_at, "geometry": {"type": "Point", "coordinates": [9.431, 54.781]}, "primary_type": "cafe"},
+    ]
+    session = AsyncMock()
+    session.execute.return_value = MappingRows(rows)
+
+    result = await viewport_features(session, query(limit=10, poi="cafe"))
+
+    assert [feature.id for feature in result.features] == ["node/31"]
+    params = session.execute.await_args.args[1]
+    assert params["poi"] == "cafe"
 
 
 @pytest.mark.asyncio

--- a/docs/osm-data.md
+++ b/docs/osm-data.md
@@ -26,6 +26,32 @@ Die fachlichen Filter `area_sizes`, `floors`, `categories`, `occupancy_statuses`
 
 Für jede fachliche Dimension gilt derselbe öffentliche Vertrag: Ein fehlender Query-Parameter bedeutet „alle Werte“, der alleinstehende Sentinel `NONE` bedeutet „keine Werte“. `NONE` darf nicht mit realen Werten kombiniert werden. Die Oberfläche startet deshalb mit sichtbar ausgewählten Optionen, lässt die vollständige Auswahl zur kompakten Standard-URL weg und schreibt eine vollständig abgewählte Gruppe ausdrücklich als `NONE`. Fehlende Angaben bleiben in der ungefilterten Gesamtsicht enthalten; bei einer Teilmenge werden sie nicht geschätzt und erfüllen den Filter nicht.
 
+### Öffentlicher POI-Query-Vertrag
+
+Der einzige öffentliche URL-Parameter für eine semantische POI-Kategorie ist
+`poi=<category>`, zum Beispiel `/karte?poi=cafe` oder
+`/karte?poi=restaurant`. Der Wert wird beim initialen SSR-/Hydration-Lauf und
+bei Vor-/Zurück-Navigation in den vorhandenen Viewport-Store übernommen. Der
+Store gibt ihn an den Karten-Viewport weiter; dort wird er vor der
+Ergebnislimitierung auf den vorhandenen semantischen POI-Typ angewandt. Die
+lang lebende MapLibre-Quelle erhält dadurch nur die passenden POIs.
+
+Der frühere öffentliche Name `osm_kategorie` ist entfernt und wird weder
+erzeugt noch ausgewertet. `poi` beschreibt die fachliche Nutzerabsicht und
+nicht die Datenquelle. Interne Bezeichner wie `osm_categories`, OSM-Tagfelder
+und `osm-pois` bleiben reine Provider- beziehungsweise Layerdetails.
+
+Der Repository-Audit für #216 klassifiziert die Fundstellen wie folgt:
+
+| Fundgruppe | Klassifikation | Begründung |
+| --- | --- | --- |
+| `useGisFilterHistory`, `poiCategories`, `legacy-map` | `PUBLIC_QUERY_CONTRACT` | Lesen, Schreiben, Validieren und Legacy-Routing des einzigen URL-Schlüssels `poi` |
+| `osmViewport`, Backend-Viewport und `primary_type` | `INTERNAL_OSM_DETAIL` | Übersetzung des semantischen Werts auf den vorhandenen Datenprovider |
+| MapLibre-IDs wie `osm-pois` und `osm-poi-circle` | `INTERNAL_OSM_DETAIL` | Stabile Source-/Layer-Namen, keine URL-Schlüssel |
+| Unit-, Contract- und Playwright-Dateien | `TEST_FIXTURE` | Sichern Deep Link, Reload, Änderung, Entfernen und gerenderten Filter |
+| diese Seite und die Benutzerdokumentation | `DOCUMENTATION` | Beschreiben den kanonischen Vertrag und die entfernte Altbezeichnung |
+| frühere öffentliche Auswertung von `osm_kategorie` | `OBSOLETE` | Auf der Epic-91-Basis bereits ohne Runtime-Fund; negativer Guard verhindert die Rückkehr |
+
 OSM-Tags werden in `app/services/osm_canonical.py` serverseitig auf die bestehenden Stadtplaner-Kategorien normalisiert. Das Mapping basiert auf dem lokal importierten Flensburger Tagbestand. Beispiele:
 
 | Stadtplaner-Kategorie | OSM-Tags, auszugsweise |

--- a/frontend/app/components/filters/OsmFeatureFilter.vue
+++ b/frontend/app/components/filters/OsmFeatureFilter.vue
@@ -1,6 +1,10 @@
 <template>
   <section aria-labelledby="osm-filter-title">
     <h3 id="osm-filter-title" class="text-xs font-bold uppercase tracking-wide text-slate-500">OpenStreetMap</h3>
+    <div v-if="osm.poi" class="mt-3 flex items-center justify-between gap-3 rounded-xl border border-[#8baabd] bg-[#edf5f8] p-3">
+      <p class="min-w-0 text-xs font-semibold text-[#154d73]">POI-Kategorie: {{ getPoiCategoryLabel(osm.poi) }}</p>
+      <button class="min-h-8 shrink-0 cursor-pointer rounded-lg px-2 text-xs font-bold text-[#154d73] hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#154d73]" type="button" @click="osm.clearPoi()">Entfernen</button>
+    </div>
     <div class="mt-3 grid gap-1 text-sm text-slate-700" :class="{ 'opacity-60': !osmEnabled }">
       <GisFilterToggleRow v-model="osm.showPois" label="Orte und Einrichtungen anzeigen" aria-label="Orte und Einrichtungen aus OpenStreetMap anzeigen" :disabled="!osmEnabled" />
       <GisFilterToggleRow v-model="osm.showAreas" label="Flächenobjekte anzeigen" aria-label="OpenStreetMap-Flächenobjekte anzeigen" :disabled="!osmEnabled" />
@@ -26,6 +30,7 @@
 
 <script setup lang="ts">
 import { osmPoiCategories } from '~/utils/osmCategories'
+import { getPoiCategoryLabel } from '~/utils/poiCategories'
 
 const osm = useOsmViewportStore()
 const filter = useFilterStore()

--- a/frontend/app/components/layout/AppShell.vue
+++ b/frontend/app/components/layout/AppShell.vue
@@ -75,7 +75,7 @@ useGisFilterHistory()
 const isDesktop = ref(false)
 const isCompact = ref(false)
 const isMobile = computed(() => !isDesktop.value && !isCompact.value)
-const activeFilterCount = computed(() => filterStore.activeFilterCount)
+const activeFilterCount = computed(() => filterStore.activeFilterCount + (osmStore.poi ? 1 : 0))
 const resultCount = computed(() => usePolygonStore().polygons.length + (osmStore.data?.meta.business_count || 0))
 const resultLabel = computed(() => resultCount.value ? `${resultCount.value} Ergebnisse anzeigen` : 'Keine Ergebnisse')
 const activePanelTitle = computed(() => {

--- a/frontend/app/components/layout/LeftSidebar.vue
+++ b/frontend/app/components/layout/LeftSidebar.vue
@@ -14,12 +14,12 @@
           <ListFilter class="size-4 text-[#154d73]" aria-hidden="true" />
           <h2 class="text-sm font-bold text-slate-800">Filter</h2>
           <span v-if="activeFilterCount" class="rounded-full bg-[#e2edf4] px-2 py-0.5 text-[11px] font-black text-[#154d73]">{{ activeFilterCount }} aktiv</span>
-          <button v-if="filter.canReset" class="ml-auto min-h-8 cursor-pointer rounded-md px-2 text-xs font-bold text-[#154d73] hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#154d73]" type="button" @click="resetAll">Zurücksetzen</button>
+          <button v-if="canReset" class="ml-auto min-h-8 cursor-pointer rounded-md px-2 text-xs font-bold text-[#154d73] hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#154d73]" type="button" @click="resetAll">Zurücksetzen</button>
         </div>
         <template v-if="compact">
           <div class="flex min-w-0 items-start gap-2">
             <p class="min-w-0 flex-1 text-xs font-semibold leading-5 text-slate-700">{{ compactFilterStatus }}</p>
-            <button v-if="filter.canReset" class="min-h-8 shrink-0 cursor-pointer rounded-md px-2 text-xs font-bold text-[#154d73] hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#154d73]" type="button" @click="resetAll">Zurücksetzen</button>
+            <button v-if="canReset" class="min-h-8 shrink-0 cursor-pointer rounded-md px-2 text-xs font-bold text-[#154d73] hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#154d73]" type="button" @click="resetAll">Zurücksetzen</button>
           </div>
           <p class="mt-0.5 text-xs font-bold text-slate-600">{{ compactResultSummary }}</p>
           <details class="mt-1 text-[11px] leading-4 text-slate-500">
@@ -78,6 +78,7 @@
 <script setup lang="ts">
 import { Info, ListFilter } from '@lucide/vue'
 import { mapThemes } from '~/utils/mapThemes'
+import { getPoiCategoryLabel } from '~/utils/poiCategories'
 
 withDefaults(defineProps<{ embedded?: boolean, compact?: boolean }>(), { embedded: false, compact: false })
 
@@ -85,9 +86,11 @@ const mapStore = useMapStore()
 const filter = useFilterStore()
 const polygonStore = usePolygonStore()
 const osmStore = useOsmViewportStore()
-const activeFilterCount = computed(() => filter.activeFilterCount)
+const activeFilterCount = computed(() => filter.activeFilterCount + (osmStore.poi ? 1 : 0))
+const canReset = computed(() => filter.canReset || Boolean(osmStore.poi))
 const filterStatus = computed(() => {
   const descriptions = [...filter.activeFilterDescriptions]
+  if (osmStore.poi) descriptions.push(`POI: ${getPoiCategoryLabel(osmStore.poi)}`)
   return descriptions.length
     ? `${descriptions.length} Filter aktiv · ${descriptions.join(' · ')}`
     : 'Alle passenden Objekte werden angezeigt.'
@@ -99,6 +102,7 @@ const resultSummary = computed(() => {
 })
 const compactFilterStatus = computed(() => {
   const descriptions = [...filter.activeFilterDescriptions]
+  if (osmStore.poi) descriptions.push(`POI: ${getPoiCategoryLabel(osmStore.poi)}`)
   return descriptions.length ? descriptions.join(' · ') : 'Alle passenden Objekte'
 })
 const compactResultSummary = computed(() => {

--- a/frontend/app/composables/useGisFilterHistory.ts
+++ b/frontend/app/composables/useGisFilterHistory.ts
@@ -4,13 +4,20 @@ import {
   gisFilterStateKey,
   gisFilterUrlQuery
 } from '~/utils/gisFilters'
+import { poiFromQuery, withPoiQuery } from '~/utils/poiCategories'
 
 /** Keeps the GIS filter state in the URL only while the map application is mounted. */
 export function useGisFilterHistory() {
   const filters = useFilterStore()
+  const osm = useOsmViewportStore()
+  const route = useRoute()
   let applyingLocation = false
   let ready = false
   let historyTimer: ReturnType<typeof setTimeout> | undefined
+
+  // Apply the route during setup so SSR and hydration start from the same
+  // canonical map-filter state.
+  osm.setPoi(poiFromQuery(route.query.poi))
 
   function locationQuery(): Record<string, string | string[]> {
     const params = new URLSearchParams(window.location.search)
@@ -22,20 +29,23 @@ export function useGisFilterHistory() {
 
   async function applyLocation() {
     const next = gisFiltersFromQuery(locationQuery())
+    const nextPoi = poiFromQuery(new URLSearchParams(window.location.search).get('poi'))
     const nextKey = gisFilterStateKey(next)
-    if (nextKey !== filters.stateKey) {
+    if (nextKey !== filters.stateKey || nextPoi !== osm.poi) {
       applyingLocation = true
       filters.applyFilters(next)
+      osm.setPoi(nextPoi)
       await nextTick()
       applyingLocation = false
     }
-    canonicalizeLocation(next)
+    canonicalizeLocation(next, nextPoi)
     ready = true
   }
 
-  function canonicalizeLocation(next: ReturnType<typeof gisFiltersFromQuery>) {
-    const url = new URL(window.location.href)
-    const previous = url.search
+  function canonicalizeLocation(next: ReturnType<typeof gisFiltersFromQuery>, poi: string | null) {
+    const current = new URL(window.location.href)
+    const previous = current.search
+    const url = withPoiQuery(current, poi)
     for (const key of GIS_FILTER_QUERY_KEYS) url.searchParams.delete(key)
     for (const [key, value] of gisFilterUrlQuery(next)) url.searchParams.set(key, value)
     if (url.search !== previous) window.history.replaceState({ ...window.history.state }, '', url)
@@ -46,17 +56,21 @@ export function useGisFilterHistory() {
     window.addEventListener('popstate', applyLocation)
   })
 
-  watch(() => filters.stateKey, () => {
+  watch(() => [filters.stateKey, osm.poi], () => {
     if (!ready || applyingLocation) return
     clearTimeout(historyTimer)
     historyTimer = setTimeout(() => {
-      const url = new URL(window.location.href)
+      const url = withPoiQuery(new URL(window.location.href), osm.poi)
       for (const key of GIS_FILTER_QUERY_KEYS) url.searchParams.delete(key)
       for (const [key, value] of gisFilterUrlQuery(filters.filterState)) {
         url.searchParams.set(key, value)
       }
       window.history.pushState({ ...window.history.state }, '', url)
     }, 200)
+  })
+
+  watch(() => route.fullPath, () => {
+    if (import.meta.client) void applyLocation()
   })
 
   onBeforeUnmount(() => {

--- a/frontend/app/composables/useMapCanvasHost.ts
+++ b/frontend/app/composables/useMapCanvasHost.ts
@@ -112,7 +112,9 @@ export function useMapCanvasHost() {
   })
 
   const visibleFeatureCollection = computed<FeatureCollection>(() => polygonStore.featureCollection as FeatureCollection)
-  const showEmptyState = computed(() => filterStore.activeFilterCount > 0 && filterStore.selectedSources.length > 0
+  const showEmptyState = computed(() => osmStore.poi
+    ? !osmStore.loading && (osmStore.data?.meta.count || 0) === 0
+    : filterStore.activeFilterCount > 0 && filterStore.selectedSources.length > 0
     && !polygonStore.loading && !osmStore.loading
     && polygonStore.polygons.length === 0 && (osmStore.data?.meta.business_count || 0) === 0)
 
@@ -248,7 +250,7 @@ export function useMapCanvasHost() {
   })
   watch(() => mapStore.polygonsVisible, setPolygonVisibility)
   watch(
-    () => [osmStore.showPois, osmStore.showAreas, osmStore.showBuildings, osmStore.activeCategories.join(',')],
+    () => [osmStore.showPois, osmStore.showAreas, osmStore.showBuildings, osmStore.activeCategories.join(','), osmStore.poi],
     () => scheduleOsmViewportRefresh(0)
   )
   watch(() => [route.query.polygon, route.query.flaeche], async () => {
@@ -646,6 +648,7 @@ export function useMapCanvasHost() {
   }
 
   function resetVisibleFilters() {
+    osmStore.clearPoi()
     filterStore.reset()
   }
 

--- a/frontend/app/config/documentation.ts
+++ b/frontend/app/config/documentation.ts
@@ -22,9 +22,13 @@ export const documentationPages: DocumentationPage[] = [
   },
   {
     slug: 'karte', title: 'Karte bedienen', navTitle: 'Karte', description: 'Kartennavigation, Auswahl und Ebenen.',
-    group: 'Karte und Daten', keywords: ['Karte', 'MapLibre', 'Zoom'], audience: 'public', sections: [
+    group: 'Karte und Daten', keywords: ['Karte', 'MapLibre', 'Zoom', 'POI', 'Deep Link'], audience: 'public', sections: [
       { id: 'navigation', title: 'Navigation', blocks: [{ type: 'paragraph', text: 'Die Karte lässt sich mit Maus, Tastatur und Touch-Gesten bedienen. Die öffentliche Übersicht bleibt schreibgeschützt.' }] },
-      { id: 'auswahl', title: 'Auswahl', blocks: [{ type: 'paragraph', text: 'Ausgewählte Polygone, OSM-Objekte und Modulobjekte erscheinen in derselben generischen Auswahloberfläche.' }] }
+      { id: 'auswahl', title: 'Auswahl', blocks: [{ type: 'paragraph', text: 'Ausgewählte Polygone, OSM-Objekte und Modulobjekte erscheinen in derselben generischen Auswahloberfläche.' }] },
+      { id: 'poi-deep-links', title: 'POI-Deep-Links', blocks: [
+        { type: 'paragraph', text: 'Der Parameter poi grenzt die Karte auf eine semantische Kategorie für Orte und Einrichtungen ein. Ein Link wie /karte?poi=cafe aktiviert den Café-Filter auch nach einem Neuladen. Die konkrete Datenquelle ist nicht Teil dieses öffentlichen Vertrags.' },
+        { type: 'code', language: 'text', code: '/karte?poi=cafe\n/karte?poi=restaurant' }
+      ] }
     ]
   },
   {

--- a/frontend/app/stores/osmViewport.ts
+++ b/frontend/app/stores/osmViewport.ts
@@ -44,6 +44,7 @@ export const useOsmViewportStore = defineStore('osmViewport', {
     showAreas: true,
     showBuildings: false,
     activeCategories: osmPoiCategories.map(item => item.key) as OsmFeatureCategory[],
+    poi: null as string | null,
     data: null as OsmViewportResult | null,
     loading: false,
     error: null as string | null,
@@ -68,6 +69,7 @@ export const useOsmViewportStore = defineStore('osmViewport', {
       return entity?.type === 'osm' ? entity.feature : null
     },
     requestedCategories(state): OsmFeatureCategory[] {
+      if (state.poi) return osmPoiCategories.map(item => item.key)
       return [
         ...(state.showPois ? state.activeCategories : []),
         ...(state.showAreas ? ['landuse' as const] : []),
@@ -86,6 +88,7 @@ export const useOsmViewportStore = defineStore('osmViewport', {
       const mobile = import.meta.client && window.matchMedia('(max-width: 767px)').matches
       const limit = mobile ? 800 : zoom < 15 ? 800 : zoom < 17 ? 1200 : 2000
       const query = gisFilterQuery(useFilterStore().filterState)
+      if (this.poi) query.delete('sources')
       query.set('west', bounds.west.toFixed(6))
       query.set('south', bounds.south.toFixed(6))
       query.set('east', bounds.east.toFixed(6))
@@ -94,10 +97,11 @@ export const useOsmViewportStore = defineStore('osmViewport', {
       query.set('osm_categories', categories.join(','))
       query.set('buildings', String(this.showBuildings))
       query.set('limit', String(limit))
+      if (this.poi) query.set('poi', this.poi)
       return query.toString()
     },
     viewportFilterKey() {
-      return `${this.requestedCategories.slice().sort().join(',')}|${this.showBuildings}|${useFilterStore().filterKey}`
+      return `${this.requestedCategories.slice().sort().join(',')}|${this.showBuildings}|${this.poi || ''}|${useFilterStore().filterKey}`
     },
     hasCacheFor(bounds: OsmBounds, zoom: number) {
       return Boolean(this.data && this.dataRequestKey === this.viewportRequestKey(bounds, zoom))
@@ -110,7 +114,7 @@ export const useOsmViewportStore = defineStore('osmViewport', {
     },
     async load(bounds: OsmBounds, zoom: number, options: { force?: boolean } = {}) {
       const categories = this.requestedCategories
-      const osmEnabled = useFilterStore().selectedSources.includes('OSM')
+      const osmEnabled = Boolean(this.poi) || useFilterStore().selectedSources.includes('OSM')
       const key = this.viewportRequestKey(bounds, zoom)
       const filterKey = this.viewportFilterKey()
       const bucket = zoomBucket(zoom)
@@ -229,7 +233,14 @@ export const useOsmViewportStore = defineStore('osmViewport', {
     setRenderDuration(value: number) {
       this.lastRenderDurationMs = Math.round(value)
     },
+    setPoi(category: string | null) {
+      this.poi = category
+    },
+    clearPoi() {
+      this.poi = null
+    },
     reset() {
+      this.poi = null
       this.showPois = true
       this.showAreas = true
       this.showBuildings = false

--- a/frontend/app/utils/poiCategories.ts
+++ b/frontend/app/utils/poiCategories.ts
@@ -67,6 +67,17 @@ export function isPoiCategoryToken(category: unknown): category is string {
   return typeof category === 'string' && /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,79}$/.test(category)
 }
 
+export function poiFromQuery(value: unknown): string | null {
+  return isPoiCategoryToken(value) ? value : null
+}
+
+export function withPoiQuery(url: URL, poi: string | null): URL {
+  const next = new URL(url)
+  next.searchParams.delete('poi')
+  if (poi) next.searchParams.set('poi', poi)
+  return next
+}
+
 export function withoutPoiQuery<T extends Record<string, unknown>>(query: T) {
   const result = { ...query }
   delete result.poi

--- a/frontend/e2e/poi-query-contract.spec.ts
+++ b/frontend/e2e/poi-query-contract.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+test.describe('fachneutraler POI-Query-Vertrag', () => {
+  test('wendet Deep Link, Änderung, Reload, Entfernen und Browser-History auf die Karte an', async ({ page }) => {
+    const viewportQueries: URL[] = []
+    page.on('request', (request) => {
+      if (request.url().includes('/api/v1/osm/features?')) viewportQueries.push(new URL(request.url()))
+    })
+
+    await page.goto('/karte?poi=cafe')
+
+    await expect(page).toHaveURL(/\/karte\?poi=cafe/)
+    await expect(page.getByText('POI-Kategorie: Cafés')).toBeVisible({ timeout: 15_000 })
+    await expect.poll(() => renderedPoiTypes(page)).toEqual(['cafe'])
+    expect(viewportQueries.some(url => url.searchParams.get('poi') === 'cafe')).toBe(true)
+
+    await page.reload()
+    await expect(page.getByText('POI-Kategorie: Cafés')).toBeVisible({ timeout: 15_000 })
+    await expect.poll(() => renderedPoiTypes(page)).toEqual(['cafe'])
+
+    await page.evaluate(() => {
+      window.history.pushState({}, '', '/karte?poi=restaurant')
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+    await expect(page).toHaveURL(/\/karte\?poi=restaurant/)
+    await expect(page.getByText('POI-Kategorie: Restaurants')).toBeVisible()
+    await expect.poll(() => renderedPoiTypes(page)).toEqual(['restaurant'])
+
+    await page.getByRole('button', { name: 'Entfernen' }).click()
+    await expect.poll(() => new URL(page.url()).searchParams.has('poi')).toBe(false)
+    await expect.poll(() => renderedPoiTypes(page)).toEqual(['cafe', 'restaurant'])
+
+    await page.goBack()
+    await expect(page).toHaveURL(/\/karte\?poi=restaurant/)
+    await expect.poll(() => renderedPoiTypes(page)).toEqual(['restaurant'])
+  })
+})
+
+async function renderedPoiTypes(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const map = window.__stadtplanerMapPerformance?.map
+    if (!map?.getSource('osm-pois')) return []
+    return map.querySourceFeatures('osm-pois')
+      .map(feature => String(feature.properties.primary_type || ''))
+      .filter(Boolean)
+      .sort()
+  })
+}

--- a/frontend/tests/osm-viewport.store.test.ts
+++ b/frontend/tests/osm-viewport.store.test.ts
@@ -97,4 +97,21 @@ describe('OSM viewport store lifecycle', () => {
     expect(store.generation).toBe(generation + 1)
     expect(store.lastRequestKey).toBe('')
   })
+
+  it('uses the semantic POI filter for viewport requests without leaking provider URL state', () => {
+    const store = useOsmViewportStore()
+    store.setPoi('cafe')
+
+    const query = new URLSearchParams(store.viewportRequestKey(bounds, 16))
+    expect(store.poi).toBe('cafe')
+    expect(query.get('poi')).toBe('cafe')
+    expect(query.get('osm_categories')).toContain('gastronomy')
+    expect(query.get('sources')).toBeNull()
+
+    store.setPoi('restaurant')
+    expect(new URLSearchParams(store.viewportRequestKey(bounds, 16)).get('poi')).toBe('restaurant')
+    store.clearPoi()
+    expect(store.poi).toBeNull()
+    expect(new URLSearchParams(store.viewportRequestKey(bounds, 16)).has('poi')).toBe(false)
+  })
 })

--- a/frontend/tests/poi-query-contract.test.ts
+++ b/frontend/tests/poi-query-contract.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { getPoiCategoryLabel, poiFromQuery, withPoiQuery } from '~/utils/poiCategories'
+
+describe('public POI query contract', () => {
+  it('restores a safe category from a deep link and rejects ambiguous values', () => {
+    expect(poiFromQuery('cafe')).toBe('cafe')
+    expect(poiFromQuery(['cafe', 'restaurant'])).toBeNull()
+    expect(poiFromQuery('drop table')).toBeNull()
+  })
+
+  it('writes, changes and clears only the canonical POI query parameter', () => {
+    const original = new URL('https://stadtplaner.example/karte?gebiet=innenstadt-test&zoom=16')
+    const cafe = withPoiQuery(original, 'cafe')
+    expect(cafe.searchParams.get('poi')).toBe('cafe')
+    expect(cafe.searchParams.get('gebiet')).toBe('innenstadt-test')
+
+    const restaurant = withPoiQuery(cafe, 'restaurant')
+    expect(restaurant.searchParams.get('poi')).toBe('restaurant')
+
+    const cleared = withPoiQuery(restaurant, null)
+    expect(cleared.searchParams.has('poi')).toBe(false)
+    expect(cleared.searchParams.get('zoom')).toBe('16')
+  })
+
+  it('uses the same value after serializing and reloading a deep link', () => {
+    const written = withPoiQuery(new URL('https://stadtplaner.example/karte'), 'cafe')
+    expect(poiFromQuery(new URL(written.href).searchParams.get('poi'))).toBe('cafe')
+    expect(getPoiCategoryLabel('cafe')).toBe('Cafés')
+  })
+
+  it('keeps the retired provider-specific query key out of frontend runtime sources', () => {
+    const retiredKey = ['osm', 'kategorie'].join('_')
+    const runtimeFiles = [
+      'app',
+      'module-host',
+      'server'
+    ]
+    const candidates = runtimeFiles.flatMap(directory => sourceFiles(resolve(import.meta.dirname, '..', directory)))
+    const violations = candidates.filter(path => readFileSync(path, 'utf8').includes(retiredKey))
+    expect(violations).toEqual([])
+  })
+})
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) return sourceFiles(path)
+    return /\.(?:ts|vue)$/.test(entry.name) ? [path] : []
+  })
+}


### PR DESCRIPTION
## Problem

Der öffentliche Kartenvertrag für semantische POI-Kategorien war im Host nicht vollständig umgesetzt. Analysis Areas 1.5.3 erzeugt bereits `poi=cafe`, während der Host diesen Wert bislang weder zuverlässig in URL-/SSR-Zustand übernahm noch auf die tatsächlich gerenderten Kartendaten anwandte. Der frühere providerbezogene Name `osm_kategorie` darf nicht als paralleler Vertrag fortbestehen.

## Lösung

- vereinheitlicht Lesen, Schreiben, Ändern, Entfernen, Reload und Browser-History auf ausschließlich `poi=<category>`
- übernimmt `poi` synchron in den bestehenden Viewport-Store und reicht ihn an den vorhandenen OSM-Viewport weiter
- filtert serverseitig exakt auf den bestehenden semantischen `primary_type`, bevor Ranking und Limits greifen
- zeigt den aktiven POI-Filter in der bestehenden Filteroberfläche und bindet ihn in Reset/Leerzustand ein
- dokumentiert die Trennung zwischen öffentlichem fachneutralem Vertrag und internen OSM-/MapLibre-Bezeichnern
- ergänzt Unit-, Contract- und ungemockte Playwright-Abdeckung; die POI-Fixtures sind vom allgemeinen Host-Seed getrennt

Alter Vertrag: `osm_kategorie=<wert>` ist entfernt und wird weder erzeugt noch ausgewertet.

Neuer Vertrag: `poi=<wert>`, beispielsweise `/karte?poi=cafe`.

Der Vertrag bleibt fachneutral: `poi` beschreibt die Nutzerabsicht; `osm_categories`, OSM-Tags, `primary_type` und MapLibre-Layer-IDs bleiben interne Providerdetails. Es gibt keine Analysis-Areas-spezifische Sonderbehandlung und keine Moduländerung.

## Betroffene Bereiche

- Karten-URL-/History-Zustand und vorhandener OSM-Viewport-Store
- OSM-Viewport-Schema, SQL-Filterung und Cache-Key
- Filteranzeige und Reset-Verhalten
- Host-E2E-Workflow und dedizierte Testdaten
- Benutzer- und technische Dokumentation

Keine Schemaänderung, Migration oder Konfigurationsänderung.

## Tests

Erfolgreich:

- `uv run ruff check app tests`
- gezielte Backend-POI-Tests: 15 bestanden
- `pnpm test`: 459 bestanden
- `pnpm typecheck`
- `pnpm build`
- Sprach- und SEO-Audit
- Frontend-Modul-Preflight, Architektur und SSR: 59 + 3 bestanden
- Backend-Modul-Contract-Gate: 432 bestanden, 8 übersprungen
- ungemockter POI-Playwright-Test mit Deep Link, Reload, Wechsel, Entfernen und Zurück: bestanden
- Analysis Areas 1.5.3 Registry-Cutover mit Digest `88ead403d89209c155b78101676b691a642139991cf9fd0787115ccfe0338f6b`: aktivierte Parität, 3/3 Browser-Flows, Disable und Re-enable bestanden

Gesamtläufe mit bekannten reihenfolge-/zeitabhängigen Ausreißern:

- Backend: 835/837 bestanden; zwei bestehende Observability-Tests scheitern nur im Gesamtlauf und bestehen isoliert 2/2
- Playwright: 54/55 bestanden; ein bestehender Profil-Hydrierungstest überschritt einmal sein 5-Sekunden-Sichtbarkeitsfenster und bestand auf frischer Datenbank isoliert 1/1. Der neue POI-Test bestand im Gesamtlauf.

## Rollout / Rollback

Normaler Host-Rollout ohne Datenmigration. Rollback erfolgt durch Rücknahme dieser Commits. Es wurden kein Produktionsdeploy, keine Registry-Mutation und kein Release durchgeführt.

Closes #216

Coordinates: #197 #184 #210